### PR TITLE
[BREAKING]: Cache Client lists no longer have a sliding expiration and each cache item expires independently

### DIFF
--- a/src/Foundatio.TestHarness/Caching/CacheClientTestsBase.cs
+++ b/src/Foundatio.TestHarness/Caching/CacheClientTestsBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Foundatio.TestHarness/Caching/CacheClientTestsBase.cs
+++ b/src/Foundatio.TestHarness/Caching/CacheClientTestsBase.cs
@@ -973,7 +973,7 @@ public abstract class CacheClientTestsBase : TestWithLoggingBase
 
             // Add with expiration
             Assert.Equal(1, await cache.ListAddAsync(key, [2], TimeSpan.FromMilliseconds(100)));
-            Assert.Equal(1, await cache.ListAddAsync(key, [3], TimeSpan.FromMilliseconds(150)));
+            Assert.Equal(1, await cache.ListAddAsync(key, [3], TimeSpan.FromMilliseconds(175)));
 
             var cacheValue = await cache.GetListAsync<int>(key);
             Assert.True(cacheValue.HasValue);
@@ -981,7 +981,7 @@ public abstract class CacheClientTestsBase : TestWithLoggingBase
             Assert.True(cacheValue.Value.Contains(2));
             Assert.True(cacheValue.Value.Contains(3));
 
-            await Task.Delay(100);
+            await Task.Delay(125);
             cacheValue = await cache.GetListAsync<int>(key);
             Assert.True(cacheValue.HasValue);
             Assert.Single(cacheValue.Value);

--- a/src/Foundatio.TestHarness/Caching/CacheClientTestsBase.cs
+++ b/src/Foundatio.TestHarness/Caching/CacheClientTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class CacheClientTestsBase : TestWithLoggingBase
             await cache.SetAsync("test1", 1);
             await cache.SetAsync("test2", 2);
             await cache.SetAsync("test3", 3);
-            var result = await cache.GetAllAsync<int>(new[] { "test1", "test2", "test3" });
+            var result = await cache.GetAllAsync<int>(["test1", "test2", "test3"]);
             Assert.NotNull(result);
             Assert.Equal(3, result.Count);
             Assert.Equal(1, result["test1"].Value);
@@ -51,7 +51,7 @@ public abstract class CacheClientTestsBase : TestWithLoggingBase
             await cache.SetAsync("obj3", (SimpleModel)null);
             await cache.SetAsync("obj4", new SimpleModel { Data1 = "test 1", Data2 = 4 });
 
-            var result2 = await cache.GetAllAsync<SimpleModel>(new[] { "obj1", "obj2", "obj3", "obj4", "obj5" });
+            var result2 = await cache.GetAllAsync<SimpleModel>(["obj1", "obj2", "obj3", "obj4", "obj5"]);
             Assert.NotNull(result2);
             Assert.Equal(5, result2.Count);
             Assert.True(result2["obj3"].IsNull);
@@ -64,7 +64,7 @@ public abstract class CacheClientTestsBase : TestWithLoggingBase
             await cache.SetAsync("str1", "string 1");
             await cache.SetAsync("str2", "string 2");
             await cache.SetAsync("str3", (string)null);
-            var result3 = await cache.GetAllAsync<string>(new[] { "str1", "str2", "str3" });
+            var result3 = await cache.GetAllAsync<string>(["str1", "str2", "str3"]);
             Assert.NotNull(result3);
             Assert.Equal(3, result3.Count);
         }
@@ -89,7 +89,7 @@ public abstract class CacheClientTestsBase : TestWithLoggingBase
                 { "test5", 5.0 }
             });
 
-            var result = await cache.GetAllAsync<double>(new[] { "test1", "test2", "test3", "test4", "test5" });
+            var result = await cache.GetAllAsync<double>(["test1", "test2", "test3", "test4", "test5"]);
             Assert.NotNull(result);
             Assert.Equal(5, result.Count);
             Assert.Equal(1.0, result["test1"].Value);
@@ -349,10 +349,10 @@ public abstract class CacheClientTestsBase : TestWithLoggingBase
             Assert.Equal(0, await nestedScopedCache1.GetAsync<double>("total", 0));
             Assert.Equal(20, await nestedScopedCache1.IncrementAsync("total", 20));
             Assert.Equal(20, await nestedScopedCache1.GetAsync<double>("total", 0));
