### PR TITLE
Storage bug fixes with DeleteFilesAsync

### DIFF
--- a/src/Foundatio.TestHarness/Storage/FileStorageTestsBase.cs
+++ b/src/Foundatio.TestHarness/Storage/FileStorageTestsBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
@@ -402,6 +402,10 @@ public abstract class FileStorageTestsBase : TestWithLoggingBase
             Assert.True(await storage.ExistsAsync(@"x\hello.txt"));
             Assert.False(await storage.ExistsAsync(@"x\nested\hello.txt"));
             Assert.False(await storage.ExistsAsync(@"x\nested\world.csv"));
+
+            Assert.Equal(1, await storage.DeleteFilesAsync(@"x\hello*"));
+            Assert.Empty(await storage.GetFileListAsync());
+            Assert.False(await storage.ExistsAsync(@"x\hello.txt"));
         }
     }
 

--- a/src/Foundatio.TestHarness/Storage/FileStorageTestsBase.cs
+++ b/src/Foundatio.TestHarness/Storage/FileStorageTestsBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
@@ -396,7 +396,7 @@ public abstract class FileStorageTestsBase : TestWithLoggingBase
             Assert.Equal(2, (await storage.GetFileListAsync(@"x\nested\*")).Count);
             Assert.Equal(2, (await storage.GetFileListAsync(@"x\*.txt")).Count);
 
-            await storage.DeleteFilesAsync(@"x\nested\*");
+            Assert.Equal(2, await storage.DeleteFilesAsync(@"x\nested\*"));
 
             Assert.Single(await storage.GetFileListAsync());
             Assert.True(await storage.ExistsAsync(@"x\hello.txt"));

--- a/src/Foundatio.TestHarness/Storage/FileStorageTestsBase.cs
+++ b/src/Foundatio.TestHarness/Storage/FileStorageTestsBase.cs
@@ -35,7 +35,7 @@ public abstract class FileStorageTestsBase : TestWithLoggingBase
 
         using (storage)
         {
-            Assert.Empty(await storage.GetFileListAsync(Guid.NewGuid() + "\\*"));
+            Assert.Empty(await storage.GetFileListAsync($"{Guid.NewGuid()}\\*"));
         }
     }
 
@@ -283,11 +283,12 @@ public abstract class FileStorageTestsBase : TestWithLoggingBase
 
         using (storage)
         {
+            await storage.SaveFileAsync(@"x\README", "hello");
             await storage.SaveFileAsync(@"x\hello.txt", "hello");
             await storage.SaveFileAsync(@"x\nested\world.csv", "nested world");
-            Assert.Equal(2, (await storage.GetFileListAsync()).Count);
+            Assert.Equal(3, (await storage.GetFileListAsync()).Count);
 
-            await storage.DeleteFilesAsync(@"x\*");
+            Assert.Equal(3, await storage.DeleteFilesAsync(@"x\*"));
             Assert.Empty(await storage.GetFileListAsync());
         }
     }
@@ -304,13 +305,14 @@ public abstract class FileStorageTestsBase : TestWithLoggingBase
         {
             await storage.SaveFileAsync(@"x\hello.txt", "hello");
             await storage.SaveFileAsync(@"x\nested\world.csv", "nested world");
-            Assert.Equal(2, (await storage.GetFileListAsync()).Count);
+            await storage.SaveFileAsync(@"x\nested\docs\README", "manual");
             Assert.Single(await storage.GetFileListAsync(limit: 1));
-            Assert.Equal(2, (await storage.GetFileListAsync(@"x\*")).Count);
-            Assert.Single(await storage.GetFileListAsync(@"x\nested\*"));
+            Assert.Equal(3, (await storage.GetFileListAsync()).Count);
+            Assert.Equal(3, (await storage.GetFileListAsync(@"x\*")).Count);
+            Assert.Equal(2, (await storage.GetFileListAsync(@"x\nested\*")).Count);
+            Assert.Single(await storage.GetFileListAsync(@"x\nested\docs\*"));
 
-            await storage.DeleteFilesAsync(@"x\*");
-
+            Assert.Equal(3, await storage.DeleteFilesAsync(@"x\*"));
             Assert.Empty(await storage.GetFileListAsync());
         }
     }
