### PR TITLE
Propagate exceptions raised by subscriber message handlers

### DIFF
--- a/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
+++ b/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
@@ -304,7 +304,15 @@ namespace Foundatio.Tests.Messaging {
                 return;
 
             try {
-                var countdown = new AsyncCountdownEvent(2);
+                var countdown = new AsyncCountdownEvent(4);
+                await messageBus.SubscribeAsync<SimpleMessageA>(msg => {
+                    Assert.Equal("Hello", msg.Data);
+                    countdown.Signal();
+                });
+                await messageBus.SubscribeAsync<SimpleMessageA>(msg => {
+                    Assert.Equal("Hello", msg.Data);
+                    countdown.Signal();
+                });
                 await messageBus.SubscribeAsync<SimpleMessageA>(msg => {
                     throw new Exception();
                 });

--- a/src/Foundatio/Messaging/InMemoryMessageBus.cs
+++ b/src/Foundatio/Messaging/InMemoryMessageBus.cs
@@ -56,8 +56,9 @@ namespace Foundatio.Messaging {
 
             try {
                 await SendMessageToSubscribers(messageData);
-            } catch {
+            } catch (Exception ex) {
                 // swallow exceptions from subscriber handlers for the in memory bus
+                _logger.LogWarning(ex, "Error sending message to subscribers: {ErrorMessage}", ex.Message);
             }
         }
     }

--- a/src/Foundatio/Messaging/InMemoryMessageBus.cs
+++ b/src/Foundatio/Messaging/InMemoryMessageBus.cs
@@ -31,31 +31,31 @@ namespace Foundatio.Messaging {
             _messageCounts.Clear();
         }
 
-        protected override Task PublishImplAsync(string messageType, object message, TimeSpan? delay, CancellationToken cancellationToken) {
+        protected override async Task PublishImplAsync(string messageType, object message, TimeSpan? delay, CancellationToken cancellationToken) {
             Interlocked.Increment(ref _messagesSent);
             _messageCounts.AddOrUpdate(messageType, t => 1, (t, c) => c + 1);
-            Type mappedType = GetMappedMessageType(messageType);
+            var mappedType = GetMappedMessageType(messageType);
 
             if (_subscribers.IsEmpty)
-                return Task.CompletedTask;
+                return;
 
             bool isTraceLogLevelEnabled = _logger.IsEnabled(LogLevel.Trace);
             if (delay.HasValue && delay.Value > TimeSpan.Zero) {
                 if (isTraceLogLevelEnabled)
                     _logger.LogTrace("Schedule delayed message: {MessageType} ({Delay}ms)", messageType, delay.Value.TotalMilliseconds);
                 SendDelayedMessage(mappedType, message, delay.Value);
-                return Task.CompletedTask;
+                return;
             }
-            
-            var body = SerializeMessageBody(messageType, message);
+
+            byte[] body = SerializeMessageBody(messageType, message);
             var messageData = new Message(() => DeserializeMessageBody(messageType, body)) {
                 Type = messageType,
                 ClrType = mappedType,
                 Data = body
             };
 
-            SendMessageToSubscribers(messageData);
-            return Task.CompletedTask;
+            await SendMessageToSubscribers(messageData);
+            return;
         }
     }
 }

--- a/src/Foundatio/Messaging/InMemoryMessageBus.cs
+++ b/src/Foundatio/Messaging/InMemoryMessageBus.cs
@@ -46,7 +46,7 @@ namespace Foundatio.Messaging {
                 SendDelayedMessage(mappedType, message, delay.Value);
                 return Task.CompletedTask;
             }
-
+            
             var body = SerializeMessageBody(messageType, message);
             var messageData = new Message(() => DeserializeMessageBody(messageType, body)) {
                 Type = messageType,

--- a/src/Foundatio/Messaging/InMemoryMessageBus.cs
+++ b/src/Foundatio/Messaging/InMemoryMessageBus.cs
@@ -57,7 +57,7 @@ namespace Foundatio.Messaging {
             try {
                 SendMessageToSubscribers(messageData);
             } catch {
-                // swallow exceptions from subscribers
+                // swallow exceptions from subscriber handlers for the in memory bus
             }
 
             return Task.CompletedTask;

--- a/src/Foundatio/Messaging/InMemoryMessageBus.cs
+++ b/src/Foundatio/Messaging/InMemoryMessageBus.cs
@@ -55,7 +55,6 @@ namespace Foundatio.Messaging {
             };
 
             await SendMessageToSubscribers(messageData);
-            return;
         }
     }
 }