-            Assert.Equal(1, await nestedScopedCache1.RemoveAllAsync(new[] { "id", "total" }));
+            Assert.Equal(1, await nestedScopedCache1.RemoveAllAsync(["id", "total"]));
             Assert.Equal(0, await nestedScopedCache1.GetAsync<double>("total", 0));
 
-            Assert.Equal(1, await scopedCache1.RemoveAllAsync(new[] { "id", "total" }));
+            Assert.Equal(1, await scopedCache1.RemoveAllAsync(["id", "total"]));
             Assert.Equal(0, await scopedCache1.GetAsync<double>("total", 0));
         }
     }
@@ -673,7 +673,7 @@ public abstract class CacheClientTestsBase : TestWithLoggingBase
             Assert.True(await cache.SetAsync("test", value));
             Assert.Equal(value, await cache.GetAsync<double>("test", 0));
 
-            var lowerValue = value - 1000;
+            double lowerValue = value - 1000;
             Assert.Equal(1000, await cache.SetIfLowerAsync("test", lowerValue));
             Assert.Equal(lowerValue, await cache.GetAsync<double>("test", 0));
 
@@ -722,7 +722,7 @@ public abstract class CacheClientTestsBase : TestWithLoggingBase
             Assert.Equal(TimeSpan.Zero, actual.Offset);
 
             var lowerValue = value - TimeSpan.FromHours(1);
-            var lowerUnixTimeValue = lowerValue.ToUnixTimeMilliseconds();
+            long lowerUnixTimeValue = lowerValue.ToUnixTimeMilliseconds();
             Assert.Equal((long)TimeSpan.FromHours(1).TotalMilliseconds, await cache.SetIfLowerAsync("test", lowerValue));
             Assert.Equal(lowerUnixTimeValue, await cache.GetAsync<long>("test", 0));
 
@@ -747,7 +747,7 @@ public abstract class CacheClientTestsBase : TestWithLoggingBase
             Assert.Equal(value, await cache.GetUnixTimeMillisecondsAsync("test"));
 
             var higherValue = value + TimeSpan.FromHours(1);
-            var higherUnixTimeValue = higherValue.ToUnixTimeMilliseconds();
+            long higherUnixTimeValue = higherValue.ToUnixTimeMilliseconds();
             Assert.Equal((long)TimeSpan.FromHours(1).TotalMilliseconds, await cache.SetIfHigherAsync("test", higherValue));
             Assert.Equal(higherUnixTimeValue, await cache.GetAsync<long>("test", 0));
             Assert.Equal(higherValue, await cache.GetUnixTimeMillisecondsAsync("test"));
@@ -770,7 +770,7 @@ public abstract class CacheClientTestsBase : TestWithLoggingBase
             Assert.Equal(value, await cache.GetAsync<double>("test", 0));
             Assert.InRange((await cache.GetExpirationAsync("test")).Value, minExpiration, TimeSpan.FromHours(2));
 
-            var lowerValue = value - 1000;
+            double lowerValue = value - 1000;
             Assert.Equal(1000, await cache.SetIfLowerAsync("test", lowerValue, TimeSpan.FromHours(2)));
             Assert.Equal(lowerValue, await cache.GetAsync<double>("test", 0));
             Assert.InRange((await cache.GetExpirationAsync("test")).Value, minExpiration, TimeSpan.FromHours(2));
