### PR TITLE
Add storage streammode

### DIFF
--- a/src/Foundatio.TestHarness/Storage/FileStorageTestsBase.cs
+++ b/src/Foundatio.TestHarness/Storage/FileStorageTestsBase.cs
@@ -468,7 +468,7 @@ namespace Foundatio.Tests.Storage {
 
             using (storage) {
 
-                using (var writer = new StreamWriter(await storage.GetFileStreamAsync(path, FileAccess.ReadWrite), Encoding.UTF8, 1024, false)) {
+                using (var writer = new StreamWriter(await storage.GetFileStreamAsync(path, StreamMode.Write), Encoding.UTF8, 1024, false)) {
                     await writer.WriteAsync(testContent);
                 }
 

--- a/src/Foundatio/Storage/IFileStorage.cs
+++ b/src/Foundatio/Storage/IFileStorage.cs
@@ -13,7 +13,14 @@ namespace Foundatio.Storage {
     public interface IFileStorage : IHaveSerializer, IDisposable {
         [Obsolete($"Use {nameof(GetFileStreamAsync)} with {nameof(FileAccess)} instead to define read or write behaviour of stream.")]
         Task<Stream> GetFileStreamAsync(string path, CancellationToken cancellationToken = default);
-        Task<Stream> GetFileStreamAsync(string path, FileAccess fileAccess, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Gets a file stream in the specified mode
+        /// </summary>
+        /// <param name="path">Path to the file in the file storage</param>
+        /// <param name="streamMode">What the stream is used for</param>
+        /// <param name="cancellationToken">Token to cancel</param>
+        /// <returns>Stream in the specified mode</returns>
+        Task<Stream> GetFileStreamAsync(string path, StreamMode streamMode, CancellationToken cancellationToken = default);
         Task<FileSpec> GetFileInfoAsync(string path);
         Task<bool> ExistsAsync(string path);
         Task<bool> SaveFileAsync(string path, Stream stream, CancellationToken cancellationToken = default);

--- a/src/Foundatio/Storage/InMemoryFileStorage.cs
+++ b/src/Foundatio/Storage/InMemoryFileStorage.cs
@@ -38,9 +38,9 @@ namespace Foundatio.Storage {
         ISerializer IHaveSerializer.Serializer => _serializer;
 
         public Task<Stream> GetFileStreamAsync(string path, CancellationToken cancellationToken = default) =>
-            GetFileStreamAsync(path, FileAccess.Read, cancellationToken);
+            GetFileStreamAsync(path, StreamMode.Read, cancellationToken);
 
-        public Task<Stream> GetFileStreamAsync(string path, FileAccess fileAccess, CancellationToken cancellationToken = default) {
+        public Task<Stream> GetFileStreamAsync(string path, StreamMode streamMode, CancellationToken cancellationToken = default) {
             if (String.IsNullOrEmpty(path))
                 throw new ArgumentNullException(nameof(path));
 

--- a/src/Foundatio/Storage/ScopedFileStorage.cs
+++ b/src/Foundatio/Storage/ScopedFileStorage.cs
@@ -21,9 +21,9 @@ namespace Foundatio.Storage {
         ISerializer IHaveSerializer.Serializer => UnscopedStorage.Serializer;
 
         public Task<Stream> GetFileStreamAsync(string path, CancellationToken cancellationToken = default)
-            => GetFileStreamAsync(path, FileAccess.Read, cancellationToken);
+            => GetFileStreamAsync(path, StreamMode.Read, cancellationToken);
 
-        public Task<Stream> GetFileStreamAsync(string path, FileAccess fileAccess, CancellationToken cancellationToken = default) {
+        public Task<Stream> GetFileStreamAsync(string path, StreamMode streamMode, CancellationToken cancellationToken = default) {
             if (String.IsNullOrEmpty(path))
                 throw new ArgumentNullException(nameof(path));
 

--- a/src/Foundatio/Storage/StreamMode.cs
+++ b/src/Foundatio/Storage/StreamMode.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Foundatio.Storage;
+
+/// <summary>
+/// Tells what the stream will be used for
+/// </summary>
+public enum StreamMode {
+    Read,
+    Write
+}


### PR DESCRIPTION
Add package internal enumeration for stream mode that can be expanded as new options to use a stream is added.

The option to use FileAccess in FolderStorage was kept to be able to use it if desired and not cut off the functionality.