### PR TITLE
Fix interval between failing job runs

### DIFF
--- a/src/Foundatio.TestHarness/Jobs/HelloWorldJob.cs
+++ b/src/Foundatio.TestHarness/Jobs/HelloWorldJob.cs
@@ -26,6 +26,25 @@ namespace Foundatio.Tests.Jobs {
         }
     }
 
+    public class FailingJob : JobBase {
+        private readonly string _id;
+
+        public int RunCount { get; set; }
+
+        public FailingJob(ILoggerFactory loggerFactory) : base(loggerFactory) {
+            _id = Guid.NewGuid().ToString("N").Substring(0, 10);
+        }
+
+        protected override Task<JobResult> RunInternalAsync(JobContext context) {
+            RunCount++;
+
+            if (_logger.IsEnabled(LogLevel.Trace))
+                _logger.LogTrace("FailingJob Running: instance={Id} runs={RunCount}", _id, RunCount);
+
+            return Task.FromResult(JobResult.FailedWithMessage("Test failure"));
+        }
+    }
+
     public class LongRunningJob : JobBase {
         private readonly string _id;
         private int _iterationCount;

--- a/src/Foundatio/Jobs/IJob.cs
+++ b/src/Foundatio/Jobs/IJob.cs
@@ -43,7 +43,7 @@ namespace Foundatio.Jobs {
 
                     // Maybe look into yeilding threads. task scheduler queue is starving.
                     if (result.Error != null) {
-                        await SystemClock.SleepAsync(Math.Max(interval?.Milliseconds ?? 0, 100)).AnyContext();
+                        await SystemClock.SleepAsync(Math.Max((int)(interval?.TotalMilliseconds ?? 0), 100)).AnyContext();
                     } else if (interval.HasValue && interval.Value > TimeSpan.Zero) {
                         await SystemClock.SleepAsync(interval.Value).AnyContext();
                     } else if (sw.ElapsedMilliseconds > 5000) {

--- a/test/Foundatio.Tests/Jobs/JobTests.cs
+++ b/test/Foundatio.Tests/Jobs/JobTests.cs
@@ -138,6 +138,19 @@ namespace Foundatio.Tests.Jobs {
             }
         }
 
+        [Fact]
+        public async Task CanRunJobsWithIntervalBetweenFailingJob() {
+            var job = new FailingJob(Log);
+            var interval = TimeSpan.FromMilliseconds(50);
+       
+            var sw = Stopwatch.StartNew();
+
+            await job.RunContinuousAsync(iterationLimit: 2, interval: interval);
+
+            Assert.Equal(2, job.RunCount);
+            Assert.True(interval.TotalMilliseconds <= sw.ElapsedMilliseconds);
+        }
+
         [Fact(Skip = "Meant to be run manually.")]
         public async Task JobLoopPerf() {
             const int iterations = 10000;


### PR DESCRIPTION
The current implementation uses `Milliseconds` rather than `TotalMilliseconds`.