@@ -798,6 +798,7 @@ public abstract class CacheClientTestsBase : TestWithLoggingBase
         using (cache)
         {
             await cache.RemoveAllAsync();
+            const string key = "list";
 
             await Assert.ThrowsAsync<ArgumentNullException>(() => cache.ListAddAsync(null, 1));
             await Assert.ThrowsAsync<ArgumentNullException>(() => cache.ListAddAsync(String.Empty, 1));
@@ -808,45 +809,36 @@ public abstract class CacheClientTestsBase : TestWithLoggingBase
             await Assert.ThrowsAsync<ArgumentNullException>(() => cache.GetListAsync<ICollection<int>>(null));
             await Assert.ThrowsAsync<ArgumentNullException>(() => cache.GetListAsync<ICollection<int>>(String.Empty));
 
-            await cache.ListAddAsync("test1", new[] { 1, 2, 3 });
-            var result = await cache.GetListAsync<int>("test1");
+            await cache.ListAddAsync(key, [1, 2, 3, 3]);
+            var result = await cache.GetListAsync<int>(key);
             Assert.NotNull(result);
             Assert.Equal(3, result.Value.Count);
 
-            await cache.ListRemoveAsync("test1", new[] { 1, 2, 3 });
-            result = await cache.GetListAsync<int>("test1");
+            await cache.ListRemoveAsync(key, [1, 2, 3]);
+            result = await cache.GetListAsync<int>(key);
             Assert.NotNull(result);
             Assert.Empty(result.Value);
 
-            // test single strings don't get handled as char arrays
             await cache.RemoveAllAsync();
 
-            await cache.ListAddAsync("stringlist", "myvalue");
-            var stringResult = await cache.GetListAsync<string>("stringlist");
-            Assert.Single(stringResult.Value);
-            Assert.Equal("myvalue", stringResult.Value.First());
+            // Add an empty item.
+            await cache.ListAddAsync<int>(key, []);
 
-            await cache.ListRemoveAsync("stringlist", "myvalue");
-            stringResult = await cache.GetListAsync<string>("stringlist");
-            Assert.Empty(stringResult.Value);
-
-            await cache.RemoveAllAsync();
-
-            await cache.ListAddAsync("test1", 1);
-            await cache.ListAddAsync("test1", 2);
-            await cache.ListAddAsync("test1", 3);
-            result = await cache.GetListAsync<int>("test1");
+            await cache.ListAddAsync(key, 1);
+            await cache.ListAddAsync(key, 2);
+            await cache.ListAddAsync(key, 3);
+            result = await cache.GetListAsync<int>(key);
             Assert.NotNull(result);
             Assert.Equal(3, result.Value.Count);
 
-            await cache.ListRemoveAsync("test1", 2);
-            result = await cache.GetListAsync<int>("test1");
+            await cache.ListRemoveAsync(key, 2);
+            result = await cache.GetListAsync<int>(key);
             Assert.NotNull(result);
             Assert.Equal(2, result.Value.Count);
 
-            await cache.ListRemoveAsync("test1", 1);
-            await cache.ListRemoveAsync("test1", 3);
-            result = await cache.GetListAsync<int>("test1");
+            await cache.ListRemoveAsync(key, 1);
+            await cache.ListRemoveAsync(key, 3);
+            result = await cache.GetListAsync<int>(key);
             Assert.NotNull(result);
             Assert.Empty(result.Value);
 
@@ -855,31 +847,175 @@ public abstract class CacheClientTestsBase : TestWithLoggingBase
                 await cache.AddAsync("key1", 1);
                 await cache.ListAddAsync("key1", 1);
             });
+        }
+    }
 
