### PR TITLE
Fixes #285: InMemoryCacheClient ReplaceIfEqualAsync was not setting cache expiration causing locks to fail

### DIFF
--- a/src/Foundatio.TestHarness/Caching/CacheClientTestsBase.cs
+++ b/src/Foundatio.TestHarness/Caching/CacheClientTestsBase.cs
@@ -483,16 +483,19 @@ namespace Foundatio.Tests.Caching {
             using (cache) {
                 await cache.RemoveAllAsync();
 
-                Assert.True(await cache.AddAsync("replace-if-equal", "123"));
-                var result = await cache.GetAsync<string>("replace-if-equal");
+                const string cacheKey = "replace-if-equal";
+                Assert.True(await cache.AddAsync(cacheKey, "123"));
+                var result = await cache.GetAsync<string>(cacheKey);
                 Assert.NotNull(result);
                 Assert.Equal("123", result.Value);
+                Assert.Null(await cache.GetExpirationAsync(cacheKey));
 
-                Assert.False(await cache.ReplaceIfEqualAsync("replace-if-equal", "456", "789"));
-                Assert.True(await cache.ReplaceIfEqualAsync("replace-if-equal", "456", "123"));
-                result = await cache.GetAsync<string>("replace-if-equal");
+                Assert.False(await cache.ReplaceIfEqualAsync(cacheKey, "456", "789", TimeSpan.FromHours(1)));
+                Assert.True(await cache.ReplaceIfEqualAsync(cacheKey, "456", "123", TimeSpan.FromHours(1)));
+                result = await cache.GetAsync<string>(cacheKey);
                 Assert.NotNull(result);
                 Assert.Equal("456", result.Value);
+                Assert.NotNull(await cache.GetExpirationAsync(cacheKey));
             }
         }
         

--- a/tests/Foundatio.Tests/Caching/InMemoryCacheClientTests.cs
+++ b/tests/Foundatio.Tests/Caching/InMemoryCacheClientTests.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Foundatio.Caching;
 using Foundatio.Utility;

--- a/tests/Foundatio.Tests/Caching/InMemoryHybridCacheClientTests.cs
+++ b/tests/Foundatio.Tests/Caching/InMemoryHybridCacheClientTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Foundatio.Caching;
 using Foundatio.Messaging;
 using Microsoft.Extensions.Logging;

--- a/tests/Foundatio.Tests/Serializer/JsonNetSerializerTests.cs
+++ b/tests/Foundatio.Tests/Serializer/JsonNetSerializerTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Foundatio.Serializer;
+﻿using Foundatio.Serializer;
 using Foundatio.TestHarness.Utility;
 using Microsoft.Extensions.Logging;
 using Xunit;

--- a/tests/Foundatio.Tests/Serializer/MessagePackSerializerTests.cs
+++ b/tests/Foundatio.Tests/Serializer/MessagePackSerializerTests.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Exporters.Json;
-using BenchmarkDotNet.Loggers;
-using BenchmarkDotNet.Reports;
-using Foundatio.Serializer;
+﻿using Foundatio.Serializer;
 using Foundatio.TestHarness.Utility;
 using Microsoft.Extensions.Logging;
 using Xunit;

--- a/tests/Foundatio.Tests/Serializer/SystemTextJsonSerializerTests.cs
+++ b/tests/Foundatio.Tests/Serializer/SystemTextJsonSerializerTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Foundatio.Serializer;
+﻿using Foundatio.Serializer;
 using Foundatio.TestHarness.Utility;
 using Microsoft.Extensions.Logging;
 using Xunit;

--- a/tests/Foundatio.Tests/Serializer/Utf8JsonSerializerTests.cs
+++ b/tests/Foundatio.Tests/Serializer/Utf8JsonSerializerTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Foundatio.Serializer;
+﻿using Foundatio.Serializer;
 using Foundatio.TestHarness.Utility;
 using Microsoft.Extensions.Logging;
 using Xunit;

--- a/tests/Foundatio.Tests/Utility/ConnectionStringParserTests.cs
+++ b/tests/Foundatio.Tests/Utility/ConnectionStringParserTests.cs
@@ -1,8 +1,5 @@
-using System;
-using System.Collections.Generic;
-using Foundatio.Xunit;
+﻿using System;
 using Xunit;
-using Xunit.Abstractions;
 using Foundatio.Utility;
 
 namespace Foundatio.Tests.Utility {

--- a/tests/Foundatio.Tests/Utility/RunTests.cs
+++ b/tests/Foundatio.Tests/Utility/RunTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Foundatio.Xunit;
+﻿using Foundatio.Xunit;
 using Foundatio.Utility;
 using Xunit;
 using Xunit.Abstractions;


### PR DESCRIPTION
No changes are required for the Redis client (tests passed)