### PR TITLE
netstandard1.5 for Foundatio.Logging.Serilog

### DIFF
--- a/src/Foundatio.Logging.Serilog/Foundatio.Logging.Serilog.csproj
+++ b/src/Foundatio.Logging.Serilog/Foundatio.Logging.Serilog.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net46</TargetFrameworks>
     <PackageTags>Logging;Log;Serilog;</PackageTags>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Support netstandard1.5 for Foundatio.Logging.Serilog.

In keeping with the rest of Foundatio, which supports both .NET Framework 4.6 and .NET Standard 1.5, add support for .NET Standard 1.5 to Foundatio.Logging.Serilog.

Simply adding this to the list of target frameworks appears to work and allow this to build to .NET Standard 1.5 locally in Visual Studio 2017.  Perhaps it was just an oversight that this has not been done already?

All logging unit-tests still pass.