-            // test paging through items in list
-            await cache.ListAddAsync("testpaging", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 });
-            var pagedResult = await cache.GetListAsync<int>("testpaging", 1, 5);
-            Assert.NotNull(pagedResult);
-            Assert.Equal(5, pagedResult.Value.Count);
-            Assert.Equal(pagedResult.Value.ToArray(), new[] { 1, 2, 3, 4, 5 });
+    /// <summary>
+    /// single strings don't get handled as char arrays
+    /// </summary>
+    public virtual async Task CanManageStringListsAsync()
+    {
+        var cache = GetCacheClient();
+        if (cache == null)
+            return;
 
-            pagedResult = await cache.GetListAsync<int>("testpaging", 2, 5);
-            Assert.NotNull(pagedResult);
-            Assert.Equal(5, pagedResult.Value.Count);
-            Assert.Equal(pagedResult.Value.ToArray(), new[] { 6, 7, 8, 9, 10 });
+        using (cache)
+        {
+            await cache.RemoveAllAsync();
+            const string key = "list:strings";
 
-            await cache.ListAddAsync("testpaging", new[] { 21, 22 });
+            await cache.ListAddAsync(key, "my-value");
+            var stringResult = await cache.GetListAsync<string>(key);
+            Assert.Single(stringResult.Value);
+            Assert.Equal("my-value", stringResult.Value.First());
 
-            pagedResult = await cache.GetListAsync<int>("testpaging", 5, 5);
+            await cache.ListRemoveAsync(key, "my-value");
+            stringResult = await cache.GetListAsync<string>(key);
+            Assert.Empty(stringResult.Value);
+        }
+    }
+
+    public virtual async Task CanManageListPagingAsync()
+    {
+        var cache = GetCacheClient();
+        if (cache == null)
+            return;
+
+        using (cache)
+        {
+            await cache.RemoveAllAsync();
+            const string key = "list:paging";
+
+            int[] values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
+            await cache.ListAddAsync(key, values, TimeSpan.FromMinutes(1));
+
+            CacheValue<ICollection<int>> pagedResult;
+            var firstPageResults = new HashSet<int>(5);
+            var actualResults = new HashSet<int>(values.Length);
+
+            for (int page = 1; page < values.Length / 5 + 1; page++)
+            {
+                pagedResult = await cache.GetListAsync<int>(key, page, 5);
+                Assert.NotNull(pagedResult);
+                Assert.Equal(5, pagedResult.Value.Count);
+                actualResults.AddRange(pagedResult.Value);
+
+                if (page is 1)
+                    firstPageResults.AddRange(pagedResult.Value);
+            }
+
+            // Use a higher expiration so we can assert the new items are returned last in the list.
+            await cache.ListAddAsync(key, [21, 22], TimeSpan.FromMinutes(2));
+            pagedResult = await cache.GetListAsync<int>(key, 5, 5);
             Assert.NotNull(pagedResult);
             Assert.Equal(2, pagedResult.Value.Count);
-            Assert.Equal(pagedResult.Value.ToArray(), new[] { 21, 22 });
+            actualResults.AddRange(pagedResult.Value);
+            Assert.Equal(values.Length + 2, actualResults.Count);
 
-            await cache.ListRemoveAsync("testpaging", 2);
-            pagedResult = await cache.GetListAsync<int>("testpaging", 1, 5);
+            // Assert invalid starting page is empty.
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => cache.GetListAsync<int>(key, 0, 5));
+
+            // Assert invalid page is empty
+            pagedResult = await cache.GetListAsync<int>(key, 6, 5);
+            Assert.NotNull(pagedResult);
+            Assert.Empty(pagedResult.Value);
+
+            // Assert the first page is the same.
+            pagedResult = await cache.GetListAsync<int>(key, 1, 5);
             Assert.NotNull(pagedResult);
             Assert.Equal(5, pagedResult.Value.Count);
-            Assert.Equal(pagedResult.Value.ToArray(), new[] { 1, 3, 4, 5, 6 });
+            Assert.Equal(firstPageResults, pagedResult.Value.ToArray());
+        }
+    }
+
+    public virtual async Task CanManageGetListExpirationAsync()
+    {
+        var cache = GetCacheClient();
+        if (cache == null)
+            return;
+
+        using (cache)
+        {
+            await cache.RemoveAllAsync();
+            const string key = "list:expiration:get";
+
+            Assert.Equal(1, await cache.ListAddAsync(key, [1], TimeSpan.FromMilliseconds(100)));
+
+            var cacheValue = await cache.GetListAsync<int>(key);
+            Assert.True(cacheValue.HasValue);
+            Assert.Single(cacheValue.Value);
+            Assert.True(cacheValue.Value.Contains(1));
+
+            await Task.Delay(150);
+
+            // GetList should invalidate expired items
+            cacheValue = await cache.GetListAsync<int>(key);
+            Assert.False(cacheValue.HasValue);
+            Assert.False(await cache.ExistsAsync(key));
+        }
+    }
+    public virtual async Task CanManageListAddExpirationAsync()
+    {
+        var cache = GetCacheClient();
+        if (cache == null)
+            return;
+
+        using (cache)
+        {
+            await cache.RemoveAllAsync();
+            const string key = "list:expiration:add";
+
+            Assert.Equal(1, await cache.ListAddAsync(key, [1]));
+
+            // Remove the expired item via Add.
+            Assert.Equal(0, await cache.ListAddAsync(key, [1], TimeSpan.FromSeconds(-1)));
+            Assert.False(await cache.ExistsAsync(key));
+
+            // Add with expiration
+            Assert.Equal(1, await cache.ListAddAsync(key, [2], TimeSpan.FromMilliseconds(100)));
+            Assert.Equal(1, await cache.ListAddAsync(key, [3], TimeSpan.FromMilliseconds(150)));
+
+            var cacheValue = await cache.GetListAsync<int>(key);
+            Assert.True(cacheValue.HasValue);
+            Assert.Equal(2, cacheValue.Value.Count);
+            Assert.True(cacheValue.Value.Contains(2));
+            Assert.True(cacheValue.Value.Contains(3));
+
+            await Task.Delay(100);
+            cacheValue = await cache.GetListAsync<int>(key);
+            Assert.True(cacheValue.HasValue);
+            Assert.Single(cacheValue.Value);
+            Assert.True(cacheValue.Value.Contains(3));
+
+            await Task.Delay(100);
+            Assert.False(await cache.ExistsAsync(key));
+        }
+    }
+
+    public virtual async Task CanManageListRemoveExpirationAsync()
+    {
+        var cache = GetCacheClient();
+        if (cache == null)
+            return;
+
+        using (cache)
+        {
+            await cache.RemoveAllAsync();
+            const string key = "list:expiration:remove";
+
+            Assert.Equal(2, await cache.ListAddAsync(key, [1, 2]));
+
+            // Past expiration just calls remove on the item if it's there.
+            Assert.Equal(1, await cache.ListRemoveAsync(key, [1], TimeSpan.FromSeconds(-1)));
+            Assert.Equal(0, await cache.ListRemoveAsync(key, [1], TimeSpan.FromSeconds(-1)));
+
+            var cacheValue = await cache.GetListAsync<int>(key);
+            Assert.True(cacheValue.HasValue);
+            Assert.Single(cacheValue.Value);
+            Assert.True(cacheValue.Value.Contains(2));
+
+            Assert.Equal(1, await cache.ListRemoveAsync(key, [2], TimeSpan.FromSeconds(1)));
+            Assert.False(await cache.ExistsAsync(key));
         }
     }
 

