### PR TITLE
Update GitHubActionsTestLogger

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -33,7 +33,7 @@ jobs:
       if: hashFiles('docker-compose.yml') != ''
       run: docker compose up -d && docker compose up ready || true
     - name: Run Tests
-      run: dotnet test ${{ inputs.solution }} --configuration Release --no-build --logger "GitHubActions;report-warnings=false" 
+      run: dotnet test ${{ inputs.solution }} --configuration Release --no-build --logger GitHubActions
     - name: Package
       if: github.event_name != 'pull_request'
       run: dotnet pack ${{ inputs.solution }} --configuration Release --no-build

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -9,6 +9,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.4.1"  PrivateAssets="All" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.0"  PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Includes better, more compact summaries:
https://github.com/Tyrrrz/GitHubActionsTestLogger/blob/master/Changelog.md

Also `report-warnings` is no longer needed