--- a/src/Foundatio/Messaging/InMemoryMessageBus.cs
+++ b/src/Foundatio/Messaging/InMemoryMessageBus.cs
@@ -34,7 +34,7 @@ namespace Foundatio.Messaging {
         protected override Task PublishImplAsync(string messageType, object message, TimeSpan? delay, CancellationToken cancellationToken) {
             Interlocked.Increment(ref _messagesSent);
             _messageCounts.AddOrUpdate(messageType, t => 1, (t, c) => c + 1);
-            var mappedType = GetMappedMessageType(messageType);
+            Type mappedType = GetMappedMessageType(messageType);
 
             if (_subscribers.IsEmpty)
                 return Task.CompletedTask;
@@ -47,7 +47,7 @@ namespace Foundatio.Messaging {
                 return Task.CompletedTask;
             }
 
-            byte[] body = SerializeMessageBody(messageType, message);
+            var body = SerializeMessageBody(messageType, message);
             var messageData = new Message(() => DeserializeMessageBody(messageType, body)) {
                 Type = messageType,
                 ClrType = mappedType,

--- a/src/Foundatio/Messaging/InMemoryMessageBus.cs
+++ b/src/Foundatio/Messaging/InMemoryMessageBus.cs
@@ -54,7 +54,12 @@ namespace Foundatio.Messaging {
                 Data = body
             };
 
-            SendMessageToSubscribers(messageData);
+            try {
+                SendMessageToSubscribers(messageData);
+            } catch {
+                // swallow exceptions from subscribers
+            }
+
             return Task.CompletedTask;
         }
     }

--- a/src/Foundatio/Messaging/InMemoryMessageBus.cs
+++ b/src/Foundatio/Messaging/InMemoryMessageBus.cs
@@ -47,7 +47,7 @@ namespace Foundatio.Messaging {
                 return;
             }
 
-            byte[] body = SerializeMessageBody(messageType, message);
+            var body = SerializeMessageBody(messageType, message);
             var messageData = new Message(() => DeserializeMessageBody(messageType, body)) {
                 Type = messageType,
                 ClrType = mappedType,

--- a/src/Foundatio/Messaging/InMemoryMessageBus.cs
+++ b/src/Foundatio/Messaging/InMemoryMessageBus.cs
@@ -31,30 +31,31 @@ namespace Foundatio.Messaging {
             _messageCounts.Clear();
         }
 
-        protected override async Task PublishImplAsync(string messageType, object message, TimeSpan? delay, CancellationToken cancellationToken) {
+        protected override Task PublishImplAsync(string messageType, object message, TimeSpan? delay, CancellationToken cancellationToken) {
             Interlocked.Increment(ref _messagesSent);
             _messageCounts.AddOrUpdate(messageType, t => 1, (t, c) => c + 1);
             var mappedType = GetMappedMessageType(messageType);
 
             if (_subscribers.IsEmpty)
-                return;
+                return Task.CompletedTask;
 
             bool isTraceLogLevelEnabled = _logger.IsEnabled(LogLevel.Trace);
             if (delay.HasValue && delay.Value > TimeSpan.Zero) {
                 if (isTraceLogLevelEnabled)
                     _logger.LogTrace("Schedule delayed message: {MessageType} ({Delay}ms)", messageType, delay.Value.TotalMilliseconds);
                 SendDelayedMessage(mappedType, message, delay.Value);
-                return;
+                return Task.CompletedTask;
             }
 
-            var body = SerializeMessageBody(messageType, message);
+            byte[] body = SerializeMessageBody(messageType, message);
             var messageData = new Message(() => DeserializeMessageBody(messageType, body)) {
                 Type = messageType,
                 ClrType = mappedType,
                 Data = body
             };
 
-            await SendMessageToSubscribers(messageData);
+            SendMessageToSubscribers(messageData);
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Foundatio/Messaging/MessageBusBase.cs
+++ b/src/Foundatio/Messaging/MessageBusBase.cs
@@ -161,15 +161,9 @@ namespace Foundatio.Messaging {
             
             var body = new Lazy<object>(() => DeserializeMessageBody(message.Type, message.Data));
 
-            if (body == null) {
-                if (_logger.IsEnabled(LogLevel.Warning))
-                    _logger.LogWarning("Unable to send null message for type {MessageType}", message.Type);
-                return;
-            }
-
             var subscriberHandlers = subscribers.Select(subscriber => {
                 if (subscriber.CancellationToken.IsCancellationRequested) {
-                    if (_subscribers.TryRemove(subscriber.Id, out var _)) {
+                    if (_subscribers.TryRemove(subscriber.Id, out _)) {
                         if (isTraceLogLevelEnabled)
                             _logger.LogTrace("Removed cancelled subscriber: {SubscriberId}", subscriber.Id);
                     } else if (isTraceLogLevelEnabled) {

--- a/src/Foundatio/Messaging/MessageBusBase.cs
+++ b/src/Foundatio/Messaging/MessageBusBase.cs
@@ -149,7 +149,7 @@ namespace Foundatio.Messaging {
             return body;
         }
 
-        protected void SendMessageToSubscribers(IMessage message) {
+        protected async Task SendMessageToSubscribers(IMessage message) {
             bool isTraceLogLevelEnabled = _logger.IsEnabled(LogLevel.Trace);
             var subscribers = GetMessageSubscribers(message);
 
@@ -201,7 +201,7 @@ namespace Foundatio.Messaging {
             });
 
             try {
-                Task.WaitAll(subscriberHandlers.ToArray());
+                await Task.WhenAll(subscriberHandlers.ToArray());
             } catch (Exception ex) {
                 if (_logger.IsEnabled(LogLevel.Warning))
                     _logger.LogWarning(ex, "Error sending message to subscribers: {ErrorMessage}", ex.Message);

--- a/src/Foundatio/Messaging/MessageBusBase.cs
+++ b/src/Foundatio/Messaging/MessageBusBase.cs
@@ -167,47 +167,41 @@ namespace Foundatio.Messaging {
                 return;
             }
 
-            async Task RunSubscriberHandler(Subscriber subscriber)
-            {
-                if (subscriber.CancellationToken.IsCancellationRequested)
-                {
-                    if (_subscribers.TryRemove(subscriber.Id, out var _))
-                    {
+            var subscriberHandlers = subscribers.Select(subscriber => {
+                if (subscriber.CancellationToken.IsCancellationRequested) {
+                    if (_subscribers.TryRemove(subscriber.Id, out var _)) {
                         if (isTraceLogLevelEnabled)
                             _logger.LogTrace("Removed cancelled subscriber: {SubscriberId}", subscriber.Id);
-                    }
-                    else if (isTraceLogLevelEnabled)
-                    {
+                    } else if (isTraceLogLevelEnabled) {
                         _logger.LogTrace("Unable to remove cancelled subscriber: {SubscriberId}", subscriber.Id);
                     }
 
-                    return;
+                    return Task.CompletedTask;
                 }
 
-                if (subscriber.CancellationToken.IsCancellationRequested)
-                {
+                return Task.Run(async () => {
+                    if (subscriber.CancellationToken.IsCancellationRequested) {
+                        if (isTraceLogLevelEnabled)
+                            _logger.LogTrace("The cancelled subscriber action will not be called: {SubscriberId}", subscriber.Id);
+
+                        return;
+                    }
+
                     if (isTraceLogLevelEnabled)
-                        _logger.LogTrace("The cancelled subscriber action will not be called: {SubscriberId}", subscriber.Id);
+                        _logger.LogTrace("Calling subscriber action: {SubscriberId}", subscriber.Id);
 
-                    return;
-                }
+                    if (subscriber.Type == typeof(IMessage))
+                        await subscriber.Action(message, subscriber.CancellationToken).AnyContext();
+                    else
+                        await subscriber.Action(body.Value, subscriber.CancellationToken).AnyContext();
 
-                if (isTraceLogLevelEnabled)
-                    _logger.LogTrace("Calling subscriber action: {SubscriberId}", subscriber.Id);
-
-                if (subscriber.Type == typeof(IMessage))
-                    await subscriber.Action(message, subscriber.CancellationToken).AnyContext();
-                else
-                    await subscriber.Action(body.Value, subscriber.CancellationToken).AnyContext();
-
-                if (isTraceLogLevelEnabled)
-                    _logger.LogTrace("Finished calling subscriber action: {SubscriberId}", subscriber.Id);
-            }
-
-            var subscriberHandlers = subscribers.Select(RunSubscriberHandler).ToArray();
+                    if (isTraceLogLevelEnabled)
+                        _logger.LogTrace("Finished calling subscriber action: {SubscriberId}", subscriber.Id);
+                });
+            });
 
             try {
-                Task.WaitAll(subscriberHandlers);
+                Task.WaitAll(subscriberHandlers.ToArray());
             } catch (Exception ex) {
                 if (_logger.IsEnabled(LogLevel.Warning))
                     _logger.LogWarning(ex, "Error sending message to subscribers: {ErrorMessage}", ex.Message);

--- a/src/Foundatio/Messaging/MessageBusBase.cs
+++ b/src/Foundatio/Messaging/MessageBusBase.cs
@@ -167,41 +167,47 @@ namespace Foundatio.Messaging {
                 return;
             }
 
-            var subscriberHandlers = subscribers.Select(subscriber => {
-                if (subscriber.CancellationToken.IsCancellationRequested) {
-                    if (_subscribers.TryRemove(subscriber.Id, out var _)) {
+            async Task RunSubscriberHandler(Subscriber subscriber)
+            {
+                if (subscriber.CancellationToken.IsCancellationRequested)
+                {
+                    if (_subscribers.TryRemove(subscriber.Id, out var _))
+                    {
                         if (isTraceLogLevelEnabled)
                             _logger.LogTrace("Removed cancelled subscriber: {SubscriberId}", subscriber.Id);
-                    } else if (isTraceLogLevelEnabled) {
+                    }
+                    else if (isTraceLogLevelEnabled)
+                    {
                         _logger.LogTrace("Unable to remove cancelled subscriber: {SubscriberId}", subscriber.Id);
                     }
 
-                    return Task.CompletedTask;
+                    return;
                 }
 
-                return Task.Factory.StartNew(async () => {
-                    if (subscriber.CancellationToken.IsCancellationRequested) {
-                        if (isTraceLogLevelEnabled)
-                            _logger.LogTrace("The cancelled subscriber action will not be called: {SubscriberId}", subscriber.Id);
-
-                        return;
-                    }
-
+                if (subscriber.CancellationToken.IsCancellationRequested)
+                {
                     if (isTraceLogLevelEnabled)
-                        _logger.LogTrace("Calling subscriber action: {SubscriberId}", subscriber.Id);
+                        _logger.LogTrace("The cancelled subscriber action will not be called: {SubscriberId}", subscriber.Id);
 
-                    if (subscriber.Type == typeof(IMessage))
-                        await subscriber.Action(message, subscriber.CancellationToken).AnyContext();
-                    else
-                        await subscriber.Action(body.Value, subscriber.CancellationToken).AnyContext();
+                    return;
+                }
 
-                    if (isTraceLogLevelEnabled)
-                        _logger.LogTrace("Finished calling subscriber action: {SubscriberId}", subscriber.Id);
-                });
-            });
+                if (isTraceLogLevelEnabled)
+                    _logger.LogTrace("Calling subscriber action: {SubscriberId}", subscriber.Id);
+
+                if (subscriber.Type == typeof(IMessage))
+                    await subscriber.Action(message, subscriber.CancellationToken).AnyContext();
+                else
+                    await subscriber.Action(body.Value, subscriber.CancellationToken).AnyContext();
+
+                if (isTraceLogLevelEnabled)
+                    _logger.LogTrace("Finished calling subscriber action: {SubscriberId}", subscriber.Id);
+            }
+
+            var subscriberHandlers = subscribers.Select(RunSubscriberHandler).ToArray();
 
             try {
-                Task.WaitAll(subscriberHandlers.ToArray());
+                Task.WaitAll(subscriberHandlers);
             } catch (Exception ex) {
                 if (_logger.IsEnabled(LogLevel.Warning))
                     _logger.LogWarning(ex, "Error sending message to subscribers: {ErrorMessage}", ex.Message);

--- a/src/Foundatio/Messaging/MessageBusBase.cs
+++ b/src/Foundatio/Messaging/MessageBusBase.cs
@@ -158,7 +158,7 @@ namespace Foundatio.Messaging {
             
             if (subscribers.Count == 0)
                 return;
-
+            
             var body = new Lazy<object>(() => DeserializeMessageBody(message.Type, message.Data));
 
             if (body == null) {

--- a/src/Foundatio/Messaging/MessageBusBase.cs
+++ b/src/Foundatio/Messaging/MessageBusBase.cs
@@ -161,6 +161,12 @@ namespace Foundatio.Messaging {
             
             var body = new Lazy<object>(() => DeserializeMessageBody(message.Type, message.Data));
 
+            if (body == null) {
+                if (_logger.IsEnabled(LogLevel.Warning))
+                    _logger.LogWarning("Unable to send null message for type {MessageType}", message.Type);
+                return;
+            }
+
             var subscriberHandlers = subscribers.Select(subscriber => {
                 if (subscriber.CancellationToken.IsCancellationRequested) {
                     if (_subscribers.TryRemove(subscriber.Id, out _)) {

--- a/src/Foundatio/Messaging/SharedMessageBusOptions.cs
+++ b/src/Foundatio/Messaging/SharedMessageBusOptions.cs
@@ -27,7 +27,7 @@ namespace Foundatio.Messaging {
         public TBuilder MapMessageType<T>(string name) {
             if (Target.MessageTypeMappings == null)
                 Target.MessageTypeMappings = new Dictionary<string, Type>();
-
+            
             Target.MessageTypeMappings[name] = typeof(T);
             return (TBuilder)this;
         }
@@ -35,7 +35,7 @@ namespace Foundatio.Messaging {
         public TBuilder MapMessageTypeToClassName<T>() {
             if (Target.MessageTypeMappings == null)
                 Target.MessageTypeMappings = new Dictionary<string, Type>();
-
+            
             Target.MessageTypeMappings[typeof(T).Name] = typeof(T);
             return (TBuilder)this;
         }

--- a/src/Foundatio/Messaging/SharedMessageBusOptions.cs
+++ b/src/Foundatio/Messaging/SharedMessageBusOptions.cs
@@ -12,11 +12,6 @@ namespace Foundatio.Messaging {
         /// Controls which types messages are mapped to.
         /// </summary>
         public Dictionary<string, Type> MessageTypeMappings { get; set; } = new Dictionary<string, Type>();
-
-        /// <summary>
-        /// Controls the way the messages are sent to subscribers
-        /// </summary>
-        public bool SendMessagesSynchronously { get; set; } = false;
     }
 
     public class SharedMessageBusOptionsBuilder<TOptions, TBuilder> : SharedOptionsBuilder<TOptions, TBuilder>

--- a/src/Foundatio/Messaging/SharedMessageBusOptions.cs
+++ b/src/Foundatio/Messaging/SharedMessageBusOptions.cs
@@ -16,7 +16,7 @@ namespace Foundatio.Messaging {
         /// <summary>
         /// Controls the way the messages are sent to subscribers
         /// </summary>
-        public bool SendMessagesSynchronously { get; set; } = true;
+        public bool SendMessagesSynchronously { get; set; } = false;
     }
 
     public class SharedMessageBusOptionsBuilder<TOptions, TBuilder> : SharedOptionsBuilder<TOptions, TBuilder>

--- a/src/Foundatio/Messaging/SharedMessageBusOptions.cs
+++ b/src/Foundatio/Messaging/SharedMessageBusOptions.cs
@@ -12,6 +12,11 @@ namespace Foundatio.Messaging {
         /// Controls which types messages are mapped to.
         /// </summary>
         public Dictionary<string, Type> MessageTypeMappings { get; set; } = new Dictionary<string, Type>();
+
+        /// <summary>
+        /// Controls the way the messages are sent to subscribers
+        /// </summary>
+        public bool SendMessagesSynchronously { get; set; } = true;
     }
 
     public class SharedMessageBusOptionsBuilder<TOptions, TBuilder> : SharedOptionsBuilder<TOptions, TBuilder>
@@ -27,7 +32,7 @@ namespace Foundatio.Messaging {
         public TBuilder MapMessageType<T>(string name) {
             if (Target.MessageTypeMappings == null)
                 Target.MessageTypeMappings = new Dictionary<string, Type>();
-            
+
             Target.MessageTypeMappings[name] = typeof(T);
             return (TBuilder)this;
         }
@@ -35,7 +40,7 @@ namespace Foundatio.Messaging {
         public TBuilder MapMessageTypeToClassName<T>() {
             if (Target.MessageTypeMappings == null)
                 Target.MessageTypeMappings = new Dictionary<string, Type>();
-            
+
             Target.MessageTypeMappings[typeof(T).Name] = typeof(T);
             return (TBuilder)this;
         }


### PR DESCRIPTION
When using the AzureServiceBus the best way to guarantee the delivery of messages is to use `ReceiveMode.PeekLock` on the subscription client.  For details see FoundatioFx/Foundatio.AzureServiceBus#38.

In order for this to work correctly the handler of a message needs to be able to throw an exception up to the subscription client.  These changes allow that to happen by optionally running the handlers sequentially rather than in parallel in a task as they are by default so that if a handler throws an exception it can be handled by the underlying client.