--- a/src/Foundatio.TestHarness/Caching/HybridCacheClientTests.cs
+++ b/src/Foundatio.TestHarness/Caching/HybridCacheClientTests.cs
@@ -144,6 +144,36 @@ public class HybridCacheClientTests : CacheClientTestsBase, IDisposable
     }
 
     [Fact]
+    public override Task CanManageStringListsAsync()
+    {
+        return base.CanManageStringListsAsync();
+    }
+
+    [Fact]
+    public override Task CanManageListPagingAsync()
+    {
+        return base.CanManageListPagingAsync();
+    }
+
+    [Fact]
+    public override Task CanManageGetListExpirationAsync()
+    {
+        return base.CanManageGetListExpirationAsync();
+    }
+
+    [Fact]
+    public override Task CanManageListAddExpirationAsync()
+    {
+        return base.CanManageListAddExpirationAsync();
+    }
+
+    [Fact]
+    public override Task CanManageListRemoveExpirationAsync()
+    {
+        return base.CanManageListAddExpirationAsync();
+    }
+
+    [Fact]
     public virtual async Task WillUseLocalCache()
     {
         using var firstCache = GetCacheClient() as HybridCacheClient;

--- a/src/Foundatio.TestHarness/Caching/HybridCacheClientTests.cs
+++ b/src/Foundatio.TestHarness/Caching/HybridCacheClientTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Foundatio.AsyncEx;

--- a/src/Foundatio.TestHarness/Caching/HybridCacheClientTests.cs
+++ b/src/Foundatio.TestHarness/Caching/HybridCacheClientTests.cs
@@ -170,7 +170,7 @@ public class HybridCacheClientTests : CacheClientTestsBase, IDisposable
     [Fact]
     public override Task CanManageListRemoveExpirationAsync()
     {
-        return base.CanManageListAddExpirationAsync();
+        return base.CanManageListRemoveExpirationAsync();
     }
 
     [Fact]

--- a/src/Foundatio/Caching/InMemoryCacheClient.cs
+++ b/src/Foundatio/Caching/InMemoryCacheClient.cs
@@ -725,10 +725,10 @@ public class InMemoryCacheClient : IMemoryCacheClient, IHaveTimeProvider, IHaveL
             return 0;
 
         int limit = Math.Min(_maxItems.GetValueOrDefault(values.Count), values.Count);
-        if (values.Count > limit)
+        if (_maxItems.HasValue && values.Count > _maxItems)
         {
             _logger.LogWarning(
-                "Received {TotalCount} items but max items is {MaxItems}: processing only the first {Limit}",
+                "Received {TotalCount} items but max items is {MaxItems}: processing the last {Limit}",
                 values.Count, _maxItems, limit);
         }
 
@@ -737,7 +737,7 @@ public class InMemoryCacheClient : IMemoryCacheClient, IHaveTimeProvider, IHaveL
         // Use the whole dictionary when possible, otherwise copy just the slice we need.
         var work = limit >= values.Count
             ? (IReadOnlyDictionary<string, T>)values
-            : values.Take(limit).ToDictionary(kv => kv.Key, kv => kv.Value);
+            : values.Skip(values.Count - limit).ToDictionary(kv => kv.Key, kv => kv.Value);
 
         const int batchSize = 1_024;
 

--- a/src/Foundatio/Caching/InMemoryCacheClient.cs
+++ b/src/Foundatio/Caching/InMemoryCacheClient.cs
@@ -532,7 +532,7 @@ public class InMemoryCacheClient : IMemoryCacheClient, IHaveTimeProvider, IHaveL
 
                 ExpireListValues(dictionary, existingKey);
 
-                dictionary.Add(stringValue, expiresAt);
+                dictionary[stringValue] = expiresAt;
                 existingEntry.Value = dictionary;
                 existingEntry.ExpiresAt = dictionary.Values.Max();
                 return existingEntry;
@@ -614,7 +614,7 @@ public class InMemoryCacheClient : IMemoryCacheClient, IHaveTimeProvider, IHaveL
             });
 
             await StartMaintenanceAsync().AnyContext();
