### PR TITLE
Fix cache lock provider allowing multiple locks to be acquired.

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -42,7 +42,7 @@ jobs:
       run: "echo ref: ${{github.ref}} event: ${{github.event_name}}"
     - name: Build Version
       run: |
-        dotnet tool install --global minver-cli --version 4.3.0
+        dotnet tool install --global minver-cli --version 5.0.0
         version=$(minver --tag-prefix v)
         echo "MINVERVERSIONOVERRIDE=$version" >> $GITHUB_ENV
         echo "### Version: $version" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -32,23 +32,4 @@ _NCrunch_*
 .DS_Store
 
 # Rider
-
-# User specific
-**/.idea/**/workspace.xml
-**/.idea/**/tasks.xml
-**/.idea/shelf/*
-**/.idea/dictionaries
-
-# Sensitive or high-churn files
-**/.idea/**/dataSources/
-**/.idea/**/dataSources.ids
-**/.idea/**/dataSources.xml
-**/.idea/**/dataSources.local.xml
-**/.idea/**/sqlDataSources.xml
-**/.idea/**/dynamic.xml
-
-# Rider
-# Rider auto-generates .iml files, and contentModel.xml
-**/.idea/**/*.iml
-**/.idea/**/contentModel.xml
-**/.idea/**/modules.xml
+.idea

