### PR TITLE
Fixes #309 - FolderFileStorage doesn't overwrite existing content

### DIFF
--- a/src/Foundatio.TestHarness/Storage/FileStorageTestsBase.cs
+++ b/src/Foundatio.TestHarness/Storage/FileStorageTestsBase.cs
@@ -604,9 +604,28 @@ public abstract class FileStorageTestsBase : TestWithLoggingBase
         Assert.NotEqual(DATA_DIRECTORY_QUEUE_FOLDER, storage.Folder);
         Assert.True(storage.Folder.EndsWith("Queue" + Path.DirectorySeparatorChar), storage.Folder);
     }
+
+    public virtual async Task CanSaveOverExistingStoredContent()
+    {
+        using var storage = GetStorage();
+        if (storage == null)
+            return;
+
+        await ResetAsync(storage);
+
+        var shortIdInfo = new PostInfo { ProjectId = "123" };
+        var longIdInfo = new PostInfo { ProjectId = "1234567890" };
+
+        string path = "test.json";
+        await storage.SaveObjectAsync(path, longIdInfo);
+        await storage.SaveObjectAsync(path, shortIdInfo);
+
+        var actualInfo = await storage.GetObjectAsync<PostInfo>(path);
+        Assert.Equal(shortIdInfo, actualInfo);
+    }
 }
 
-public class PostInfo
+public record PostInfo
 {
     public int ApiVersion { get; set; }
     public string CharSet { get; set; }

--- a/src/Foundatio/Storage/FolderFileStorage.cs
+++ b/src/Foundatio/Storage/FolderFileStorage.cs
@@ -60,7 +60,7 @@ public class FolderFileStorage : IFileStorage
         string fullPath = Path.Combine(Folder, normalizedPath);
         EnsureDirectory(fullPath);
 
-        var stream = streamMode == StreamMode.Read ? File.OpenRead(fullPath) : File.OpenWrite(fullPath);
+        var stream = streamMode == StreamMode.Read ? File.OpenRead(fullPath) : new FileStream(fullPath, FileMode.Create, FileAccess.Write);
         return Task.FromResult<Stream>(stream);
     }
 

--- a/tests/Foundatio.Tests/Storage/FolderFileStorageTests.cs
+++ b/tests/Foundatio.Tests/Storage/FolderFileStorageTests.cs
@@ -136,6 +136,12 @@ public class FolderFileStorageTests : FileStorageTestsBase
     }
 
     [Fact]
+    public override Task CanSaveOverExistingStoredContent()
+    {
+        return base.CanSaveOverExistingStoredContent();
+    }
+
+    [Fact]
     public async Task WillNotReturnDirectoryInGetPagedFileListAsync()
     {
         var storage = GetStorage();

--- a/tests/Foundatio.Tests/Storage/InMemoryFileStorageTests.cs
+++ b/tests/Foundatio.Tests/Storage/InMemoryFileStorageTests.cs
@@ -133,4 +133,10 @@ public class InMemoryFileStorageTests : FileStorageTestsBase
     {
         return base.WillWriteStreamContentAsync();
     }
+
+    [Fact]
+    public override Task CanSaveOverExistingStoredContent()
+    {
+        return base.CanSaveOverExistingStoredContent();
+    }
 }

--- a/tests/Foundatio.Tests/Storage/ScopedFolderFileStorageTests.cs
+++ b/tests/Foundatio.Tests/Storage/ScopedFolderFileStorageTests.cs
@@ -178,6 +178,12 @@ public class ScopedFolderFileStorageTests : FileStorageTestsBase
     }
 
     [Fact]
+    public override Task CanSaveOverExistingStoredContent()
+    {
+        return base.CanSaveOverExistingStoredContent();
+    }
+
+    [Fact]
     public async Task WillNotReturnDirectoryInGetPagedFileListAsync()
     {
         var storage = GetStorage();

--- a/tests/Foundatio.Tests/Storage/ScopedInMemoryFileStorageTests.cs
+++ b/tests/Foundatio.Tests/Storage/ScopedInMemoryFileStorageTests.cs
@@ -133,4 +133,10 @@ public class ScopedInMemoryFileStorageTests : FileStorageTestsBase
     {
         return base.WillWriteStreamContentAsync();
     }
+
+    [Fact]
+    public override Task CanSaveOverExistingStoredContent()
+    {
+        return base.CanSaveOverExistingStoredContent();
+    }
 }


### PR DESCRIPTION
File.OpenWrite(fullPath)

- Opens the file if it exists.
- Does not truncate the file; it only allows writing from the current position.
- If the file does not exist, it creates a new file.

FileStream with FileMode.Create

- Creates a new file or overwrites an existing file.
- Truncates the file to zero length if it already exists.
- Opens the file for writing.