### PR TITLE
Job running improvements

### DIFF
--- a/src/Foundatio/Jobs/IJob.cs
+++ b/src/Foundatio/Jobs/IJob.cs
@@ -33,7 +33,7 @@ namespace Foundatio.Jobs {
                     logger.LogInformation("Starting continuous job type {JobName} on machine {MachineName}...", jobName, Environment.MachineName);
 
                 var sw = Stopwatch.StartNew();
-                while (true) {
+                while (!cancellationToken.IsCancellationRequested) {
                     var result = await job.TryRunAsync(cancellationToken).AnyContext();
                     LogResult(result, logger, jobName);
                     iterations++;

--- a/src/Foundatio/Jobs/IJob.cs
+++ b/src/Foundatio/Jobs/IJob.cs
@@ -38,7 +38,7 @@ namespace Foundatio.Jobs {
                     LogResult(result, logger, jobName);
                     iterations++;
 
-                    if (cancellationToken.IsCancellationRequested || (-1 < iterationLimit && iterationLimit <= iterations))
+                    if (cancellationToken.IsCancellationRequested || (iterationLimit > -1 && iterationLimit <= iterations))
                        break;
 
                     // Maybe look into yeilding threads. task scheduler queue is starving.

--- a/src/Foundatio/Utility/SystemClock.cs
+++ b/src/Foundatio/Utility/SystemClock.cs
@@ -31,7 +31,7 @@ namespace Foundatio.Utility {
         private TimeSpan _timeZoneOffset = DateTimeOffset.Now.Offset;
         private bool _fakeSleep = false;
 
-        public DateTime UtcNow() => _fixedUtc ?? DateTime.UtcNow.Add(_offset);
+        public DateTime UtcNow() => (_fixedUtc ?? DateTime.UtcNow).Add(_offset);
         public DateTime Now() => new DateTime(UtcNow().Ticks + TimeZoneOffset().Ticks, DateTimeKind.Local);
         public DateTimeOffset OffsetNow() => new DateTimeOffset(UtcNow().Ticks + TimeZoneOffset().Ticks, TimeZoneOffset());
         public DateTimeOffset OffsetUtcNow() => new DateTimeOffset(UtcNow().Ticks, TimeSpan.Zero);

--- a/test/Foundatio.Tests/Jobs/JobTests.cs
+++ b/test/Foundatio.Tests/Jobs/JobTests.cs
@@ -139,16 +139,39 @@ namespace Foundatio.Tests.Jobs {
         }
 
         [Fact]
+        public async Task CanRunJobsWithInterval() {
+            using (TestSystemClock.Install()) {
+                var time = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+                SystemClock.Test.SetFixedTime(time);
+                SystemClock.Test.UseFakeSleep();
+
+                var job = new HelloWorldJob(Log);
+                var interval = TimeSpan.FromHours(.75);
+
+                await job.RunContinuousAsync(iterationLimit: 2, interval: interval);
+
+                Assert.Equal(2, job.RunCount);
+                Assert.Equal(interval, (SystemClock.UtcNow - time));
+            }
+        }
+
+        [Fact]
         public async Task CanRunJobsWithIntervalBetweenFailingJob() {
-            var job = new FailingJob(Log);
-            var interval = TimeSpan.FromMilliseconds(50);
-       
-            var sw = Stopwatch.StartNew();
+            using (TestSystemClock.Install()) {
+                var time = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-            await job.RunContinuousAsync(iterationLimit: 2, interval: interval);
+                SystemClock.Test.SetFixedTime(time);
+                SystemClock.Test.UseFakeSleep();
 
-            Assert.Equal(2, job.RunCount);
-            Assert.True(interval.TotalMilliseconds <= sw.ElapsedMilliseconds);
+                var job = new FailingJob(Log);
+                var interval = TimeSpan.FromHours(.75);
+                
+                await job.RunContinuousAsync(iterationLimit: 2, interval: interval);
+
+                Assert.Equal(2, job.RunCount);
+                Assert.Equal(interval, (SystemClock.UtcNow - time));
+            }
         }
 
         [Fact(Skip = "Meant to be run manually.")]


### PR DESCRIPTION
- Improved job interval tests to cover bug spotted in previous PR #123
- Removed unnecessary interval after the last job run when iteration limit supplied
- Fixes interval addition with `TestSystemClock.UtcNow()`

The method will currently run a job once when `iterationLimit == 0`. Is this the behaviour we want? I would have thought we should either throw an `ArgumentOutOfRangeException` or log and return.