### PR TITLE
InMemoryCacheClient.SetAllAsync isn't respecting the expiry

### DIFF
--- a/src/Foundatio/Caching/InMemoryCacheClient.cs
+++ b/src/Foundatio/Caching/InMemoryCacheClient.cs
@@ -532,7 +532,7 @@ namespace Foundatio.Caching {
 
             var tasks = new List<Task<bool>>();
             foreach (var entry in values)
-                tasks.Add(SetAsync(entry.Key, entry.Value));
+                tasks.Add(SetAsync(entry.Key, entry.Value, expiresIn));
 
             bool[] results = await Task.WhenAll(tasks).AnyContext();
             return results.Count(r => r);

--- a/tests/Foundatio.Tests/Caching/InMemoryCacheClientTests.cs
+++ b/tests/Foundatio.Tests/Caching/InMemoryCacheClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Foundatio.Caching;
 using Foundatio.Utility;
@@ -151,6 +152,17 @@ namespace Foundatio.Tests.Caching {
                     Assert.Equal(2, cache.Misses);
                 }
             }
+        }
+
+        [Fact]
+        public async Task SetAllShouldExpire() {
+            var client = GetCacheClient();
+
+            var expiry = TimeSpan.FromMilliseconds(50);
+            await client.SetAllAsync(new Dictionary<string, object> { { "test", "value" } }, expiry);
+            await Task.Delay(expiry);
+
+            Assert.False(await client.ExistsAsync("test"));
         }
     }
 }


### PR DESCRIPTION
Related to issue: https://github.com/FoundatioFx/Foundatio/issues/271