-            return items.Count;
+            return removed;
         }
         else
         {

--- a/src/Foundatio/Caching/InMemoryCacheClient.cs
+++ b/src/Foundatio/Caching/InMemoryCacheClient.cs
@@ -579,7 +579,7 @@ public class InMemoryCacheClient : IMemoryCacheClient, IHaveTimeProvider, IHaveL
         return expiredValues;
     }
 
-    public async Task<long> ListRemoveAsync<T>(string key, IEnumerable<T> values, TimeSpan? expiresIn = null)
+    public Task<long> ListRemoveAsync<T>(string key, IEnumerable<T> values, TimeSpan? expiresIn = null)
     {
         if (String.IsNullOrEmpty(key))
             throw new ArgumentNullException(nameof(key), "Key cannot be null or empty");
@@ -613,13 +613,13 @@ public class InMemoryCacheClient : IMemoryCacheClient, IHaveTimeProvider, IHaveL
                 return existingEntry;
             });
 
-            return removed;
+            return Task.FromResult(removed);
         }
         else
         {
             var items = new HashSet<T>(values);
             if (items.Count == 0)
-                return 0;
+                return Task.FromResult<long>(0);
 
             _memory.TryUpdate(key, (existingKey, existingEntry) =>
             {
@@ -641,7 +641,7 @@ public class InMemoryCacheClient : IMemoryCacheClient, IHaveTimeProvider, IHaveL
                 return existingEntry;
             });
 
-            return removed;
+            return Task.FromResult(removed);
         }
     }
 

--- a/src/Foundatio/Caching/InMemoryCacheClient.cs
+++ b/src/Foundatio/Caching/InMemoryCacheClient.cs
@@ -743,7 +743,7 @@ public class InMemoryCacheClient : IMemoryCacheClient, IHaveTimeProvider, IHaveL
         // NOTE: Would be great to target Parallel.ForEachAsync but we need .NET 6+;
 
         // Use the whole dictionary when possible, otherwise copy just the slice we need.
-        var work = limit == values.Count
+        var work = limit >= values.Count
             ? (IReadOnlyDictionary<string, T>)values
             : values.Take(limit).ToDictionary(kv => kv.Key, kv => kv.Value);
 

