### PR TITLE
Add QueueException and guard against reusing behavior instances

### DIFF
--- a/src/Foundatio/Queues/QueueBehaviour.cs
+++ b/src/Foundatio/Queues/QueueBehaviour.cs
@@ -16,6 +16,11 @@ public abstract class QueueBehaviorBase<T> : IQueueBehavior<T>, IDisposable wher
 
     public virtual void Attach(IQueue<T> queue)
     {
+        ArgumentNullException.ThrowIfNull(queue);
+
+        if (_queue is not null)
+            throw new QueueException("This behavior is already attached to a queue. Create a separate behavior instance for each queue.");
+
         _queue = queue;
 
         _disposables.Add(_queue.Enqueuing.AddHandler(OnEnqueuing));

--- a/src/Foundatio/Queues/QueueException.cs
+++ b/src/Foundatio/Queues/QueueException.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Foundatio.Queues;
+
+/// <summary>
+/// Exception thrown for queue operation errors.
+/// </summary>
+public class QueueException : Exception
+{
+    public QueueException(string message) : base(message)
+    {
+    }
+
+    public QueueException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/tests/Foundatio.Tests/Queue/InMemoryQueueTests.cs
+++ b/tests/Foundatio.Tests/Queue/InMemoryQueueTests.cs
@@ -330,6 +330,30 @@ public class InMemoryQueueTests : QueueTestBase
         Assert.True(behavior.QueueDeletedCalled);
     }
 
+    [Fact]
+    public void AttachBehavior_WhenAlreadyAttached_ThrowsQueueException()
+    {
+        // Arrange
+        using var q1 = new InMemoryQueue<SimpleWorkItem>(o => o.LoggerFactory(Log));
+        using var q2 = new InMemoryQueue<SimpleWorkItem>(o => o.LoggerFactory(Log));
+        var behavior = new QueueDeletedTestBehavior<SimpleWorkItem>();
+        q1.AttachBehavior(behavior);
+
+        // Act & Assert
+        var ex = Assert.Throws<QueueException>(() => q2.AttachBehavior(behavior));
+        Assert.Contains("already attached", ex.Message);
+    }
+
+    [Fact]
+    public void AttachBehavior_WithNullQueue_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var behavior = new QueueDeletedTestBehavior<SimpleWorkItem>();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => behavior.Attach(null));
+    }
+
     private class QueueDeletedTestBehavior<T> : QueueBehaviorBase<T> where T : class
     {
         public bool QueueDeletedCalled { get; private set; }


### PR DESCRIPTION
## Summary

- Add `QueueException` following the established pattern (`CacheException`, `StorageException`, `MessageBusException`) to provide a consistent exception type for queue-specific errors
- Add a guard in `QueueBehaviorBase<T>.Attach()` that throws `QueueException` if the behavior is already attached to a queue, preventing subtle bugs from duplicate event handler subscriptions or stale `_queue` references when reusing a single behavior instance across multiple queues
- Document behavior attachment rules and `QueueException` in `docs/guide/queues.md`

## Changes

| File | Description |
|------|-------------|
| `src/Foundatio/Queues/QueueException.cs` | New exception class with `message` and `message + innerException` constructors |
| `src/Foundatio/Queues/QueueBehaviour.cs` | `ArgumentNullException` guard + `QueueException` if already attached |
| `docs/guide/queues.md` | "Behavior Attachment Rules" subsection + "Queue Exceptions" section |
| `tests/.../InMemoryQueueTests.cs` | `AttachBehavior_WhenAlreadyAttached_ThrowsQueueException` and `AttachBehavior_WithNullQueue_ThrowsArgumentNullException` |

## Test plan

- [x] `AttachBehavior_WhenAlreadyAttached_ThrowsQueueException` — verifies the guard throws when reusing a behavior across two queues
- [x] `AttachBehavior_WithNullQueue_ThrowsArgumentNullException` — verifies null argument guard
- [x] Full test suite passes (1783 passed, 1 pre-existing flaky failure in `CanQueueAndDequeueMultipleWorkItemsAsync`)
