### PR TITLE
Fixes #411: Adds option to dispose underlying scoped implementations

### DIFF
--- a/src/Foundatio/Caching/InMemoryCacheClient.cs
+++ b/src/Foundatio/Caching/InMemoryCacheClient.cs
@@ -30,7 +30,9 @@ public class InMemoryCacheClient : IMemoryCacheClient, IHaveTimeProvider, IHaveL
     private readonly ILoggerFactory _loggerFactory;
     private readonly AsyncLock _lock = new();
 
-    public InMemoryCacheClient() : this(o => o) { }
+    public InMemoryCacheClient() : this(o => o)
+    {
+    }
 
     public InMemoryCacheClient(InMemoryCacheClientOptions options = null)
     {
@@ -1069,7 +1071,7 @@ public class InMemoryCacheClient : IMemoryCacheClient, IHaveTimeProvider, IHaveL
             await CompactAsync().AnyContext();
     }
 
-    public void Dispose()
+    public virtual void Dispose()
     {
         _memory.Clear();
         ItemExpired?.Dispose();

--- a/src/Foundatio/Caching/ScopedCacheClient.cs
+++ b/src/Foundatio/Caching/ScopedCacheClient.cs
@@ -8,11 +8,26 @@ using Microsoft.Extensions.Logging;
 
 namespace Foundatio.Caching;
 
+/// <summary>
+/// Provides a scoped hybrid cache client that prefixes all cache keys with the specified scope.
+/// </summary>
 public class ScopedHybridCacheClient : ScopedCacheClient, IHybridCacheClient
 {
-    public ScopedHybridCacheClient(IHybridCacheClient client, string scope = null, bool shouldDispose = false) : base(client, scope, shouldDispose) { }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ScopedHybridCacheClient"/> class with the specified hybrid cache client and scope.
+    /// </summary>
+    /// <param name="client">The underlying hybrid cache client to use.</param>
+    /// <param name="scope">The scope for cache keys. When specified, all operations will be prefixed with this scope.</param>
+    /// <param name="shouldDispose">Whether to dispose the underlying cache client when this instance is disposed.
+    /// Defaults to false, meaning the underlying cache client will not be disposed when this instance is disposed.
+    /// Set to true to have the underlying cache client automatically disposed when this instance is disposed, enabling use with 'using' statements.</param>
+    public ScopedHybridCacheClient(IHybridCacheClient client, string scope, bool shouldDispose = false) : base(client, scope, shouldDispose) { }
 }
 
+/// <summary>
+/// Provides a scoped cache client that prefixes all cache keys with the specified scope.
+/// Can optionally dispose the underlying cache client when this instance is disposed.
+/// </summary>
 public class ScopedCacheClient : ICacheClient, IHaveLogger, IHaveLoggerFactory, IHaveTimeProvider, IHaveResiliencePolicyProvider
 {
     private string _keyPrefix;
@@ -20,6 +35,14 @@ public class ScopedCacheClient : ICacheClient, IHaveLogger, IHaveLoggerFactory, 
     private readonly object _lock = new();
     private readonly bool _shouldDispose;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ScopedCacheClient"/> class with the specified cache client and scope.
+    /// </summary>
+    /// <param name="client">The underlying cache client to use.</param>
+    /// <param name="scope">The scope for cache keys. When specified, all operations will be prefixed with this scope.</param>
+    /// <param name="shouldDispose">Whether to dispose the underlying cache client when this instance is disposed.
+    /// Defaults to false, meaning the underlying cache client will not be disposed when this instance is disposed.
+    /// Set to true to have the underlying cache client automatically disposed when this instance is disposed, enabling use with 'using' statements.</param>
     public ScopedCacheClient(ICacheClient client, string scope, bool shouldDispose = false)
     {
         UnscopedCache = client ?? new NullCacheClient();

--- a/src/Foundatio/Storage/InMemoryFileStorage.cs
+++ b/src/Foundatio/Storage/InMemoryFileStorage.cs
@@ -24,7 +24,9 @@ public class InMemoryFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory
     private readonly TimeProvider _timeProvider;
     private readonly IResiliencePolicyProvider _resiliencePolicyProvider;
 
-    public InMemoryFileStorage() : this(o => o) { }
+    public InMemoryFileStorage() : this(o => o)
+    {
+    }
 
     public InMemoryFileStorage(InMemoryFileStorageOptions options)
     {
@@ -303,7 +305,7 @@ public class InMemoryFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory
         });
     }
 
-    public void Dispose()
+    public virtual void Dispose()
     {
         _storage?.Clear();
     }

--- a/src/Foundatio/Storage/ScopedFileStorage.cs
+++ b/src/Foundatio/Storage/ScopedFileStorage.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,11 +10,25 @@ using Microsoft.Extensions.Logging;
 
 namespace Foundatio.Storage;
 
+/// <summary>
+/// Provides a scoped file storage implementation that prefixes all file paths with the specified scope.
+/// Can optionally dispose the underlying storage when this instance is disposed.
+/// </summary>
 public class ScopedFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, IHaveTimeProvider, IHaveResiliencePolicyProvider
 {
     private readonly string _pathPrefix;
     private readonly bool _shouldDispose;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ScopedFileStorage"/> class with the specified file storage and scope.
+    /// </summary>
+    /// <param name="storage">The underlying file storage to use.</param>
+    /// <param name="scope">The scope for file paths. When specified, all operations will be prefixed with this scope.</param>
+    /// <param name="shouldDispose">Whether to dispose the underlying file storage when this instance is disposed.
+    /// Defaults to false, meaning the underlying file storage will not be disposed when this instance is disposed.
+    /// Set to true to have the underlying file storage automatically disposed when this instance is disposed, enabling use with 'using' statements.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="storage"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="scope"/> contains a wildcard character.</exception>
     public ScopedFileStorage(IFileStorage storage, string scope, bool shouldDispose = false)
     {
         UnscopedStorage = storage ?? throw new ArgumentNullException(nameof(storage));

--- a/src/Foundatio/Storage/ScopedFileStorage.cs
+++ b/src/Foundatio/Storage/ScopedFileStorage.cs
@@ -13,12 +13,14 @@ namespace Foundatio.Storage;
 public class ScopedFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, IHaveTimeProvider, IHaveResiliencePolicyProvider
 {
     private readonly string _pathPrefix;
+    private readonly bool _shouldDispose;
 
-    public ScopedFileStorage(IFileStorage storage, string scope)
+    public ScopedFileStorage(IFileStorage storage, string scope, bool shouldDispose = false)
     {
         UnscopedStorage = storage ?? throw new ArgumentNullException(nameof(storage));
         Scope = !String.IsNullOrWhiteSpace(scope) ? scope.Trim().NormalizePath() : null;
         _pathPrefix = Scope != null ? String.Concat(Scope, "/") : String.Empty;
+        _shouldDispose = shouldDispose;
 
         // NOTE: we can't really check reliably using Path.GetInvalidPathChars() because each storage implementation and platform could be different.
         if (Scope is not null && Scope.Contains("*"))
@@ -142,5 +144,9 @@ public class ScopedFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, 
         };
     }
 
-    public void Dispose() { }
+    public void Dispose()
+    {
+        if (_shouldDispose)
+            UnscopedStorage.Dispose();
+    }
 }

--- a/tests/Foundatio.Tests/Caching/ScopedCacheClientShouldDisposeTests.cs
+++ b/tests/Foundatio.Tests/Caching/ScopedCacheClientShouldDisposeTests.cs
@@ -1,16 +1,13 @@
-using System;
 using Foundatio.Caching;
+using Foundatio.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Foundatio.Tests.Caching;
-    public class ScopedCacheClientShouldDisposeTests : IDisposable
+    public class ScopedCacheClientShouldDisposeTests : TestWithLoggingBase
     {
-        private readonly ITestOutputHelper _output;
-
-        public ScopedCacheClientShouldDisposeTests(ITestOutputHelper output)
+        public ScopedCacheClientShouldDisposeTests(ITestOutputHelper output) : base(output)
         {
-            _output = output;
         }
 
         [Fact]
@@ -48,7 +45,7 @@ namespace Foundatio.Tests.Caching;
             var innerCache = new TrackableDisposableCacheClient();
 
             // Act
-            using (var scopedCache = new ScopedCacheClient(innerCache, "test", shouldDispose: true))
+            using (new ScopedCacheClient(innerCache, "test", shouldDispose: true))
             {
                 // No operations needed
             }
@@ -64,7 +61,7 @@ namespace Foundatio.Tests.Caching;
             var innerCache = new TrackableDisposableCacheClient();
 
             // Act
-            using (var scopedCache = new ScopedCacheClient(innerCache, "test", shouldDispose: false))
+            using (new ScopedCacheClient(innerCache, "test", shouldDispose: false))
             {
                 // No operations needed
             }
@@ -73,16 +70,11 @@ namespace Foundatio.Tests.Caching;
             Assert.False(innerCache.WasDisposed);
         }
 
-        public void Dispose()
-        {
-            // Cleanup if needed
-        }
-
         private class TrackableDisposableCacheClient : InMemoryCacheClient
         {
             public bool WasDisposed { get; private set; }
 
-            public new void Dispose()
+            public override void Dispose()
             {
                 WasDisposed = true;
                 base.Dispose();

--- a/tests/Foundatio.Tests/Caching/ScopedCacheClientShouldDisposeTests.cs
+++ b/tests/Foundatio.Tests/Caching/ScopedCacheClientShouldDisposeTests.cs
@@ -1,0 +1,91 @@
+using System;
+using Foundatio.Caching;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Foundatio.Tests.Caching;
+    public class ScopedCacheClientShouldDisposeTests : IDisposable
+    {
+        private readonly ITestOutputHelper _output;
+
+        public ScopedCacheClientShouldDisposeTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void Dispose_DefaultBehavior_DoesNotDisposeUnderlyingCache()
+        {
+            // Arrange
+            var innerCache = new TrackableDisposableCacheClient();
+            var scopedCache = new ScopedCacheClient(innerCache, "test");
+
+            // Act
+            scopedCache.Dispose();
+
+            // Assert
+            Assert.False(innerCache.WasDisposed);
+        }
+
+        [Fact]
+        public void Dispose_ShouldDisposeTrue_DisposesUnderlyingCache()
+        {
+            // Arrange
+            var innerCache = new TrackableDisposableCacheClient();
+            var scopedCache = new ScopedCacheClient(innerCache, "test", shouldDispose: true);
+
+            // Act
+            scopedCache.Dispose();
+
+            // Assert
+            Assert.True(innerCache.WasDisposed);
+        }
+
+        [Fact]
+        public void Dispose_WithUsingStatementAndShouldDisposeTrue_DisposesUnderlyingCache()
+        {
+            // Arrange
+            var innerCache = new TrackableDisposableCacheClient();
+
+            // Act
+            using (var scopedCache = new ScopedCacheClient(innerCache, "test", shouldDispose: true))
+            {
+                // No operations needed
+            }
+
+            // Assert
+            Assert.True(innerCache.WasDisposed);
+        }
+
+        [Fact]
+        public void Dispose_WithUsingStatementAndShouldDisposeFalse_DoesNotDisposeUnderlyingCache()
+        {
+            // Arrange
+            var innerCache = new TrackableDisposableCacheClient();
+
+            // Act
+            using (var scopedCache = new ScopedCacheClient(innerCache, "test", shouldDispose: false))
+            {
+                // No operations needed
+            }
+
+            // Assert
+            Assert.False(innerCache.WasDisposed);
+        }
+
+        public void Dispose()
+        {
+            // Cleanup if needed
+        }
+
+        private class TrackableDisposableCacheClient : InMemoryCacheClient
+        {
+            public bool WasDisposed { get; private set; }
+
+            public new void Dispose()
+            {
+                WasDisposed = true;
+                base.Dispose();
+            }
+        }
+    }

--- a/tests/Foundatio.Tests/Storage/ScopedFileStorageShouldDisposeTests.cs
+++ b/tests/Foundatio.Tests/Storage/ScopedFileStorageShouldDisposeTests.cs
@@ -1,16 +1,13 @@
-using System;
 using Foundatio.Storage;
+using Foundatio.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Foundatio.Tests.Storage;
-    public class ScopedFileStorageShouldDisposeTests : IDisposable
+    public class ScopedFileStorageShouldDisposeTests : TestWithLoggingBase
     {
-        private readonly ITestOutputHelper _output;
-
-        public ScopedFileStorageShouldDisposeTests(ITestOutputHelper output)
+        public ScopedFileStorageShouldDisposeTests(ITestOutputHelper output) : base(output)
         {
-            _output = output;
         }
 
         [Fact]
@@ -48,7 +45,7 @@ namespace Foundatio.Tests.Storage;
             var innerStorage = new TrackableDisposableFileStorage();
 
             // Act
-            using (var scopedStorage = new ScopedFileStorage(innerStorage, "test", shouldDispose: true))
+            using (new ScopedFileStorage(innerStorage, "test", shouldDispose: true))
             {
                 // No operations needed
             }
@@ -64,7 +61,7 @@ namespace Foundatio.Tests.Storage;
             var innerStorage = new TrackableDisposableFileStorage();
 
             // Act
-            using (var scopedStorage = new ScopedFileStorage(innerStorage, "test", shouldDispose: false))
+            using (new ScopedFileStorage(innerStorage, "test", shouldDispose: false))
             {
                 // No operations needed
             }
@@ -73,16 +70,11 @@ namespace Foundatio.Tests.Storage;
             Assert.False(innerStorage.WasDisposed);
         }
 
-        public void Dispose()
-        {
-            // Cleanup if needed
-        }
-
         private class TrackableDisposableFileStorage : InMemoryFileStorage
         {
             public bool WasDisposed { get; private set; }
 
-            public new void Dispose()
+            public override void Dispose()
             {
                 WasDisposed = true;
                 base.Dispose();

--- a/tests/Foundatio.Tests/Storage/ScopedFileStorageShouldDisposeTests.cs
+++ b/tests/Foundatio.Tests/Storage/ScopedFileStorageShouldDisposeTests.cs
@@ -1,0 +1,91 @@
+using System;
+using Foundatio.Storage;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Foundatio.Tests.Storage;
+    public class ScopedFileStorageShouldDisposeTests : IDisposable
+    {
+        private readonly ITestOutputHelper _output;
+
+        public ScopedFileStorageShouldDisposeTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void Dispose_DefaultBehavior_DoesNotDisposeUnderlyingStorage()
+        {
+            // Arrange
+            var innerStorage = new TrackableDisposableFileStorage();
+            var scopedStorage = new ScopedFileStorage(innerStorage, "test");
+
+            // Act
+            scopedStorage.Dispose();
+
+            // Assert
+            Assert.False(innerStorage.WasDisposed);
+        }
+
+        [Fact]
+        public void Dispose_ShouldDisposeTrue_DisposesUnderlyingStorage()
+        {
+            // Arrange
+            var innerStorage = new TrackableDisposableFileStorage();
+            var scopedStorage = new ScopedFileStorage(innerStorage, "test", shouldDispose: true);
+
+            // Act
+            scopedStorage.Dispose();
+
+            // Assert
+            Assert.True(innerStorage.WasDisposed);
+        }
+
+        [Fact]
+        public void Dispose_WithUsingStatementAndShouldDisposeTrue_DisposesUnderlyingStorage()
+        {
+            // Arrange
+            var innerStorage = new TrackableDisposableFileStorage();
+
+            // Act
+            using (var scopedStorage = new ScopedFileStorage(innerStorage, "test", shouldDispose: true))
+            {
+                // No operations needed
+            }
+
+            // Assert
+            Assert.True(innerStorage.WasDisposed);
+        }
+
+        [Fact]
+        public void Dispose_WithUsingStatementAndShouldDisposeFalse_DoesNotDisposeUnderlyingStorage()
+        {
+            // Arrange
+            var innerStorage = new TrackableDisposableFileStorage();
+
+            // Act
+            using (var scopedStorage = new ScopedFileStorage(innerStorage, "test", shouldDispose: false))
+            {
+                // No operations needed
+            }
+
+            // Assert
+            Assert.False(innerStorage.WasDisposed);
+        }
+
+        public void Dispose()
+        {
+            // Cleanup if needed
+        }
+
+        private class TrackableDisposableFileStorage : InMemoryFileStorage
+        {
+            public bool WasDisposed { get; private set; }
+
+            public new void Dispose()
+            {
+                WasDisposed = true;
+                base.Dispose();
+            }
+        }
+    }


### PR DESCRIPTION
Introduces a `shouldDispose` option to `ScopedCacheClient` and `ScopedFileStorage`.

This allows control over whether the underlying cache/storage client is disposed when the scoped client is disposed. By default, the underlying client is not disposed, preserving existing behavior.

Adds tests to verify the new disposal behavior.