@@ -388,20 +390,26 @@ public abstract class FileStorageTestsBase : TestWithLoggingBase
         using (storage)
         {
             await storage.SaveFileAsync(@"x\hello.txt", "hello");
-            await storage.SaveFileAsync(@"x\nested\world.csv", "nested world");
             await storage.SaveFileAsync(@"x\nested\hello.txt", "nested hello");
-            Assert.Equal(3, (await storage.GetFileListAsync()).Count);
+            await storage.SaveFileAsync(@"x\nested\world.csv", "nested world");
+            await storage.SaveFileAsync(@"x\nested\docs\README", "README");
+            await storage.SaveFileAsync(@"x\nested\media\README", "README");
+            Assert.Equal(5, (await storage.GetFileListAsync()).Count);
             Assert.Single(await storage.GetFileListAsync(limit: 1));
-            Assert.Equal(3, (await storage.GetFileListAsync(@"x\*")).Count);
-            Assert.Equal(2, (await storage.GetFileListAsync(@"x\nested\*")).Count);
+            Assert.Equal(5, (await storage.GetFileListAsync(@"x\*")).Count);
+            Assert.Equal(4, (await storage.GetFileListAsync(@"x\nested\*")).Count);
             Assert.Equal(2, (await storage.GetFileListAsync(@"x\*.txt")).Count);
 
+            Assert.Equal(1, await storage.DeleteFilesAsync(@"x\nested\docs\"));
+            Assert.Equal(1, await storage.DeleteFilesAsync(@"x\nested\media"));
             Assert.Equal(2, await storage.DeleteFilesAsync(@"x\nested\*"));
 
             Assert.Single(await storage.GetFileListAsync());
             Assert.True(await storage.ExistsAsync(@"x\hello.txt"));
             Assert.False(await storage.ExistsAsync(@"x\nested\hello.txt"));
             Assert.False(await storage.ExistsAsync(@"x\nested\world.csv"));
+            Assert.False(await storage.ExistsAsync(@"x\nested\docs\README"));
+            Assert.False(await storage.ExistsAsync(@"x\nested\media\README"));
 
             Assert.Equal(1, await storage.DeleteFilesAsync(@"x\hello*"));
             Assert.Empty(await storage.GetFileListAsync());
@@ -430,7 +438,7 @@ public abstract class FileStorageTestsBase : TestWithLoggingBase
             Assert.Equal(3, (await storage.GetFileListAsync(@"x\nested\*")).Count);
             Assert.Equal(3, (await storage.GetFileListAsync(@"x\*.txt")).Count);
 
-            await storage.DeleteFilesAsync(@"x\nested\*.txt");
+            Assert.Equal(2, await storage.DeleteFilesAsync(@"x\nested\*.txt"));
 
             Assert.Equal(3, (await storage.GetFileListAsync()).Count);
             Assert.True(await storage.ExistsAsync(@"x\hello.txt"));

--- a/src/Foundatio/Storage/FolderFileStorage.cs
+++ b/src/Foundatio/Storage/FolderFileStorage.cs
@@ -239,7 +239,7 @@ public class FolderFileStorage : IFileStorage
             if (Directory.Exists(Folder))
             {
                 _logger.LogInformation("Deleting {Directory} directory", Folder);
-                count += Directory.EnumerateFiles(Folder, "*,*", SearchOption.AllDirectories).Count();
+                count += Directory.EnumerateFiles(Folder, "*.*", SearchOption.AllDirectories).Count();
                 Directory.Delete(Folder, true);
                 _logger.LogTrace("Finished deleting {Directory} directory with {FileCount} files", Folder, count);
             }
@@ -249,13 +249,13 @@ public class FolderFileStorage : IFileStorage
 
         searchPattern = searchPattern.NormalizePath();
         string path = Path.Combine(Folder, searchPattern);
-        if (path[path.Length - 1] == Path.DirectorySeparatorChar || path.EndsWith(Path.DirectorySeparatorChar + "*"))
+        if (path[path.Length - 1] == Path.DirectorySeparatorChar || path.EndsWith($"{Path.DirectorySeparatorChar}*"))
         {
             string directory = Path.GetDirectoryName(path);
             if (Directory.Exists(directory))
             {
                 _logger.LogInformation("Deleting {Directory} directory", directory);
-                count += Directory.EnumerateFiles(directory, "*,*", SearchOption.AllDirectories).Count();
+                count += Directory.EnumerateFiles(directory, "*.*", SearchOption.AllDirectories).Count();
                 Directory.Delete(directory, true);
                 _logger.LogTrace("Finished deleting {Directory} directory with {FileCount} files", directory, count);
                 return Task.FromResult(count);
@@ -267,7 +267,7 @@ public class FolderFileStorage : IFileStorage
         if (Directory.Exists(path))
         {
             _logger.LogInformation("Deleting {Directory} directory", path);
-            count += Directory.EnumerateFiles(path, "*,*", SearchOption.AllDirectories).Count();
+            count += Directory.EnumerateFiles(path, "*.*", SearchOption.AllDirectories).Count();
             Directory.Delete(path, true);
             _logger.LogTrace("Finished deleting {Directory} directory with {FileCount} files", path, count);
             return Task.FromResult(count);

--- a/src/Foundatio/Storage/InMemoryFileStorage.cs
+++ b/src/Foundatio/Storage/InMemoryFileStorage.cs
@@ -228,11 +228,10 @@ public class InMemoryFileStorage : IFileStorage
 
         if (searchPattern[searchPattern.Length - 1] == Path.DirectorySeparatorChar)
             searchPattern = $"{searchPattern}*";
-        else if (!searchPattern.EndsWith(Path.DirectorySeparatorChar + "*") && !Path.HasExtension(searchPattern))
+        else if (!searchPattern.EndsWith("*") && !Path.HasExtension(searchPattern))
             searchPattern = Path.Combine(searchPattern, "*");
 
         var regex = new Regex($"^{Regex.Escape(searchPattern).Replace("\\*", ".*?")}$");
-
         var keys = _storage.Keys.Where(k => regex.IsMatch(k)).Select(k => _storage[k].Spec).ToList();
 
         _logger.LogInformation("Deleting {FileCount} files matching {SearchPattern} (Regex={SearchPatternRegex})", keys.Count, searchPattern, regex);


### PR DESCRIPTION
1. [Fixed a bug where folder file storage wasn't returning deleted counts.](https://github.com/FoundatioFx/Foundatio/commit/8a7d6a4a072f3567a878fc851e2df74a827b9142)
2. [Fixed a bug where the in memory file storage couldn't delete files with a wildcard ending (no extension)
](https://github.com/FoundatioFx/Foundatio/commit/18652f970a805299d5fffc00510ab4a975744bc9)