### PR TITLE
Working on message bus subscriptions options

### DIFF
--- a/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
+++ b/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
@@ -522,7 +522,7 @@ namespace Foundatio.Tests.Messaging {
                     Interlocked.Increment(ref messageCount);
                     cancellationTokenSource.Cancel();
                     countdown.Signal();
-                }, cancellationTokenSource.Token);
+                }, cancellationToken: cancellationTokenSource.Token);
 
                 await messageBus.SubscribeAsync<object>(msg => countdown.Signal());
 

--- a/src/Foundatio.TestHarness/Queue/QueueTestBase.cs
+++ b/src/Foundatio.TestHarness/Queue/QueueTestBase.cs
@@ -553,6 +553,7 @@ namespace Foundatio.Tests.Queue {
                 return;
 
             try {
+                Log.MinimumLevel = LogLevel.Trace;
                 await queue.DeleteQueueAsync();
                 await AssertEmptyQueueAsync(queue);
 
@@ -564,14 +565,16 @@ namespace Foundatio.Tests.Queue {
                 Assert.InRange(sw.Elapsed, TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(5000));
 
                 _ = Task.Run(async () => {
-                    await SystemClock.SleepAsync(500);
+                    await Task.Delay(500);
+                    _logger.LogInformation("Enqueuing async message");
                     await queue.EnqueueAsync(new SimpleWorkItem {
                         Data = "Hello"
                     });
                 });
 
                 sw.Restart();
-                workItem = await queue.DequeueAsync(TimeSpan.FromSeconds(1));
+                _logger.LogInformation("Dequeuing message with timeout");
+                workItem = await queue.DequeueAsync(TimeSpan.FromSeconds(10));
                 sw.Stop();
                 if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTrace("Time {Elapsed:g}", sw.Elapsed);
                 Assert.True(sw.Elapsed > TimeSpan.FromMilliseconds(400));

--- a/src/Foundatio/Foundatio.csproj
+++ b/src/Foundatio/Foundatio.csproj
@@ -5,5 +5,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0" />
+    <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio/Messaging/IMessageBus.cs
+++ b/src/Foundatio/Messaging/IMessageBus.cs
@@ -7,6 +7,8 @@ namespace Foundatio.Messaging {
     public class MessageOptions {
         public string UniqueId { get; set; }
         public string CorrelationId { get; set; }
+        public string Topic { get; set; }
+        public string MessageType { get; set; }
         public TimeSpan? DeliveryDelay { get; set; }
         public IDictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
     }

--- a/src/Foundatio/Messaging/IMessageSubscriber.cs
+++ b/src/Foundatio/Messaging/IMessageSubscriber.cs
@@ -1,37 +1,77 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Foundatio.Messaging {
     public interface IMessageSubscriber {
-        Task SubscribeAsync<T>(Func<T, CancellationToken, Task> handler, CancellationToken cancellationToken = default) where T : class;
+        Task<IMessageSubscription> SubscribeAsync<T>(Func<T, CancellationToken, Task> handler, MessageSubscriptionOptions options = null) where T : class;
     }
 
     public static class MessageBusExtensions {
-        public static Task SubscribeAsync<T>(this IMessageSubscriber subscriber, Func<T, Task> handler, CancellationToken cancellationToken = default) where T : class {
-            return subscriber.SubscribeAsync<T>((msg, token) => handler(msg), cancellationToken);
+        public static Task<IMessageSubscription> SubscribeAsync<T>(this IMessageSubscriber subscriber, Func<T, Task> handler, MessageSubscriptionOptions options = null) where T : class {
+            return subscriber.SubscribeAsync<T>((msg, token) => handler(msg), options);
         }
 
-        public static Task SubscribeAsync<T>(this IMessageSubscriber subscriber, Action<T> handler, CancellationToken cancellationToken = default) where T : class {
+        public static Task<IMessageSubscription> SubscribeAsync<T>(this IMessageSubscriber subscriber, Action<T> handler, MessageSubscriptionOptions options = null) where T : class {
             return subscriber.SubscribeAsync<T>((msg, token) => {
                 handler(msg);
                 return Task.CompletedTask;
-            }, cancellationToken);
+            }, options);
         }
 
-        public static Task SubscribeAsync(this IMessageSubscriber subscriber, Func<IMessage, CancellationToken, Task> handler, CancellationToken cancellationToken = default) {
-            return subscriber.SubscribeAsync<IMessage>((msg, token) => handler(msg, token), cancellationToken);
+        public static Task<IMessageSubscription> SubscribeAsync(this IMessageSubscriber subscriber, Func<IMessage, CancellationToken, Task> handler, MessageSubscriptionOptions options = null) {
+            return subscriber.SubscribeAsync<IMessage>((msg, token) => handler(msg, token), options);
         }
 
-        public static Task SubscribeAsync(this IMessageSubscriber subscriber, Func<IMessage, Task> handler, CancellationToken cancellationToken = default) {
-            return subscriber.SubscribeAsync((msg, token) => handler(msg), cancellationToken);
+        public static Task<IMessageSubscription> SubscribeAsync(this IMessageSubscriber subscriber, Func<IMessage, Task> handler, MessageSubscriptionOptions options = null) {
+            return subscriber.SubscribeAsync((msg, token) => handler(msg), options);
         }
 
-        public static Task SubscribeAsync(this IMessageSubscriber subscriber, Action<IMessage> handler, CancellationToken cancellationToken = default) {
+        public static Task<IMessageSubscription> SubscribeAsync(this IMessageSubscriber subscriber, Action<IMessage> handler, MessageSubscriptionOptions options = null) {
             return subscriber.SubscribeAsync((msg, token) => {
                 handler(msg);
                 return Task.CompletedTask;
-            }, cancellationToken);
+            }, options);
         }
+    }
+
+    public interface IMessageSubscription : IAsyncDisposable {
+        string SubscriptionId { get; }
+        IDictionary<string, string> Properties { get; }
+    }
+
+    public class MessageSubscription : IMessageSubscription {
+        private readonly Func<ValueTask> _disposeSubscriptionFunc;
+
+        public MessageSubscription(string subscriptionId, Func<ValueTask> disposeSubscriptionFunc) {
+            SubscriptionId = subscriptionId;
+            _disposeSubscriptionFunc = disposeSubscriptionFunc;
+        }
+
+        public string SubscriptionId { get; }
+        public IDictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
+
+        public ValueTask DisposeAsync() {
+            return _disposeSubscriptionFunc?.Invoke() ?? new ValueTask();
+        }
+    }
+
+    public class MessageSubscriptionOptions {
+        /// <summary>
+        /// The topic name
+        /// </summary>
+        public string Topic { get; set; }
+
+        /// <summary>
+        /// Resolves a message to a .NET type.
+        /// </summary>
+        public Func<IConsumeMessageContext, Type> MessageTypeResolver { get; set; }
+
+        public CancellationToken CancellationToken { get; set; }
+
+        public IDictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
+
+        public static implicit operator MessageSubscriptionOptions(CancellationToken cancellationToken) => new() {  CancellationToken = cancellationToken };
     }
 }

--- a/src/Foundatio/Messaging/IMessageSubscriber.cs
+++ b/src/Foundatio/Messaging/IMessageSubscriber.cs
@@ -5,34 +5,34 @@ using System.Threading.Tasks;
 
 namespace Foundatio.Messaging {
     public interface IMessageSubscriber {
-        Task<IMessageSubscription> SubscribeAsync<T>(Func<T, CancellationToken, Task> handler, MessageSubscriptionOptions options = null) where T : class;
+        Task<IMessageSubscription> SubscribeAsync<T>(Func<T, CancellationToken, Task> handler, MessageSubscriptionOptions options = null, CancellationToken cancellationToken = default) where T : class;
     }
 
     public static class MessageBusExtensions {
-        public static Task<IMessageSubscription> SubscribeAsync<T>(this IMessageSubscriber subscriber, Func<T, Task> handler, MessageSubscriptionOptions options = null) where T : class {
-            return subscriber.SubscribeAsync<T>((msg, token) => handler(msg), options);
+        public static Task<IMessageSubscription> SubscribeAsync<T>(this IMessageSubscriber subscriber, Func<T, Task> handler, MessageSubscriptionOptions options = null, CancellationToken cancellationToken = default) where T : class {
+            return subscriber.SubscribeAsync<T>((msg, token) => handler(msg), options, cancellationToken);
         }
 
-        public static Task<IMessageSubscription> SubscribeAsync<T>(this IMessageSubscriber subscriber, Action<T> handler, MessageSubscriptionOptions options = null) where T : class {
+        public static Task<IMessageSubscription> SubscribeAsync<T>(this IMessageSubscriber subscriber, Action<T> handler, MessageSubscriptionOptions options = null, CancellationToken cancellationToken = default) where T : class {
             return subscriber.SubscribeAsync<T>((msg, token) => {
                 handler(msg);
                 return Task.CompletedTask;
-            }, options);
+            }, options, cancellationToken);
         }
 
-        public static Task<IMessageSubscription> SubscribeAsync(this IMessageSubscriber subscriber, Func<IMessage, CancellationToken, Task> handler, MessageSubscriptionOptions options = null) {
-            return subscriber.SubscribeAsync<IMessage>((msg, token) => handler(msg, token), options);
+        public static Task<IMessageSubscription> SubscribeAsync(this IMessageSubscriber subscriber, Func<IMessage, CancellationToken, Task> handler, MessageSubscriptionOptions options = null, CancellationToken cancellationToken = default) {
+            return subscriber.SubscribeAsync<IMessage>((msg, token) => handler(msg, token), options, cancellationToken);
         }
 
-        public static Task<IMessageSubscription> SubscribeAsync(this IMessageSubscriber subscriber, Func<IMessage, Task> handler, MessageSubscriptionOptions options = null) {
-            return subscriber.SubscribeAsync((msg, token) => handler(msg), options);
+        public static Task<IMessageSubscription> SubscribeAsync(this IMessageSubscriber subscriber, Func<IMessage, Task> handler, MessageSubscriptionOptions options = null, CancellationToken cancellationToken = default) {
+            return subscriber.SubscribeAsync((msg, token) => handler(msg), options, cancellationToken);
         }
 
-        public static Task<IMessageSubscription> SubscribeAsync(this IMessageSubscriber subscriber, Action<IMessage> handler, MessageSubscriptionOptions options = null) {
+        public static Task<IMessageSubscription> SubscribeAsync(this IMessageSubscriber subscriber, Action<IMessage> handler, MessageSubscriptionOptions options = null, CancellationToken cancellationToken = default) {
             return subscriber.SubscribeAsync((msg, token) => {
                 handler(msg);
                 return Task.CompletedTask;
-            }, options);
+            }, options, cancellationToken);
         }
     }
 
@@ -63,15 +63,6 @@ namespace Foundatio.Messaging {
         /// </summary>
         public string Topic { get; set; }
 
-        /// <summary>
-        /// Resolves a message to a .NET type.
-        /// </summary>
-        public Func<IConsumeMessageContext, Type> MessageTypeResolver { get; set; }
-
-        public CancellationToken CancellationToken { get; set; }
-
         public IDictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
-
-        public static implicit operator MessageSubscriptionOptions(CancellationToken cancellationToken) => new() {  CancellationToken = cancellationToken };
     }
 }

--- a/src/Foundatio/Messaging/Message.cs
+++ b/src/Foundatio/Messaging/Message.cs
@@ -7,6 +7,7 @@ namespace Foundatio.Messaging {
     public interface IMessage : IAsyncDisposable {
         string UniqueId { get; }
         string CorrelationId { get; }
+        string Topic { get; }
         string Type { get; }
         Type ClrType { get; }
         byte[] Data { get; }
@@ -33,6 +34,7 @@ namespace Foundatio.Messaging {
 
         public string UniqueId { get; set; }
         public string CorrelationId { get; set; }
+        public string Topic { get; set; }
         public string Type { get; set; }
         public Type ClrType { get; set; }
         public IDictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
@@ -40,20 +42,20 @@ namespace Foundatio.Messaging {
 
         public object GetBody() => _getBody(this);
 
-        public Task AbandonAsync() {
-            throw new NotImplementedException();
+        public virtual Task AbandonAsync() {
+            return Task.CompletedTask;
         }
 
-        public Task CompleteAsync() {
-            throw new NotImplementedException();
+        public virtual Task CompleteAsync() {
+            return Task.CompletedTask;
         }
 
-        public Task RenewLockAsync() {
-            throw new NotImplementedException();
+        public virtual Task RenewLockAsync() {
+            return Task.CompletedTask;
         }
 
-        public ValueTask DisposeAsync() {
-            throw new NotImplementedException();
+        public virtual ValueTask DisposeAsync() {
+            return new ValueTask(AbandonAsync());
         }
     }
 
@@ -65,27 +67,19 @@ namespace Foundatio.Messaging {
         }
 
         public byte[] Data => _message.Data;
-
         public T Body => (T)GetBody();
-
         public string UniqueId => _message.UniqueId;
-
         public string CorrelationId => _message.CorrelationId;
-
+        public string Topic => _message.Topic;
         public string Type => _message.Type;
-
         public Type ClrType => _message.ClrType;
-
         public IDictionary<string, string> Properties => _message.Properties;
 
         public object GetBody() => _message.GetBody();
 
         public Task AbandonAsync() => _message.AbandonAsync();
-
         public Task CompleteAsync() => _message.CompleteAsync();
-
         public Task RenewLockAsync() => _message.RenewLockAsync();
-
         public ValueTask DisposeAsync() => _message.DisposeAsync();
     }
 }

--- a/src/Foundatio/Messaging/Message.cs
+++ b/src/Foundatio/Messaging/Message.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using Foundatio.Serializer;
+using System.Threading.Tasks;
 
 namespace Foundatio.Messaging {
-    public interface IMessage {
+    public interface IMessage : IAsyncDisposable {
         string UniqueId { get; }
         string CorrelationId { get; }
         string Type { get; }
@@ -12,6 +12,10 @@ namespace Foundatio.Messaging {
         byte[] Data { get; }
         object GetBody();
         IDictionary<string, string> Properties { get; }
+
+        Task RenewLockAsync();
+        Task AbandonAsync();
+        Task CompleteAsync();
     }
 
     public interface IMessage<T> : IMessage where T: class {
@@ -33,7 +37,24 @@ namespace Foundatio.Messaging {
         public Type ClrType { get; set; }
         public IDictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
         public byte[] Data { get; set; }
+
         public object GetBody() => _getBody(this);
+
+        public Task AbandonAsync() {
+            throw new NotImplementedException();
+        }
+
+        public Task CompleteAsync() {
+            throw new NotImplementedException();
+        }
+
+        public Task RenewLockAsync() {
+            throw new NotImplementedException();
+        }
+
+        public ValueTask DisposeAsync() {
+            throw new NotImplementedException();
+        }
     }
 
     public class Message<T> : IMessage<T> where T : class {
@@ -58,5 +79,13 @@ namespace Foundatio.Messaging {
         public IDictionary<string, string> Properties => _message.Properties;
 
         public object GetBody() => _message.GetBody();
+
+        public Task AbandonAsync() => _message.AbandonAsync();
+
+        public Task CompleteAsync() => _message.CompleteAsync();
+
+        public Task RenewLockAsync() => _message.RenewLockAsync();
+
+        public ValueTask DisposeAsync() => _message.DisposeAsync();
     }
 }

--- a/src/Foundatio/Messaging/NullMessageBus.cs
+++ b/src/Foundatio/Messaging/NullMessageBus.cs
@@ -10,14 +10,10 @@ namespace Foundatio.Messaging {
             return Task.CompletedTask;
         }
 
-        public Task SubscribeAsync<T>(Func<T, CancellationToken, Task> handler, CancellationToken cancellationToken = default) where T : class {
-            return Task.CompletedTask;
+        public Task<IMessageSubscription> SubscribeAsync<T>(Func<T, CancellationToken, Task> handler, MessageSubscriptionOptions options = null, CancellationToken cancellationToken = default) where T : class {
+            return Task.FromResult<IMessageSubscription>(new MessageSubscription(Guid.NewGuid().ToString(), () => new ValueTask()));
         }
 
         public void Dispose() {}
-
-        public Task<IMessageSubscription> SubscribeAsync<T>(Func<T, CancellationToken, Task> handler, MessageSubscriptionOptions options = null) where T : class {
-            return Task.FromResult<IMessageSubscription>(new MessageSubscription(Guid.NewGuid().ToString(), () => new ValueTask()));
-        }
     }
 }

--- a/src/Foundatio/Messaging/NullMessageBus.cs
+++ b/src/Foundatio/Messaging/NullMessageBus.cs
@@ -15,5 +15,9 @@ namespace Foundatio.Messaging {
         }
 
         public void Dispose() {}
+
+        public Task<IMessageSubscription> SubscribeAsync<T>(Func<T, CancellationToken, Task> handler, MessageSubscriptionOptions options = null) where T : class {
+            return Task.FromResult<IMessageSubscription>(new MessageSubscription(Guid.NewGuid().ToString(), () => new ValueTask()));
+        }
     }
 }

--- a/src/Foundatio/Messaging/SharedMessageBusOptions.cs
+++ b/src/Foundatio/Messaging/SharedMessageBusOptions.cs
@@ -4,32 +4,37 @@ using System.Collections.Generic;
 namespace Foundatio.Messaging {
     public class SharedMessageBusOptions : SharedOptions {
         /// <summary>
-        /// The topic name
+        /// The default topic name
         /// </summary>
-        public string Topic { get; set; } = "messages";
+        public string DefaultTopic { get; set; } = "messages";
 
         /// <summary>
         /// Resolves message types
         /// </summary>
-        public IMessageTypeResolver MessageTypeResolver { get; set; }
+        public IMessageRouter Router { get; set; }
 
         /// <summary>
-        /// Statically configured message type mappings. <see cref="MessageTypeResolver"/> will be run first and then this dictionary will be checked.
+        /// Statically configured message type mappings. <see cref="Router"/> will be run first and then this dictionary will be checked.
         /// </summary>
         public Dictionary<string, Type> MessageTypeMappings { get; set; } = new Dictionary<string, Type>();
     }
 
-    public interface IMessageTypeResolver {
+    public interface IMessageRouter {
+        // get topic from bus options, message and message options
+        // get message type from message and options
+        // get .net type from topic, message type and properties (headers)
         IConsumeMessageContext ToMessageType(Type messageType);
         Type ToClrType(IConsumeMessageContext context);
     }
 
     public interface IConsumeMessageContext {
+        string Topic { get; set; }
         string MessageType { get; set; }
         IDictionary<string, string> Properties { get; }
     }
 
     public class ConsumeMessageContext : IConsumeMessageContext {
+        public string Topic { get; set; }
         public string MessageType { get; set; } 
         public IDictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
     }
@@ -40,14 +45,14 @@ namespace Foundatio.Messaging {
         public TBuilder Topic(string topic) {
             if (string.IsNullOrEmpty(topic))
                 throw new ArgumentNullException(nameof(topic));
-            Target.Topic = topic;
+            Target.DefaultTopic = topic;
             return (TBuilder)this;
         }
 
-        public TBuilder MessageTypeResolver(IMessageTypeResolver resolver) {
+        public TBuilder MessageTypeResolver(IMessageRouter resolver) {
             if (resolver == null)
                 throw new ArgumentNullException(nameof(resolver));
-            Target.MessageTypeResolver = resolver;
+            Target.Router = resolver;
             return (TBuilder)this;
         }
 

--- a/src/Foundatio/Messaging/SharedMessageBusOptions.cs
+++ b/src/Foundatio/Messaging/SharedMessageBusOptions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace Foundatio.Messaging {
@@ -9,9 +9,24 @@ namespace Foundatio.Messaging {
         public string Topic { get; set; } = "messages";
 
         /// <summary>
-        /// Controls which types messages are mapped to.
+        /// Resolves a message to a .NET type.
+        /// </summary>
+        public Func<IConsumeMessageContext, Type> MessageTypeResolver { get; set; }
+
+        /// <summary>
+        /// Statically configured message type mappings. <see cref="MessageTypeResolver"/> will be run first and then this dictionary will be checked.
         /// </summary>
         public Dictionary<string, Type> MessageTypeMappings { get; set; } = new Dictionary<string, Type>();
+    }
+
+    public interface IConsumeMessageContext {
+        string MessageType { get; set; }
+        IDictionary<string, string> Properties { get; }
+    }
+
+    public class ConsumeMessageContext : IConsumeMessageContext {
+        public string MessageType { get; set; } 
+        public IDictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
     }
 
     public class SharedMessageBusOptionsBuilder<TOptions, TBuilder> : SharedOptionsBuilder<TOptions, TBuilder>
@@ -21,6 +36,13 @@ namespace Foundatio.Messaging {
             if (string.IsNullOrEmpty(topic))
                 throw new ArgumentNullException(nameof(topic));
             Target.Topic = topic;
+            return (TBuilder)this;
+        }
+
+        public TBuilder MessageTypeResolver(Func<IConsumeMessageContext, Type> resolver) {
+            if (resolver == null)
+                throw new ArgumentNullException(nameof(resolver));
+            Target.MessageTypeResolver = resolver;
             return (TBuilder)this;
         }
 

--- a/src/Foundatio/Messaging/SharedMessageBusOptions.cs
+++ b/src/Foundatio/Messaging/SharedMessageBusOptions.cs
@@ -9,14 +9,19 @@ namespace Foundatio.Messaging {
         public string Topic { get; set; } = "messages";
 
         /// <summary>
-        /// Resolves a message to a .NET type.
+        /// Resolves message types
         /// </summary>
-        public Func<IConsumeMessageContext, Type> MessageTypeResolver { get; set; }
+        public IMessageTypeResolver MessageTypeResolver { get; set; }
 
         /// <summary>
         /// Statically configured message type mappings. <see cref="MessageTypeResolver"/> will be run first and then this dictionary will be checked.
         /// </summary>
         public Dictionary<string, Type> MessageTypeMappings { get; set; } = new Dictionary<string, Type>();
+    }
+
+    public interface IMessageTypeResolver {
+        IConsumeMessageContext ToMessageType(Type messageType);
+        Type ToClrType(IConsumeMessageContext context);
     }
 
     public interface IConsumeMessageContext {
@@ -39,7 +44,7 @@ namespace Foundatio.Messaging {
             return (TBuilder)this;
         }
 
-        public TBuilder MessageTypeResolver(Func<IConsumeMessageContext, Type> resolver) {
+        public TBuilder MessageTypeResolver(IMessageTypeResolver resolver) {
             if (resolver == null)
                 throw new ArgumentNullException(nameof(resolver));
             Target.MessageTypeResolver = resolver;

--- a/src/Foundatio/Queues/IQueueEntry.cs
+++ b/src/Foundatio/Queues/IQueueEntry.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Foundatio.Utility;
 
 namespace Foundatio.Queues {
-    public interface IQueueEntry {
+    public interface IQueueEntry : IAsyncDisposable {
         string Id { get; }
         string CorrelationId { get; }
         IDictionary<string, string> Properties { get; }
@@ -18,7 +18,6 @@ namespace Foundatio.Queues {
         Task RenewLockAsync();
         Task AbandonAsync();
         Task CompleteAsync();
-        ValueTask DisposeAsync();
     }
     
     public interface IQueueEntry<T> : IQueueEntry  where T : class {

--- a/src/Foundatio/Serializer/ISerializer.cs
+++ b/src/Foundatio/Serializer/ISerializer.cs
@@ -14,6 +14,8 @@ namespace Foundatio.Serializer {
         public static ISerializer Instance { get; set; } = new SystemTextJsonSerializer();
     }
 
+    // TODO: Add a wrapper that adds activities for serialization
+
     public static class SerializerExtensions {
         public static T Deserialize<T>(this ISerializer serializer, Stream data) {
             return (T)serializer.Deserialize(data, typeof(T));


### PR DESCRIPTION
- concurrent dictionary per topic that has a channel of messages.

- publish sends a message to the channel based on the topic for the message
- by default the message type full name is the topic (1 topic per message type)
- message publish topics can be overridden to publish multiple message types to a single topic
- subscription specifies a topic which can have wildcards
- in memory subscription will check all of the topics and add all of the matching topics
- to the subscription object
- for rabbit impl, on subscribe will ensure all exchanges are created for the message types that are being listened for
- publish will ensure the topic the message is going to is created
- queue groups can be specified on subscriptions and if multiple subscribers use the same queue group, they will round robin the messages

- subscriptions have their own channel instances
- read from topic channel, write to all matching subscriber channels which in turn call the message handlers with their instances
- when writing to a subscriber channel and there is more than one matching subscriber, then all subscribers get a copy of the message
- if multiple subscribers have the same queue group name then we round robin them
- https://deniskyashif.com/2019/12/08/csharp-channels-part-1/
- https://github.com/deniskyashif/trydotnet-channels
