### PR TITLE
Added QueueJob RunUntilEmptyAsync TimeSpan Overload, refactored cancellation tokens

### DIFF
--- a/src/Foundatio/Queues/InMemoryQueue.cs
+++ b/src/Foundatio/Queues/InMemoryQueue.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -202,10 +202,11 @@ public class InMemoryQueue<T> : QueueBase<T, InMemoryQueueOptions<T>> where T : 
             _logger.LogTrace("Waiting to dequeue item...");
             var sw = Stopwatch.StartNew();
 
+            using var dequeueCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(linkedCancellationToken);
+            dequeueCancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(10));
+
             try
             {
-                using var timeoutCancellationTokenSource = new CancellationTokenSource(10000);
-                using var dequeueCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(linkedCancellationToken, timeoutCancellationTokenSource.Token);
                 await _autoResetEvent.WaitAsync(dequeueCancellationTokenSource.Token).AnyContext();
             }
             catch (OperationCanceledException) { }

--- a/src/Foundatio/Queues/QueueBase.cs
+++ b/src/Foundatio/Queues/QueueBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -109,8 +109,8 @@ public abstract class QueueBase<T, TOptions> : MaintenanceBase, IQueue<T>, IQueu
         await EnsureQueueCreatedAsync(_queueDisposedCancellationTokenSource.Token).AnyContext();
 
         LastDequeueActivity = SystemClock.UtcNow;
-        using var linkedCancellationToken = GetLinkedDisposableCancellationTokenSource(cancellationToken);
-        return await DequeueImplAsync(linkedCancellationToken.Token).AnyContext();
+        using var linkedCancellationTokenSource = GetLinkedDisposableCancellationTokenSource(cancellationToken);
+        return await DequeueImplAsync(linkedCancellationTokenSource.Token).AnyContext();
     }
 
     public virtual async Task<IQueueEntry<T>> DequeueAsync(TimeSpan? timeout = null)
@@ -347,7 +347,7 @@ public abstract class QueueBase<T, TOptions> : MaintenanceBase, IQueue<T>, IQueu
 
     protected CancellationTokenSource GetLinkedDisposableCancellationTokenSource(CancellationToken cancellationToken)
     {
-        return CancellationTokenSource.CreateLinkedTokenSource(_queueDisposedCancellationTokenSource.Token, cancellationToken);
+        return CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _queueDisposedCancellationTokenSource.Token);
     }
 
     public override void Dispose()


### PR DESCRIPTION
This should generally speed up tests where you don't want to wait the full 30 second default timeout.