### PR TITLE
Add write file stream

### DIFF
--- a/src/Foundatio.TestHarness/Storage/FileStorageTestsBase.cs
+++ b/src/Foundatio.TestHarness/Storage/FileStorageTestsBase.cs
@@ -455,7 +455,7 @@ namespace Foundatio.Tests.Storage {
             }
         }
 
-        public virtual async Task WillWriteStremContentAsync() {
+        public virtual async Task WillWriteStreamContentAsync() {
 
             const string testContent = "test";
             const string path = "created.txt";

--- a/src/Foundatio.TestHarness/Storage/FileStorageTestsBase.cs
+++ b/src/Foundatio.TestHarness/Storage/FileStorageTestsBase.cs
@@ -6,12 +6,12 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Exceptionless;
-using Foundatio.Xunit;
 using Foundatio.Storage;
 using Foundatio.Tests.Utility;
-using Xunit;
 using Foundatio.Utility;
+using Foundatio.Xunit;
 using Microsoft.Extensions.Logging;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Foundatio.Tests.Storage {
@@ -452,6 +452,29 @@ namespace Foundatio.Tests.Storage {
                 }
 
                 Assert.Equal("Blake", await storage.GetFileContentsAsync(path));
+            }
+        }
+
+        public virtual async Task WillWriteStremContentAsync() {
+
+            const string testContent = "test";
+            const string path = "created.txt";
+
+            var storage = GetStorage();
+            if (storage == null)
+                return;
+
+            await ResetAsync(storage);
+
+            using (storage) {
+
+                using (var writer = new StreamWriter(await storage.GetFileStreamAsync(path, FileAccess.ReadWrite), Encoding.UTF8, 1024, false)) {
+                    await writer.WriteAsync(testContent);
+                }
+
+                var content = await storage.GetFileContentsAsync(path);
+
+                Assert.Equal(testContent, content);
             }
         }
 

--- a/src/Foundatio/Storage/IFileStorage.cs
+++ b/src/Foundatio/Storage/IFileStorage.cs
@@ -11,6 +11,7 @@ using Foundatio.Utility;
 
 namespace Foundatio.Storage {
     public interface IFileStorage : IHaveSerializer, IDisposable {
+        [Obsolete($"Use {nameof(GetFileStreamAsync)} with {nameof(FileAccess)} instead to define read or write behaviour of stream.")]
         Task<Stream> GetFileStreamAsync(string path, CancellationToken cancellationToken = default);
         Task<Stream> GetFileStreamAsync(string path, FileAccess fileAccess, CancellationToken cancellationToken = default);
         Task<FileSpec> GetFileInfoAsync(string path);

--- a/src/Foundatio/Storage/IFileStorage.cs
+++ b/src/Foundatio/Storage/IFileStorage.cs
@@ -12,6 +12,7 @@ using Foundatio.Utility;
 namespace Foundatio.Storage {
     public interface IFileStorage : IHaveSerializer, IDisposable {
         Task<Stream> GetFileStreamAsync(string path, CancellationToken cancellationToken = default);
+        Task<Stream> GetFileStreamAsync(string path, FileAccess fileAccess, CancellationToken cancellationToken = default);
         Task<FileSpec> GetFileInfoAsync(string path);
         Task<bool> ExistsAsync(string path);
         Task<bool> SaveFileAsync(string path, Stream stream, CancellationToken cancellationToken = default);

--- a/src/Foundatio/Storage/InMemoryFileStorage.cs
+++ b/src/Foundatio/Storage/InMemoryFileStorage.cs
@@ -37,13 +37,16 @@ namespace Foundatio.Storage {
         public long MaxFiles { get; set; }
         ISerializer IHaveSerializer.Serializer => _serializer;
 
-        public Task<Stream> GetFileStreamAsync(string path, CancellationToken cancellationToken = default) {
+        public Task<Stream> GetFileStreamAsync(string path, CancellationToken cancellationToken = default) =>
+            GetFileStreamAsync(path, FileAccess.Read, cancellationToken);
+
+        public Task<Stream> GetFileStreamAsync(string path, FileAccess fileAccess, CancellationToken cancellationToken = default) {
             if (String.IsNullOrEmpty(path))
                 throw new ArgumentNullException(nameof(path));
 
             string normalizedPath = path.NormalizePath();
             _logger.LogTrace("Getting file stream for {Path}", normalizedPath);
-            
+
             lock (_lock) {
                 if (!_storage.ContainsKey(normalizedPath)) {
                     _logger.LogError("Unable to get file stream for {Path}: File Not Found", normalizedPath);

--- a/src/Foundatio/Storage/ScopedFileStorage.cs
+++ b/src/Foundatio/Storage/ScopedFileStorage.cs
@@ -20,7 +20,10 @@ namespace Foundatio.Storage {
         public string Scope { get; private set; }
         ISerializer IHaveSerializer.Serializer => UnscopedStorage.Serializer;
 
-        public Task<Stream> GetFileStreamAsync(string path, CancellationToken cancellationToken = default) {
+        public Task<Stream> GetFileStreamAsync(string path, CancellationToken cancellationToken = default)
+            => GetFileStreamAsync(path, FileAccess.Read, cancellationToken);
+
+        public Task<Stream> GetFileStreamAsync(string path, FileAccess fileAccess, CancellationToken cancellationToken = default) {
             if (String.IsNullOrEmpty(path))
                 throw new ArgumentNullException(nameof(path));
 

--- a/tests/Foundatio.Tests/Storage/FolderFileStorageTests.cs
+++ b/tests/Foundatio.Tests/Storage/FolderFileStorageTests.cs
@@ -107,8 +107,8 @@ namespace Foundatio.Tests.Storage {
         }
 
         [Fact]
-        public override Task WillWriteStremContentAsync() {
-            return base.WillWriteStremContentAsync();
+        public override Task WillWriteStreamContentAsync() {
+            return base.WillWriteStreamContentAsync();
         }
     }
 }

--- a/tests/Foundatio.Tests/Storage/FolderFileStorageTests.cs
+++ b/tests/Foundatio.Tests/Storage/FolderFileStorageTests.cs
@@ -105,5 +105,10 @@ namespace Foundatio.Tests.Storage {
         public override Task WillRespectStreamOffsetAsync() {
             return base.WillRespectStreamOffsetAsync();
         }
+
+        [Fact]
+        public override Task WillWriteStremContentAsync() {
+            return base.WillWriteStremContentAsync();
+        }
     }
 }


### PR DESCRIPTION
To write files in the file storage, usually you want to write to the stream directly, not pass the stream over as an argument. (as I SaveFileAsync()

This PR adds an overload where you can tell if you want to use the stream you get to read or to write only. 

There should be no breaking changes on existing things, but a new method is added, therefore implementations have to implement that.