### PR TITLE
Adds queue dequeue activity tracking

### DIFF
--- a/src/Foundatio/Jobs/QueueJobBase.cs
+++ b/src/Foundatio/Jobs/QueueJobBase.cs
@@ -141,7 +141,7 @@ public abstract class QueueJobBase<T> : IQueueJob<T>, IHaveLogger, IHaveLoggerFa
 
     protected virtual Activity StartDequeueActivity()
     {
-        var activity = FoundatioDiagnostics.ActivitySource.StartActivity("DequeueQueueEntry", ActivityKind.Internal);
+        var activity = FoundatioDiagnostics.ActivitySource.StartActivity("DequeueQueueEntry");
         if (activity is null)
             return null;
 
@@ -163,7 +163,6 @@ public abstract class QueueJobBase<T> : IQueueJob<T>, IHaveLogger, IHaveLoggerFa
         activity.AddTag("EntryType", entry.EntryType.FullName);
         activity.AddTag("Id", entry.Id);
         activity.AddTag("CorrelationId", entry.CorrelationId);
-        activity.AddTag("Attempts", entry.Attempts.ToString());
     }
 
     protected virtual Activity StartProcessQueueEntryActivity(IQueueEntry<T> entry)
@@ -190,7 +189,6 @@ public abstract class QueueJobBase<T> : IQueueJob<T>, IHaveLogger, IHaveLoggerFa
         activity.AddTag("EntryType", entry.EntryType.FullName);
         activity.AddTag("Id", entry.Id);
         activity.AddTag("CorrelationId", entry.CorrelationId);
-        activity.AddTag("Attempts", entry.Attempts.ToString());
 
         if (entry.Properties is not { Count: > 0 })
             return;


### PR DESCRIPTION
Introduces activity tracking for queue dequeue operations to monitor performance and diagnose issues.

Adds tags to the activity with relevant information such as queue name, job id, entry type, id, correlation id, and attempts.

Improves the dequeue experience around viewing span data as you don't know some spans take a long time, in this case sqs queues doing long polling.

<img width="360" height="288" alt="image" src="https://github.com/user-attachments/assets/19b7cca0-ee8b-4f63-9bf9-c6716e90e195" />