--- a/src/Foundatio/Extensions/DictionaryExtensions.cs
+++ b/src/Foundatio/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Foundatio.Utility;
+
+namespace Foundatio.Extensions;
+
+internal static class DictionaryExtensions
+{
+    /// <summary>
+    /// Streams a dictionary to <paramref name="handler"/> in fixed‑size batches
+    /// with a single rented buffer (constant memory).
+    /// </summary>
+    /// <typeparam name="TKey">Key type.</typeparam>
+    /// <typeparam name="TValue">Value type.</typeparam>
+    /// <param name="source">The dictionary to process.</param>
+    /// <param name="batchSize">Number of items per batch (≥ 1).</param>
+    /// <param name="handler">
+    /// Async callback that consumes a <see cref="ReadOnlyMemory{T}"/> slice
+    /// representing one full or partial batch of <see cref="KeyValuePair{TKey,TValue}"/>.
+    /// </param>
+    /// <returns>Total item count streamed.</returns>
+    public static async Task<int> BatchAsync<TKey, TValue>(
+        this IReadOnlyDictionary<TKey, TValue> source,
+        int batchSize,
+        Func<ReadOnlyMemory<KeyValuePair<TKey, TValue>>, ValueTask> handler)
+    {
+        if (source is null) throw new ArgumentNullException(nameof(source));
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+        if (batchSize <= 0) throw new ArgumentOutOfRangeException(nameof(batchSize));
+
+        // Fast path for very small dictionaries
+        if (source.Count == 0)
+            return 0;
+
+        if (batchSize >= source.Count)
+        {
+            var oneShot = source.ToArray();
+            await handler(oneShot.AsMemory()).AnyContext();
+            return oneShot.Length;
+        }
+
+        var buffer = ArrayPool<KeyValuePair<TKey, TValue>>.Shared.Rent(batchSize);
+        int filled = 0, total = 0;
+
+        try
+        {
+            foreach (var kvp in source)
+            {
+                buffer[filled++] = kvp;
+
+                if (filled == batchSize)
+                {
+                    await handler(buffer.AsMemory(0, filled)).AnyContext();
+                    total += filled;
+                    filled = 0;
+                }
+            }
+
+            if (filled > 0)
+            {
+                await handler(buffer.AsMemory(0, filled)).AnyContext();
+                total += filled;
+            }
+        }
+        finally
+        {
+            ArrayPool<KeyValuePair<TKey, TValue>>.Shared.Return(buffer, clearArray: true);
+        }
+
+        return total;
+    }
+}

--- a/tests/Foundatio.Tests/Caching/InMemoryCacheClientTests.cs
+++ b/tests/Foundatio.Tests/Caching/InMemoryCacheClientTests.cs
@@ -158,6 +158,36 @@ public class InMemoryCacheClientTests : CacheClientTestsBase
     }
 
     [Fact]
+    public override Task CanManageStringListsAsync()
+    {
+        return base.CanManageStringListsAsync();
+    }
+
+    [Fact]
+    public override Task CanManageListPagingAsync()
+    {
+        return base.CanManageListPagingAsync();
+    }
+
+    [Fact]
+    public override Task CanManageGetListExpirationAsync()
+    {
+        return base.CanManageGetListExpirationAsync();
+    }
+
+    [Fact]
+    public override Task CanManageListAddExpirationAsync()
+    {
+        return base.CanManageListAddExpirationAsync();
+    }
+
+    [Fact]
+    public override Task CanManageListRemoveExpirationAsync()
+    {
+        return base.CanManageListAddExpirationAsync();
+    }
+
+    [Fact]
     public async Task CanSetMaxItems()
     {
         // run in tight loop so that the code is warmed up and we can catch timing issues

--- a/tests/Foundatio.Tests/Caching/InMemoryCacheClientTests.cs
+++ b/tests/Foundatio.Tests/Caching/InMemoryCacheClientTests.cs
@@ -184,7 +184,7 @@ public class InMemoryCacheClientTests : CacheClientTestsBase
     [Fact]
     public override Task CanManageListRemoveExpirationAsync()
     {
-        return base.CanManageListAddExpirationAsync();
+        return base.CanManageListRemoveExpirationAsync();
     }
 
     [Fact]


### PR DESCRIPTION
- We should also seriously consider removing the expires in param on ListRemoveAsync.
- We should look for any race conditions
- Does ordering matter between the clients? We might be able to use some sorted data structure for in memory.