### PR TITLE
Added Message Filter Function in MessageSubscriber

### DIFF
--- a/src/Foundatio/Messaging/IMessageSubscriber.cs
+++ b/src/Foundatio/Messaging/IMessageSubscriber.cs
@@ -4,19 +4,25 @@ using System.Threading.Tasks;
 
 namespace Foundatio.Messaging {
     public interface IMessageSubscriber {
-        Task SubscribeAsync<T>(Func<T, CancellationToken, Task> handler, CancellationToken cancellationToken = default) where T : class;
+        Task SubscribeAsync<T>(Func<T, CancellationToken, Task> handler, CancellationToken cancellationToken = default, Func<T, bool> messagefilter = null) where T : class;
+        
     }
 
     public static class MessageBusExtensions {
-        public static Task SubscribeAsync<T>(this IMessageSubscriber subscriber, Func<T, Task> handler, CancellationToken cancellationToken = default) where T : class {
-            return subscriber.SubscribeAsync<T>((msg, token) => handler(msg), cancellationToken);
+        public static Task SubscribeAsync<T>(this IMessageSubscriber subscriber, Func<T, Task> handler, CancellationToken cancellationToken = default, Func<T, bool> messagefilter = null) where T : class {
+            return subscriber.SubscribeAsync<T>((msg, token) => handler(msg), cancellationToken, messagefilter);
         }
 
-        public static Task SubscribeAsync<T>(this IMessageSubscriber subscriber, Action<T> handler, CancellationToken cancellationToken = default) where T : class {
+        public static Task SubscribeAsync<T>(this IMessageSubscriber subscriber, Action<T> handler, CancellationToken cancellationToken = default, Func<T, bool> messagefilter = null) where T : class {
             return subscriber.SubscribeAsync<T>((msg, token) => {
                 handler(msg);
                 return Task.CompletedTask;
-            }, cancellationToken);
+            }, cancellationToken, messagefilter);
         }
+
+
+      
     }
+
+
 }

--- a/src/Foundatio/Messaging/InMemoryMessageBus.cs
+++ b/src/Foundatio/Messaging/InMemoryMessageBus.cs
@@ -49,7 +49,7 @@ namespace Foundatio.Messaging {
                 return Task.CompletedTask;
             }
 
-            var subscribers = _subscribers.Values.Where(s => s.IsAssignableFrom(mappedType)).ToList();
+            var subscribers = _subscribers.Values.Where(s => s.IsAssignableFrom(mappedType, message)).ToList();
             if (subscribers.Count == 0) {
                 if (isTraceLogLevelEnabled)
                     _logger.LogTrace("Done sending message to 0 subscribers for message type {MessageType}.", mappedType.Name);

--- a/src/Foundatio/Messaging/NullMessageBus.cs
+++ b/src/Foundatio/Messaging/NullMessageBus.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,10 +10,10 @@ namespace Foundatio.Messaging {
             return Task.CompletedTask;
         }
 
-        public Task SubscribeAsync<T>(Func<T, CancellationToken, Task> handler, CancellationToken cancellationToken = default) where T : class {
+        public Task SubscribeAsync<T>(Func<T, CancellationToken, Task> handler, CancellationToken cancellationToken = default, Func<T, bool> messagefilter = null) where T : class {
             return Task.CompletedTask;
         }
-
+        
         public void Dispose() {}
     }
 }

--- a/tests/Foundatio.Tests/Messaging/InMemoryMessageBusTests.cs
+++ b/tests/Foundatio.Tests/Messaging/InMemoryMessageBusTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Foundatio.Messaging;
 using Xunit;
@@ -117,6 +117,11 @@ namespace Foundatio.Tests.Messaging {
         [Fact]
         public override void CanDisposeWithNoSubscribersOrPublishers() {
             base.CanDisposeWithNoSubscribersOrPublishers();
+        }
+
+        [Fact]
+        public override Task WillOnlyReceiveSubscribedMessageTypeWithFilterAsync() {
+            return base.WillOnlyReceiveSubscribedMessageTypeWithFilterAsync();
         }
 
         public void Dispose() {


### PR DESCRIPTION
I wrapped up my Messages in a generic "envelope" base message to send additional tracing properties through the message bus. That works fine, but every subscriber connects now to the same message type. aas a result,  there are many many subscribers for each message. the goal of this pull request is to filter the message with an custom function before it will be sent to all subscribers