### PR TITLE
downgraded librraries to support .NET Core 3.1 LTS.

### DIFF
--- a/samples/Foundatio.HostingSample/Foundatio.HostingSample.csproj
+++ b/samples/Foundatio.HostingSample/Foundatio.HostingSample.csproj
@@ -7,6 +7,6 @@
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.DataProtection/Foundatio.DataProtection.csproj
+++ b/src/Foundatio.DataProtection/Foundatio.DataProtection.csproj
@@ -3,7 +3,7 @@
     <PackageTags>$(PackageTags);DataProtection</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="3.1.16" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Foundatio\Foundatio.csproj" />

--- a/src/Foundatio.Extensions.Hosting/Foundatio.Extensions.Hosting.csproj
+++ b/src/Foundatio.Extensions.Hosting/Foundatio.Extensions.Hosting.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.16" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Foundatio\Foundatio.csproj" />

--- a/src/Foundatio.JsonNet/Foundatio.JsonNet.csproj
+++ b/src/Foundatio.JsonNet/Foundatio.JsonNet.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Foundatio\Foundatio.csproj" />

--- a/src/Foundatio.TestHarness/Foundatio.TestHarness.csproj
+++ b/src/Foundatio.TestHarness/Foundatio.TestHarness.csproj
@@ -9,7 +9,8 @@
     <PackageReference Include="Exceptionless.RandomData" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.16" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Foundatio/Foundatio.csproj
+++ b/src/Foundatio/Foundatio.csproj
@@ -2,8 +2,8 @@
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.16" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.16" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Need

There exists a need to be able to support applications and libraries written to the .NET Core 3.1 Long Term Support (LTS) version of .NET. .NET 3.1 is to be supported through 2022.

Problem
Currently, The core Foundatio library references 5.0 versions of a few libraries that break the support for .NET Core 3.1 and require .NET Core 5.0, a non-LTS version of .NET.

Solution

Roll back the libraries that force .NET 5.0 to their latest respective 3.1.x versions. 