### PR TITLE
Trying to handle TaskCanceledException in FolderFileStorage.

### DIFF
--- a/src/Foundatio/Storage/FolderFileStorage.cs
+++ b/src/Foundatio/Storage/FolderFileStorage.cs
@@ -98,7 +98,11 @@ namespace Foundatio.Storage {
                     return true;
                 }
             } catch (Exception ex) {
-                _logger.LogError(ex, "Error trying to save file: {Path}", path);
+                const string errorMessage = "Error trying to save file: {Path}";
+                if (ex is TaskCanceledException taskCanceledException && taskCanceledException.Task?.Exception != null)
+                    _logger.LogError(taskCanceledException.Task.Exception, errorMessage, path);
+                else
+                    _logger.LogError(ex, errorMessage, path);
                 return false;
             }
         }


### PR DESCRIPTION
When the `TaskCanceledException` was thrown in the `SaveFileAsync` method, the log message will be like
```
[18:38:09 ERR] Error trying to save file: q/e46/e46cf1028b974b1d8d217fe9c0fc507d.payload
System.Threading.Tasks.TaskCanceledException: A task was canceled.
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Foundatio.Storage.FolderFileStorage.<SaveFileAsync>d__14.MoveNext() in C:\projects\foundatio\src\Foundatio\Storage\FolderFileStorage.cs:line 98
```
Which cannot identify the root cause of the error. 