--- a/build/common.props
+++ b/build/common.props
@@ -38,7 +38,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     <PackageReference Include="AsyncFixer" Version="1.6.0" PrivateAssets="All" />
-    <PackageReference Include="MinVer" Version="4.3.0" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Foundatio.Extensions.Hosting/Jobs/ScheduledJobService.cs
+++ b/src/Foundatio.Extensions.Hosting/Jobs/ScheduledJobService.cs
@@ -24,7 +24,7 @@ public class ScheduledJobService : BackgroundService, IJobStatus
     public ScheduledJobService(IServiceProvider serviceProvider, ILoggerFactory loggerFactory)
     {
         _serviceProvider = serviceProvider;
-        var cacheClient = serviceProvider.GetService<ICacheClient>() ?? new InMemoryCacheClient();
+        var cacheClient = serviceProvider.GetService<ICacheClient>() ?? new InMemoryCacheClient(o => o.LoggerFactory(loggerFactory));
         _jobs = new List<ScheduledJobRunner>(serviceProvider.GetServices<ScheduledJobRegistration>().Select(j => new ScheduledJobRunner(j.JobFactory, j.Schedule, cacheClient, loggerFactory)));
 
         var lifetime = serviceProvider.GetService<ShutdownHostIfNoJobsRunningService>();

--- a/src/Foundatio.TestHarness/Caching/CacheClientTestsBase.cs
+++ b/src/Foundatio.TestHarness/Caching/CacheClientTestsBase.cs
@@ -210,7 +210,8 @@ public abstract class CacheClientTestsBase : TestWithLoggingBase
 
             string cacheKey = Guid.NewGuid().ToString("N").Substring(10);
             long adds = 0;
-            await Run.InParallelAsync(5, async i =>
+
+            await Parallel.ForEachAsync(Enumerable.Range(1, 5), async (i, _) =>
             {
                 if (await cache.AddAsync(cacheKey, i, TimeSpan.FromMinutes(1)))
                     Interlocked.Increment(ref adds);

--- a/src/Foundatio.TestHarness/Caching/HybridCacheClientTests.cs
+++ b/src/Foundatio.TestHarness/Caching/HybridCacheClientTests.cs
@@ -13,14 +13,18 @@ namespace Foundatio.Tests.Caching;
 
 public class HybridCacheClientTests : CacheClientTestsBase, IDisposable
 {
-    protected readonly ICacheClient _distributedCache = new InMemoryCacheClient(new InMemoryCacheClientOptions());
-    protected readonly IMessageBus _messageBus = new InMemoryMessageBus(new InMemoryMessageBusOptions());
+    protected readonly ICacheClient _distributedCache;
+    protected readonly IMessageBus _messageBus;
 
-    public HybridCacheClientTests(ITestOutputHelper output) : base(output) { }
+    public HybridCacheClientTests(ITestOutputHelper output) : base(output)
+    {
+        _distributedCache = new InMemoryCacheClient(o => o.LoggerFactory(Log));
+        _messageBus = new InMemoryMessageBus(o => o.LoggerFactory(Log));
+    }
 
     protected override ICacheClient GetCacheClient(bool shouldThrowOnSerializationError = true)
     {
-        return new HybridCacheClient(_distributedCache, _messageBus, new InMemoryCacheClientOptions { CloneValues = true, ShouldThrowOnSerializationError = shouldThrowOnSerializationError }, Log);
+        return new HybridCacheClient(_distributedCache, _messageBus, new InMemoryCacheClientOptions { CloneValues = true, ShouldThrowOnSerializationError = shouldThrowOnSerializationError, LoggerFactory = Log }, Log);
     }
 
     [Fact]

--- a/src/Foundatio.TestHarness/Jobs/JobQueueTestsBase.cs
+++ b/src/Foundatio.TestHarness/Jobs/JobQueueTestsBase.cs
@@ -74,7 +74,7 @@ public abstract class JobQueueTestsBase : TestWithLoggingBase
         using var queue = GetSampleWorkItemQueue(retries: 0, retryDelay: TimeSpan.Zero);
         await queue.DeleteQueueAsync();
 
-        var enqueueTask = Run.InParallelAsync(workItemCount, index => queue.EnqueueAsync(new SampleQueueWorkItem
+        var enqueueTask = Parallel.ForEachAsync(Enumerable.Range(1, workItemCount), async (index, _) => await queue.EnqueueAsync(new SampleQueueWorkItem
         {
             Created = SystemClock.UtcNow,
             Path = "somepath" + index
@@ -99,10 +99,10 @@ public abstract class JobQueueTestsBase : TestWithLoggingBase
         using var queue = GetSampleWorkItemQueue(retries: 3, retryDelay: TimeSpan.Zero);
         await queue.DeleteQueueAsync();
 
-        var enqueueTask = Run.InParallelAsync(workItemCount, index =>
+        var enqueueTask = Parallel.ForEachAsync(Enumerable.Range(1, workItemCount), async (index, _) =>
         {
             _logger.LogInformation($"Enqueue #{index}");
-            return queue.EnqueueAsync(new SampleQueueWorkItem
+            await queue.EnqueueAsync(new SampleQueueWorkItem
             {
                 Created = SystemClock.UtcNow,
                 Path = "somepath" + index
@@ -147,10 +147,10 @@ public abstract class JobQueueTestsBase : TestWithLoggingBase
             }
             _logger.LogInformation("Done setting up queues");
 
-            var enqueueTask = Run.InParallelAsync(workItemCount, index =>
+            var enqueueTask = Parallel.ForEachAsync(Enumerable.Range(1, workItemCount), async (_, _) =>
             {
                 var queue = queues[RandomData.GetInt(0, jobCount - 1)];
-                return queue.EnqueueAsync(new SampleQueueWorkItem
+                await queue.EnqueueAsync(new SampleQueueWorkItem
                 {
                     Created = SystemClock.UtcNow,
                     Path = RandomData.GetString()
@@ -159,7 +159,7 @@ public abstract class JobQueueTestsBase : TestWithLoggingBase
             _logger.LogInformation("Done enqueueing");
 
             var cancellationTokenSource = new CancellationTokenSource();
-            await Run.InParallelAsync(jobCount, async index =>
+            await Parallel.ForEachAsync(Enumerable.Range(1, jobCount), async (index, _) =>
             {
                 var queue = queues[index - 1];
                 var job = new SampleQueueWithRandomErrorsAndAbandonsJob(queue, metrics, Log);

--- a/src/Foundatio.TestHarness/Jobs/JobQueueTestsBase.cs
+++ b/src/Foundatio.TestHarness/Jobs/JobQueueTestsBase.cs
@@ -109,7 +109,7 @@ public abstract class JobQueueTestsBase : TestWithLoggingBase
             });
         });
 
-        var lockProvider = new ThrottlingLockProvider(new InMemoryCacheClient(new InMemoryCacheClientOptions()), allowedLockCount, TimeSpan.FromDays(1), Log);
+        var lockProvider = new ThrottlingLockProvider(new InMemoryCacheClient(o => o.LoggerFactory(Log)), allowedLockCount, TimeSpan.FromDays(1), Log);
         var job = new SampleQueueJobWithLocking(queue, null, lockProvider, Log);
         await SystemClock.SleepAsync(10);
         _logger.LogInformation("Starting RunUntilEmptyAsync");

--- a/src/Foundatio.TestHarness/Jobs/ThrottledJob.cs
+++ b/src/Foundatio.TestHarness/Jobs/ThrottledJob.cs
@@ -18,7 +18,7 @@ public class ThrottledJob : JobWithLockBase
     private readonly ILockProvider _locker;
     public int RunCount { get; set; }
 
-    protected override Task<ILock> GetLockAsync(CancellationToken cancellationToken = default(CancellationToken))
+    protected override Task<ILock> GetLockAsync(CancellationToken cancellationToken = default)
     {
         return _locker.AcquireAsync(nameof(ThrottledJob), acquireTimeout: TimeSpan.Zero);
     }
@@ -26,7 +26,7 @@ public class ThrottledJob : JobWithLockBase
     protected override Task<JobResult> RunInternalAsync(JobContext context)
     {
         RunCount++;
-
+        _logger.LogDebug("Incremented Run Count: {RunCount}", RunCount);
         return Task.FromResult(JobResult.Success);
     }
 }

--- a/src/Foundatio.TestHarness/Jobs/WithLockingJob.cs
+++ b/src/Foundatio.TestHarness/Jobs/WithLockingJob.cs
@@ -17,7 +17,7 @@ public class WithLockingJob : JobWithLockBase
 
     public WithLockingJob(ILoggerFactory loggerFactory) : base(loggerFactory)
     {
-        _locker = new CacheLockProvider(new InMemoryCacheClient(new InMemoryCacheClientOptions { LoggerFactory = loggerFactory }), new InMemoryMessageBus(new InMemoryMessageBusOptions { LoggerFactory = loggerFactory }), loggerFactory);
+        _locker = new CacheLockProvider(new InMemoryCacheClient(o => o.LoggerFactory(loggerFactory)), new InMemoryMessageBus(o => o.LoggerFactory(loggerFactory)), loggerFactory);
     }
 
     public int RunCount { get; set; }

--- a/src/Foundatio.TestHarness/Locks/LockTestBase.cs
+++ b/src/Foundatio.TestHarness/Locks/LockTestBase.cs
@@ -55,7 +55,6 @@ public abstract class LockTestBase : TestWithLoggingBase
 
         int counter = 0;
 
-        bool isTraceLogLevelEnabled = _logger.IsEnabled(LogLevel.Trace);
         await Run.InParallelAsync(25, async i =>
         {
             bool success = await locker.TryUsingAsync("test", () =>
@@ -341,7 +340,6 @@ public abstract class LockTestBase : TestWithLoggingBase
 
     public virtual async Task WillThrottleCallsAsync()
     {
-        Log.DefaultMinimumLevel = LogLevel.Trace;
         Log.SetLogLevel<ScheduledTimer>(LogLevel.Information);
         Log.SetLogLevel<ThrottlingLockProvider>(LogLevel.Trace);
 

--- a/src/Foundatio.TestHarness/Locks/LockTestBase.cs
+++ b/src/Foundatio.TestHarness/Locks/LockTestBase.cs
@@ -55,7 +55,7 @@ public abstract class LockTestBase : TestWithLoggingBase
 
         int counter = 0;
 
-        await Run.InParallelAsync(25, async i =>
+        await Parallel.ForEachAsync(Enumerable.Range(1, 25), async (_, _) =>
         {
             bool success = await locker.TryUsingAsync("test", () =>
             {

--- a/src/Foundatio.TestHarness/Queue/QueueTestBase.cs
+++ b/src/Foundatio.TestHarness/Queue/QueueTestBase.cs
@@ -1315,8 +1315,8 @@ public abstract class QueueTestBase : TestWithLoggingBase, IDisposable
 
     public virtual async Task CanDequeueWithLockingAsync()
     {
-        using var cache = new InMemoryCacheClient(new InMemoryCacheClientOptions { LoggerFactory = Log });
-        using var messageBus = new InMemoryMessageBus(new InMemoryMessageBusOptions { LoggerFactory = Log });
+        using var cache = new InMemoryCacheClient(o => o.LoggerFactory(Log));
+        using var messageBus = new InMemoryMessageBus(o => o.LoggerFactory(Log));
 
         var distributedLock = new CacheLockProvider(cache, messageBus, Log);
         await CanDequeueWithLockingImpAsync(distributedLock);
@@ -1375,8 +1375,8 @@ public abstract class QueueTestBase : TestWithLoggingBase, IDisposable
 
     public virtual async Task CanHaveMultipleQueueInstancesWithLockingAsync()
     {
-        using var cache = new InMemoryCacheClient(new InMemoryCacheClientOptions { LoggerFactory = Log });
-        using var messageBus = new InMemoryMessageBus(new InMemoryMessageBusOptions { LoggerFactory = Log });
+        using var cache = new InMemoryCacheClient(o => o.LoggerFactory(Log));
+        using var messageBus = new InMemoryMessageBus(o => o.LoggerFactory(Log));
 
         var distributedLock = new CacheLockProvider(cache, messageBus, Log);
         await CanHaveMultipleQueueInstancesWithLockingImplAsync(distributedLock);

--- a/src/Foundatio.TestHarness/Queue/QueueTestBase.cs
+++ b/src/Foundatio.TestHarness/Queue/QueueTestBase.cs
@@ -1077,13 +1077,12 @@ public abstract class QueueTestBase : TestWithLoggingBase, IDisposable
     {
         int completedCount = 0;
 
-        using var metrics = new InMemoryMetricsClient(new InMemoryMetricsClientOptions { Buffered = false, LoggerFactory = Log });
+        using var metrics = new InMemoryMetricsClient(o => o.Buffered(false).LoggerFactory(Log));
 
 #pragma warning disable CS0618 // Type or member is obsolete
         var behavior = new MetricsQueueBehavior<WorkItemData>(metrics, "metric", TimeSpan.FromMilliseconds(100), loggerFactory: Log);
 #pragma warning restore CS0618 // Type or member is obsolete
-        var options = new InMemoryQueueOptions<WorkItemData> { Behaviors = new[] { behavior }, LoggerFactory = Log };
-        using var queue = new InMemoryQueue<WorkItemData>(options);
+        using var queue = new InMemoryQueue<WorkItemData>(o => o.Behaviors(behavior).LoggerFactory(Log));
 
         Task Handler(object sender, CompletedEventArgs<WorkItemData> e)
         {
@@ -1597,6 +1596,7 @@ public abstract class QueueTestBase : TestWithLoggingBase, IDisposable
 
             await queue.StartWorkingAsync(async (item) =>
             {
+                _logger.LogDebug("Processing item: {Id} Value={Value}", item.Id, item.Value.Data);
                 if (item.Value.Data == "Delay")
                 {
                     // wait for queue item to get auto abandoned

--- a/src/Foundatio.TestHarness/Queue/QueueTestBase.cs
+++ b/src/Foundatio.TestHarness/Queue/QueueTestBase.cs
@@ -971,7 +971,7 @@ public abstract class QueueTestBase : TestWithLoggingBase, IDisposable
                     workers.Add(q);
                 }
 
-                await Run.InParallelAsync(workItemCount, async i =>
+                await Parallel.ForEachAsync(Enumerable.Range(1, workItemCount), cancellationTokenSource.Token, async (i, _) =>
                 {
                     string id = await queue.EnqueueAsync(new SimpleWorkItem
                     {
@@ -981,8 +981,8 @@ public abstract class QueueTestBase : TestWithLoggingBase, IDisposable
                     if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTrace("Enqueued Index: {Instance} Id: {Id}", i, id);
                 });
 
-                await countdown.WaitAsync();
-                await SystemClock.SleepAsync(50);
+                await countdown.WaitAsync(cancellationTokenSource.Token);
+                await SystemClock.SleepAsync(50, cancellationTokenSource.Token);
 
                 if (_logger.IsEnabled(LogLevel.Information))
                     _logger.LogInformation("Work Info Stats: Completed: {Completed} Abandoned: {Abandoned} Error: {Errors}", info.CompletedCount, info.AbandonCount, info.ErrorCount);
@@ -1428,7 +1428,7 @@ public abstract class QueueTestBase : TestWithLoggingBase, IDisposable
                     workers.Add(q);
                 }
 
-                await Run.InParallelAsync(workItemCount, async i =>
+                await Parallel.ForEachAsync(Enumerable.Range(1, workItemCount), cancellationTokenSource.Token, async (i, _) =>
                 {
                     string id = await queue.EnqueueAsync(new SimpleWorkItem
                     {
@@ -1439,7 +1439,7 @@ public abstract class QueueTestBase : TestWithLoggingBase, IDisposable
                 });
 
                 await countdown.WaitAsync(TimeSpan.FromSeconds(5));
-                await SystemClock.SleepAsync(50);
+                await SystemClock.SleepAsync(50, cancellationTokenSource.Token);
                 if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTrace("Completed: {Completed} Abandoned: {Abandoned} Error: {Errors}", info.CompletedCount, info.AbandonCount, info.ErrorCount);
 
                 if (_logger.IsEnabled(LogLevel.Information))

--- a/src/Foundatio.TestHarness/Queue/QueueTestBase.cs
+++ b/src/Foundatio.TestHarness/Queue/QueueTestBase.cs
@@ -637,7 +637,6 @@ public abstract class QueueTestBase : TestWithLoggingBase, IDisposable
 
     public virtual async Task WillWaitForItemAsync()
     {
-        Log.DefaultMinimumLevel = LogLevel.Trace;
         var queue = GetQueue();
         if (queue == null)
             return;
@@ -800,7 +799,6 @@ public abstract class QueueTestBase : TestWithLoggingBase, IDisposable
 
     public virtual async Task WorkItemsWillTimeoutAsync()
     {
-        Log.DefaultMinimumLevel = LogLevel.Trace;
         Log.SetLogLevel("Foundatio.Queues.RedisQueue", LogLevel.Trace);
         var queue = GetQueue(retryDelay: TimeSpan.Zero, workItemTimeout: TimeSpan.FromMilliseconds(50));
         if (queue == null)
@@ -1323,7 +1321,6 @@ public abstract class QueueTestBase : TestWithLoggingBase, IDisposable
             await queue.DeleteQueueAsync();
             await AssertEmptyQueueAsync(queue);
 
-            Log.DefaultMinimumLevel = LogLevel.Trace;
             using var metrics = new InMemoryMetricsClient(new InMemoryMetricsClientOptions { Buffered = false, LoggerFactory = Log });
 
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/Foundatio.TestHarness/Queue/QueueTestBase.cs
+++ b/src/Foundatio.TestHarness/Queue/QueueTestBase.cs
@@ -1409,11 +1409,11 @@ public abstract class QueueTestBase : TestWithLoggingBase, IDisposable
                     {
                         if (_logger.IsEnabled(LogLevel.Information))
                             _logger.LogInformation("[{Instance}] Acquiring distributed lock in work item: {Id}", instanceCount, w.Id);
-                        var l = await distributedLock.AcquireAsync("test");
+                        var l = await distributedLock.AcquireAsync("test", cancellationToken: cancellationTokenSource.Token);
                         Assert.NotNull(l);
                         if (_logger.IsEnabled(LogLevel.Information))
                             _logger.LogInformation("[{Instance}] Acquired distributed lock: {Id}", instanceCount, w.Id);
-                        await SystemClock.SleepAsync(TimeSpan.FromMilliseconds(50));
+                        await SystemClock.SleepAsync(TimeSpan.FromMilliseconds(50), cancellationTokenSource.Token);
                         await l.ReleaseAsync();
                         if (_logger.IsEnabled(LogLevel.Information))
                             _logger.LogInformation("[{Instance}] Released distributed lock: {Id}", instanceCount, w.Id);

--- a/src/Foundatio.TestHarness/Queue/QueueTestBase.cs
+++ b/src/Foundatio.TestHarness/Queue/QueueTestBase.cs
@@ -1608,8 +1608,9 @@ public abstract class QueueTestBase : TestWithLoggingBase, IDisposable
                             break;
 
                         stats = await queue.GetQueueStatsAsync();
-                    } while (sw.Elapsed < TimeSpan.FromSeconds(10));
+                    } while (sw.Elapsed < TimeSpan.FromSeconds(5));
 
+                    _logger.LogDebug("Asserting abandon count is 1, {Actual}", stats.Abandoned);
                     Assert.Equal(1, stats.Abandoned);
                 }
 
@@ -1617,8 +1618,9 @@ public abstract class QueueTestBase : TestWithLoggingBase, IDisposable
                 {
                     await item.CompleteAsync();
                 }
-                catch
+                catch (Exception ex)
                 {
+                    _logger.LogDebug(ex, "Error completing item: {Message}", ex.Message);
                     errorEvent.Set();
                     throw;
                 }

--- a/src/Foundatio.TestHarness/Queue/QueueTestBase.cs
+++ b/src/Foundatio.TestHarness/Queue/QueueTestBase.cs
@@ -1605,12 +1605,17 @@ public abstract class QueueTestBase : TestWithLoggingBase, IDisposable
                     do
                     {
                         if (stats.Abandoned > 0)
+                        {
+                            _logger.LogTrace("Breaking, queue item was abandoned");
                             break;
+                        }
 
                         stats = await queue.GetQueueStatsAsync();
+                        _logger.LogTrace("Getting updated stats, Abandoned={Abandoned}", stats.Abandoned);
+
+                        await Task.Delay(50, cancellationTokenSource.Token);
                     } while (sw.Elapsed < TimeSpan.FromSeconds(5));
 
-                    _logger.LogDebug("Asserting abandon count is 1, {Actual}", stats.Abandoned);
                     Assert.Equal(1, stats.Abandoned);
                 }
 

--- a/src/Foundatio.TestHarness/Queue/QueueTestBase.cs
+++ b/src/Foundatio.TestHarness/Queue/QueueTestBase.cs
@@ -265,7 +265,7 @@ public abstract class QueueTestBase : TestWithLoggingBase, IDisposable
         {
             await queue.DeleteQueueAsync();
             await AssertEmptyQueueAsync(queue);
-            queue.AttachBehavior(new DuplicateDetectionQueueBehavior<SimpleWorkItem>(new InMemoryCacheClient(), Log));
+            queue.AttachBehavior(new DuplicateDetectionQueueBehavior<SimpleWorkItem>(new InMemoryCacheClient(o => o.LoggerFactory(Log)), Log));
 
             await queue.EnqueueAsync(new SimpleWorkItem
             {

--- a/src/Foundatio.TestHarness/Storage/FileStorageTestsBase.cs
+++ b/src/Foundatio.TestHarness/Storage/FileStorageTestsBase.cs
@@ -559,7 +559,7 @@ public abstract class FileStorageTestsBase : TestWithLoggingBase
             var info = await storage.GetFileInfoAsync("nope");
             Assert.Null(info);
 
-            await Run.InParallelAsync(10, async i =>
+            await Parallel.ForEachAsync(Enumerable.Range(1, 10), async (i, ct)  =>
             {
                 var ev = new PostInfo
                 {
@@ -573,13 +573,13 @@ public abstract class FileStorageTestsBase : TestWithLoggingBase
                     UserAgent = "test"
                 };
 
-                await storage.SaveObjectAsync(Path.Combine(queueFolder, i + ".json"), ev);
-                queueItems.Add(i);
+                await storage.SaveObjectAsync(Path.Combine(queueFolder, i + ".json"), ev, cancellationToken: ct);
+                queueItems.Add(i, ct);
             });
 
             Assert.Equal(10, (await storage.GetFileListAsync()).Count);
 
-            await Run.InParallelAsync(10, async i =>
+            await Parallel.ForEachAsync(Enumerable.Range(1, 10), async (_, _)  =>
             {
                 string path = Path.Combine(queueFolder, queueItems.Random() + ".json");
                 var eventPost = await storage.GetEventPostAndSetActiveAsync(Path.Combine(queueFolder, RandomData.GetInt(0, 25) + ".json"), _logger);

--- a/src/Foundatio/Caching/InMemoryCacheClient.cs
+++ b/src/Foundatio/Caching/InMemoryCacheClient.cs
@@ -820,7 +820,7 @@ public class InMemoryCacheClient : IMemoryCacheClient
         if (String.IsNullOrEmpty(key))
             throw new ArgumentNullException(nameof(key), "Key cannot be null or empty");
 
-        if (!_memory.TryGetValue(key, out var existingEntry) || existingEntry.ExpiresAt == DateTime.MaxValue)
+        if (!_memory.TryGetValue(key, out var existingEntry))
         {
             Interlocked.Increment(ref _misses);
             return Task.FromResult<TimeSpan?>(null);

--- a/src/Foundatio/Jobs/JobWithLockBase.cs
+++ b/src/Foundatio/Jobs/JobWithLockBase.cs
@@ -20,7 +20,7 @@ public abstract class JobWithLockBase : IJob, IHaveLogger
     public string JobId { get; } = Guid.NewGuid().ToString("N").Substring(0, 10);
     ILogger IHaveLogger.Logger => _logger;
 
-    public async virtual Task<JobResult> RunAsync(CancellationToken cancellationToken = default)
+    public virtual async Task<JobResult> RunAsync(CancellationToken cancellationToken = default)
     {
         var lockValue = await GetLockAsync(cancellationToken).AnyContext();
         if (lockValue == null)

--- a/src/Foundatio/Jobs/WorkItemJob/WorkItemJob.cs
+++ b/src/Foundatio/Jobs/WorkItemJob/WorkItemJob.cs
@@ -32,7 +32,7 @@ public class WorkItemJob : IQueueJob<WorkItemData>, IHaveLogger
     IQueue<WorkItemData> IQueueJob<WorkItemData>.Queue => _queue;
     ILogger IHaveLogger.Logger => _logger;
 
-    public async virtual Task<JobResult> RunAsync(CancellationToken cancellationToken = default)
+    public virtual async Task<JobResult> RunAsync(CancellationToken cancellationToken = default)
     {
         IQueueEntry<WorkItemData> queueEntry;
 

--- a/src/Foundatio/Metrics/InMemoryMetricsClient.cs
+++ b/src/Foundatio/Metrics/InMemoryMetricsClient.cs
@@ -8,7 +8,7 @@ public class InMemoryMetricsClient : CacheBucketMetricsClientBase
     public InMemoryMetricsClient() : this(o => o) { }
 
     public InMemoryMetricsClient(InMemoryMetricsClientOptions options)
-        : base(new InMemoryCacheClient(new InMemoryCacheClientOptions { LoggerFactory = options?.LoggerFactory }), options) { }
+        : base(new InMemoryCacheClient(o => o.LoggerFactory(options?.LoggerFactory)), options) { }
 
     public InMemoryMetricsClient(Builder<InMemoryMetricsClientOptionsBuilder, InMemoryMetricsClientOptions> config)
         : this(config(new InMemoryMetricsClientOptionsBuilder()).Build()) { }

--- a/src/Foundatio/Queues/InMemoryQueue.cs
+++ b/src/Foundatio/Queues/InMemoryQueue.cs
@@ -394,7 +394,7 @@ public class InMemoryQueue<T> : QueueBase<T, InMemoryQueueOptions<T>> where T : 
 
         // Add a tiny buffer just in case the schedule next timer fires early.
         // The system clock typically has a resolution of 10-15 milliseconds, so timers cannot be more accurate than this resolution.
-        return minAbandonAt.SafeAdd(TimeSpan.FromMilliseconds(10));
+        return minAbandonAt.SafeAdd(TimeSpan.FromMilliseconds(15));
     }
 
     public override void Dispose()

--- a/src/Foundatio/Queues/InMemoryQueue.cs
+++ b/src/Foundatio/Queues/InMemoryQueue.cs
@@ -230,8 +230,8 @@ public class InMemoryQueue<T> : QueueBase<T, InMemoryQueueOptions<T>> where T : 
         Interlocked.Increment(ref _dequeuedCount);
         _logger.LogTrace("Dequeue: Got Item");
 
-        await entry.RenewLockAsync();
         ScheduleNextMaintenance(SystemClock.UtcNow.Add(_options.WorkItemTimeout));
+        await entry.RenewLockAsync();
         await OnDequeuedAsync(entry).AnyContext();
 
         return entry;

--- a/src/Foundatio/Queues/InMemoryQueue.cs
+++ b/src/Foundatio/Queues/InMemoryQueue.cs
@@ -392,7 +392,9 @@ public class InMemoryQueue<T> : QueueBase<T, InMemoryQueueOptions<T>> where T : 
                 _logger.LogError(ex, "DoMaintenance Error: {Message}", ex.Message);
         }
 
-        return minAbandonAt;
+        // Add a tiny buffer just in case the schedule next timer fires early.
+        // The system clock typically has a resolution of 10-15 milliseconds, so timers cannot be more accurate than this resolution.
+        return minAbandonAt.SafeAdd(TimeSpan.FromMilliseconds(10));
     }
 
     public override void Dispose()

--- a/src/Foundatio/Queues/InMemoryQueue.cs
+++ b/src/Foundatio/Queues/InMemoryQueue.cs
@@ -231,8 +231,8 @@ public class InMemoryQueue<T> : QueueBase<T, InMemoryQueueOptions<T>> where T : 
         _logger.LogTrace("Dequeue: Got Item");
 
         await entry.RenewLockAsync();
-        await OnDequeuedAsync(entry).AnyContext();
         ScheduleNextMaintenance(SystemClock.UtcNow.Add(_options.WorkItemTimeout));
+        await OnDequeuedAsync(entry).AnyContext();
 
         return entry;
     }

--- a/src/Foundatio/Queues/InMemoryQueue.cs
+++ b/src/Foundatio/Queues/InMemoryQueue.cs
@@ -221,6 +221,8 @@ public class InMemoryQueue<T> : QueueBase<T, InMemoryQueueOptions<T>> where T : 
         if (!_queue.TryDequeue(out var entry) || entry == null)
             return null;
 
+        ScheduleNextMaintenance(SystemClock.UtcNow.Add(_options.WorkItemTimeout));
+
         entry.Attempts++;
         entry.DequeuedTimeUtc = SystemClock.UtcNow;
 
@@ -231,7 +233,6 @@ public class InMemoryQueue<T> : QueueBase<T, InMemoryQueueOptions<T>> where T : 
         _logger.LogTrace("Dequeue: Got Item");
 
         await entry.RenewLockAsync();
-        ScheduleNextMaintenance(SystemClock.UtcNow.Add(_options.WorkItemTimeout));
         await OnDequeuedAsync(entry).AnyContext();
 
         return entry;

--- a/src/Foundatio/Queues/InMemoryQueue.cs
+++ b/src/Foundatio/Queues/InMemoryQueue.cs
@@ -230,8 +230,8 @@ public class InMemoryQueue<T> : QueueBase<T, InMemoryQueueOptions<T>> where T : 
         Interlocked.Increment(ref _dequeuedCount);
         _logger.LogTrace("Dequeue: Got Item");
 
-        ScheduleNextMaintenance(SystemClock.UtcNow.Add(_options.WorkItemTimeout));
         await entry.RenewLockAsync();
+        ScheduleNextMaintenance(SystemClock.UtcNow.Add(_options.WorkItemTimeout));
         await OnDequeuedAsync(entry).AnyContext();
 
         return entry;

--- a/src/Foundatio/Utility/Run.cs
+++ b/src/Foundatio/Utility/Run.cs
@@ -25,6 +25,7 @@ public static class Run
         }, cancellationToken);
     }
 
+    [Obsolete("Use Parallel.ForEachAsync")]
     public static Task InParallelAsync(int iterations, Func<int, Task> work)
     {
         return Task.WhenAll(Enumerable.Range(1, iterations).Select(i => Task.Run(() => work(i))));

--- a/src/Foundatio/Utility/ScheduledTimer.cs
+++ b/src/Foundatio/Utility/ScheduledTimer.cs
@@ -49,7 +49,7 @@ public class ScheduledTimer : IDisposable
         if (_next > utcNow && utcDate > _next)
         {
             if (isTraceLogLevelEnabled)
-                _logger.LogTrace("Ignoring because already scheduled for earlier time: {PreviousTicks} Next: {NextTicks}", utcDate.Value.Ticks, _next.Ticks);
+                _logger.LogTrace("Ignoring because already scheduled for earlier time: {PreviousNextRun:O} Next: {NextRun:O}", utcDate.Value, _next);
             return;
         }
 
@@ -66,7 +66,7 @@ public class ScheduledTimer : IDisposable
             if (_next > utcNow && utcDate > _next)
             {
                 if (isTraceLogLevelEnabled)
-                    _logger.LogTrace("Ignoring because already scheduled for earlier time: {PreviousTicks} Next: {NextTicks}", utcDate.Value.Ticks, _next.Ticks);
+                    _logger.LogTrace("Ignoring because already scheduled for earlier time: {PreviousNextRun:O} Next: {NextRun:O}", utcDate.Value, _next);
                 return;
             }
 

--- a/src/Foundatio/Utility/ScheduledTimer.cs
+++ b/src/Foundatio/Utility/ScheduledTimer.cs
@@ -38,6 +38,7 @@ public class ScheduledTimer : IDisposable
 
         bool isTraceLogLevelEnabled = _logger.IsEnabled(LogLevel.Trace);
         if (isTraceLogLevelEnabled) _logger.LogTrace("ScheduleNext called: value={NextRun:O}", utcDate.Value);
+
         if (utcDate == DateTime.MaxValue)
         {
             if (isTraceLogLevelEnabled) _logger.LogTrace("Ignoring MaxValue");

--- a/tests/Foundatio.Tests/Caching/InMemoryCacheClientTests.cs
+++ b/tests/Foundatio.Tests/Caching/InMemoryCacheClientTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Foundatio.Caching;
@@ -194,7 +194,9 @@ public class InMemoryCacheClientTests : CacheClientTestsBase
 
         var expiry = TimeSpan.FromMilliseconds(50);
         await client.SetAllAsync(new Dictionary<string, object> { { "test", "value" } }, expiry);
-        await Task.Delay(expiry);
+
+        // Add 1ms to the expiry to ensure the cache has expired as the delay window is not guaranteed to be exact.
+        await Task.Delay(expiry.Add(TimeSpan.FromMilliseconds(1)));
 
         Assert.False(await client.ExistsAsync("test"));
     }

--- a/tests/Foundatio.Tests/Caching/InMemoryCacheClientTests.cs
+++ b/tests/Foundatio.Tests/Caching/InMemoryCacheClientTests.cs
@@ -155,8 +155,6 @@ public class InMemoryCacheClientTests : CacheClientTestsBase
     [Fact]
     public async Task CanSetMaxItems()
     {
-        Log.DefaultMinimumLevel = LogLevel.Trace;
-
         // run in tight loop so that the code is warmed up and we can catch timing issues
         for (int x = 0; x < 5; x++)
         {

--- a/tests/Foundatio.Tests/Caching/InMemoryHybridCacheClientTests.cs
+++ b/tests/Foundatio.Tests/Caching/InMemoryHybridCacheClientTests.cs
@@ -81,7 +81,6 @@ public class InMemoryHybridCacheClientTests : HybridCacheClientTests
     [Fact(Skip = "Skip because cache invalidation loops on this with 2 in memory cache client instances")]
     public override Task WillWorkWithSets()
     {
-        Log.DefaultMinimumLevel = LogLevel.Trace;
         return base.WillWorkWithSets();
     }
 

--- a/tests/Foundatio.Tests/Jobs/InMemoryJobQueueTests.cs
+++ b/tests/Foundatio.Tests/Jobs/InMemoryJobQueueTests.cs
@@ -25,7 +25,7 @@ public class InMemoryJobQueueTests : JobQueueTestsBase
         return base.CanRunMultipleQueueJobsAsync();
     }
 
-    [RetryFact]
+    [Fact]
     public override Task CanRunQueueJobWithLockFailAsync()
     {
         Log.SetLogLevel<InMemoryCacheClient>(LogLevel.Trace);

--- a/tests/Foundatio.Tests/Jobs/JobTests.cs
+++ b/tests/Foundatio.Tests/Jobs/JobTests.cs
@@ -135,15 +135,14 @@ public class JobTests : TestWithLoggingBase
     [Fact]
     public async Task CanRunThrottledJobs()
     {
-        using var client = new InMemoryCacheClient(new InMemoryCacheClientOptions { LoggerFactory = Log });
+        using var client = new InMemoryCacheClient(o => o.LoggerFactory(Log));
         var jobs = new List<ThrottledJob>(new[] { new ThrottledJob(client, Log), new ThrottledJob(client, Log), new ThrottledJob(client, Log) });
 
         var sw = Stopwatch.StartNew();
-        using (var timeoutCancellationTokenSource = new CancellationTokenSource(1000))
-        {
-            await Task.WhenAll(jobs.Select(job => job.RunContinuousAsync(TimeSpan.FromMilliseconds(1), cancellationToken: timeoutCancellationTokenSource.Token)));
-        }
+        using var timeoutCancellationTokenSource = new CancellationTokenSource(1000);
+        await Task.WhenAll(jobs.Select(job => job.RunContinuousAsync(TimeSpan.FromMilliseconds(1), cancellationToken: timeoutCancellationTokenSource.Token)));
         sw.Stop();
+
         Assert.InRange(jobs.Sum(j => j.RunCount), 4, 14);
         _logger.LogInformation(jobs.Sum(j => j.RunCount).ToString());
         Assert.InRange(sw.ElapsedMilliseconds, 20, 1500);

--- a/tests/Foundatio.Tests/Jobs/JobTests.cs
+++ b/tests/Foundatio.Tests/Jobs/JobTests.cs
@@ -128,7 +128,7 @@ public class JobTests : TestWithLoggingBase
         await job.RunContinuousAsync(iterationLimit: 2);
         Assert.Equal(3, job.RunCount);
 
-        await Run.InParallelAsync(2, i => job.RunAsync());
+        await Parallel.ForEachAsync(Enumerable.Range(1, 2), async (_, ct) => await job.RunAsync(ct));
         Assert.Equal(4, job.RunCount);
     }
 

--- a/tests/Foundatio.Tests/Jobs/JobTests.cs
+++ b/tests/Foundatio.Tests/Jobs/JobTests.cs
@@ -117,7 +117,7 @@ public class JobTests : TestWithLoggingBase
         }
     }
 
-    [RetryFact]
+    [Fact]
     public async Task CanRunJobsWithLocks()
     {
         var job = new WithLockingJob(Log);

--- a/tests/Foundatio.Tests/Locks/InMemoryLockTests.cs
+++ b/tests/Foundatio.Tests/Locks/InMemoryLockTests.cs
@@ -59,10 +59,22 @@ public class InMemoryLockTests : LockTestBase, IDisposable
         return base.CanAcquireMultipleResources();
     }
 
-    [RetryFact]
+    [Fact]
     public override Task CanAcquireLocksInParallel()
     {
         return base.CanAcquireLocksInParallel();
+    }
+
+    [Fact]
+    public override Task CanAcquireScopedLocksInParallel()
+    {
+        return base.CanAcquireScopedLocksInParallel();
+    }
+
+    [Fact]
+    public override Task CanAcquireMultipleLocksInParallel()
+    {
+        return base.CanAcquireScopedLocksInParallel();
     }
 
     [Fact]
@@ -71,7 +83,7 @@ public class InMemoryLockTests : LockTestBase, IDisposable
         return base.CanAcquireMultipleScopedResources();
     }
 
-    [RetryFact]
+    [Fact]
     public override Task WillThrottleCallsAsync()
     {
         Log.SetLogLevel<InMemoryCacheClient>(LogLevel.Trace);

--- a/tests/Foundatio.Tests/Locks/InMemoryLockTests.cs
+++ b/tests/Foundatio.Tests/Locks/InMemoryLockTests.cs
@@ -74,7 +74,7 @@ public class InMemoryLockTests : LockTestBase, IDisposable
     [Fact]
     public override Task CanAcquireMultipleLocksInParallel()
     {
-        return base.CanAcquireScopedLocksInParallel();
+        return base.CanAcquireMultipleLocksInParallel();
     }
 
     [Fact]

--- a/tests/Foundatio.Tests/Metrics/DiagnosticsMetricsTests.cs
+++ b/tests/Foundatio.Tests/Metrics/DiagnosticsMetricsTests.cs
@@ -16,7 +16,6 @@ public class DiagnosticsMetricsTests : TestWithLoggingBase, IDisposable
 
     public DiagnosticsMetricsTests(ITestOutputHelper output) : base(output)
     {
-        Log.DefaultMinimumLevel = LogLevel.Trace;
         _client = new DiagnosticsMetricsClient(o => o.MeterName("Test"));
     }
 

--- a/tests/Foundatio.Tests/Metrics/InMemoryMetricsTests.cs
+++ b/tests/Foundatio.Tests/Metrics/InMemoryMetricsTests.cs
@@ -31,7 +31,7 @@ public class InMemoryMetricsTests : MetricsClientTestBase
         return base.CanIncrementCounterAsync();
     }
 
-    [RetryFact]
+    [Fact]
     public override Task CanWaitForCounterAsync()
     {
         using (TestSystemClock.Install())

--- a/tests/Foundatio.Tests/Queue/InMemoryQueueTests.cs
+++ b/tests/Foundatio.Tests/Queue/InMemoryQueueTests.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using Foundatio.Queues;
 using Foundatio.Utility;
@@ -385,6 +386,7 @@ public class InMemoryQueueTests : QueueTestBase
     {
         // create queue with short work item timeout so it will be auto abandoned
         var queue = new InMemoryQueue_Issue239<SimpleWorkItem>(Log);
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
         // completion source to wait for CompleteAsync call before the assert
         var taskCompletionSource = new TaskCompletionSource<bool>();
@@ -409,7 +411,7 @@ public class InMemoryQueueTests : QueueTestBase
                 // infrastructure handles user exception incorrectly
                 taskCompletionSource.SetResult(true);
             }
-        });
+        }, cancellationToken: cancellationTokenSource.Token);
 
         // enqueue item which will be processed after it's auto abandoned
         await queue.EnqueueAsync(new SimpleWorkItem() { Data = "Delay" });

--- a/tests/Foundatio.Tests/Queue/InMemoryQueueTests.cs
+++ b/tests/Foundatio.Tests/Queue/InMemoryQueueTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
@@ -291,6 +291,8 @@ public class InMemoryQueueTests : QueueTestBase
     [Fact]
     public override Task CanHandleAutoAbandonInWorker()
     {
+        Log.DefaultMinimumLevel = LogLevel.Trace;
+        Log.SetLogLevel<ScheduledTimer>(LogLevel.Trace);
         return base.CanHandleAutoAbandonInWorker();
     }
 

--- a/tests/Foundatio.Tests/Queue/InMemoryQueueTests.cs
+++ b/tests/Foundatio.Tests/Queue/InMemoryQueueTests.cs
@@ -291,8 +291,6 @@ public class InMemoryQueueTests : QueueTestBase
     [Fact]
     public override Task CanHandleAutoAbandonInWorker()
     {
-        Log.DefaultMinimumLevel = LogLevel.Trace;
-        Log.SetLogLevel<ScheduledTimer>(LogLevel.Trace);
         return base.CanHandleAutoAbandonInWorker();
     }
 

--- a/tests/Foundatio.Tests/Queue/InMemoryQueueTests.cs
+++ b/tests/Foundatio.Tests/Queue/InMemoryQueueTests.cs
@@ -290,7 +290,6 @@ public class InMemoryQueueTests : QueueTestBase
     [Fact]
     public override Task CanHandleAutoAbandonInWorker()
     {
-        Log.DefaultMinimumLevel = LogLevel.Trace;
         return base.CanHandleAutoAbandonInWorker();
     }
 
@@ -393,7 +392,7 @@ public class InMemoryQueueTests : QueueTestBase
         // start handling items
         await queue.StartWorkingAsync(async (item) =>
         {
-            // we want to wait for maintainance to be performed and auto abandon our item, we don't have any way for waiting in IQueue so we'll settle for a delay
+            // we want to wait for maintenance to be performed and auto abandon our item, we don't have any way for waiting in IQueue so we'll settle for a delay
             if (item.Value.Data == "Delay")
             {
                 await Task.Delay(TimeSpan.FromSeconds(1));
@@ -426,8 +425,6 @@ public class InMemoryQueueTests : QueueTestBase
         // one option to fix this issue is surrounding the AbandonAsync call in StartWorkingImpl exception handler in inner try/catch block
         timedout = (await Task.WhenAny(taskCompletionSource.Task, Task.Delay(TimeSpan.FromSeconds(2)))) != taskCompletionSource.Task;
         Assert.False(timedout);
-
-        return;
     }
 
     #endregion

--- a/tests/Foundatio.Tests/Utility/ScheduledTimerTests.cs
+++ b/tests/Foundatio.Tests/Utility/ScheduledTimerTests.cs
@@ -33,7 +33,7 @@ public class ScheduledTimerTests : TestWithLoggingBase
         return resetEvent.WaitAsync(new CancellationTokenSource(500).Token);
     }
 
-    [RetryFact]
+    [Fact]
     public Task CanRunAndScheduleConcurrently()
     {
         return CanRunConcurrentlyAsync();

--- a/tests/Foundatio.Tests/Utility/ScheduledTimerTests.cs
+++ b/tests/Foundatio.Tests/Utility/ScheduledTimerTests.cs
@@ -47,7 +47,6 @@ public class ScheduledTimerTests : TestWithLoggingBase
 
     private async Task CanRunConcurrentlyAsync(TimeSpan? minimumIntervalTime = null)
     {
-        Log.DefaultMinimumLevel = LogLevel.Trace;
         const int iterations = 2;
         var countdown = new AsyncCountdownEvent(iterations);
 


### PR DESCRIPTION
I noticed that multiple locks could be acquired. I've added more test coverage to try and expose the issue.

Here are some logs that lead me down this path:

```
44:28.293 T: Got lock released message: test (fvT2ltV31jWIJVbh) - CacheLockProvider
44:28.293 T: Finished calling subscriber action: 65b73751c9eb4a7aa8333f26345b816d - InMemoryMessageBus
44:28.293 T: Done enqueueing message to 1 subscribers for message type Foundatio.Lock.CacheLockReleased, Foundatio - InMemoryMessageBus
44:28.293 T: Added cache key: lock:test Updated=True - InMemoryCacheClient
44:28.293 D: Removing expired cache entry lock:test - InMemoryCacheClient
44:28.293 D: Released lock: test (fvT2ltV31jWIJVbh) - CacheLockProvider
44:28.293 T: Disposed lock (fvT2ltV31jWIJVbh) test - CacheLockProvider
44:28.293 T: Added cache key: lock:test - InMemoryCacheClient
44:28.293 D: Attempting to acquire lock (rMPQS00k5jriIlwD): test - CacheLockProvider
44:28.293 D: Acquired lock (CtO2HC1SbCLWHUWx) test after 0:00:00.1030847 - CacheLockProvider
44:28.293 T: Added cache key: lock:test - InMemoryCacheClient
44:28.293 D: Acquired lock (rMPQS00k5jriIlwD) test after 0:00:00.0000115 - CacheLockProvider
44:28.294 T: Disposing lock (rMPQS00k5jriIlwD) test - CacheLockProvider
```

After some more fixes to how we update AddAsync

```
09:53.915 D: Released lock: test (xtpVPARC2g7Rd0Vk) - CacheLockProvider
09:53.915 T: Disposed lock (xtpVPARC2g7Rd0Vk) test - CacheLockProvider
09:53.915 D: Attempting to acquire lock (sBxxiPzf8fHqLLQO): test - CacheLockProvider
09:53.915 T: Added cache key: lock:test Replacing existing expired entry - InMemoryCacheClient
09:53.915 T: Added cache key: lock:test Replacing existing expired entry - InMemoryCacheClient
09:53.915 D: Acquired lock (sBxxiPzf8fHqLLQO) test after 0:00:00.0000345 - CacheLockProvider
09:53.915 D: Acquired lock (cCUuUXR3vPpxuoTd) test after 0:00:00.099548 - CacheLockProvider
```

Investigated further and saw that it was way more stable, but it failed when maintenance is run

```
56:59.834 T: DoMaintenance - InMemoryCacheClient
56:59.834 T: Calling subscriber action: 28842d366dca40a694ac2ee823330f5b - InMemoryMessageBus
56:59.834 D: DoMaintenance: Removing expired key lock:test OriginalExpiresAt=uhoLiJcnts5dI5W6 CurrentExpiresAt=uhoLiJcnts5dI5W6 - InMemoryCacheClient
56:59.834 T: Got lock released message: test (uhoLiJcnts5dI5W6) - CacheLockProvider
56:59.834 T: Finished calling subscriber action: 28842d366dca40a694ac2ee823330f5b - InMemoryMessageBus
56:59.834 T: Replacing expired cache key: lock:test Value=O3AMARH32E61q77i ExistingValue=uhoLiJcnts5dI5W6 - InMemoryCacheClient
56:59.834 T: Added cache key: lock:test - InMemoryCacheClient
56:59.834 T: Done enqueueing message to 1 subscribers for message type Foundatio.Lock.CacheLockReleased, Foundatio - InMemoryMessageBus
56:59.834 D: Released lock: test (uhoLiJcnts5dI5W6) - CacheLockProvider
56:59.834 D: Acquired lock (O3AMARH32E61q77i) test after 0:00:00.1024995 - CacheLockProvider
56:59.834 T: Disposed lock (uhoLiJcnts5dI5W6) test - CacheLockProvider
56:59.834 D: Attempting to acquire lock (SHmUz8gq3wswz4cW): test - CacheLockProvider
56:59.834 D: Removing expired cache entry lock:test - InMemoryCacheClient
56:59.834 T: Added cache key: lock:test - InMemoryCacheClient
```

This led me to rework how maintenance removes expired items. 