### PR TITLE
Add poison message handling for queue deserialization failures

### DIFF
--- a/src/Foundatio.TestHarness/Serializer/FaultInjectingSerializer.cs
+++ b/src/Foundatio.TestHarness/Serializer/FaultInjectingSerializer.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using Foundatio.Serializer;
+
+namespace Foundatio.Tests.Serializer;
+
+public class FaultInjectingSerializer : ISerializer
+{
+    private readonly ISerializer _inner;
+
+    public bool ShouldFailOnDeserialize { get; set; }
+    public bool ShouldFailOnSerialize { get; set; }
+
+    public FaultInjectingSerializer() : this(null)
+    {
+    }
+
+    public FaultInjectingSerializer(ISerializer inner)
+    {
+        _inner = inner ?? DefaultSerializer.Instance;
+    }
+
+    public object Deserialize(Stream data, Type objectType)
+    {
+        if (ShouldFailOnDeserialize)
+            throw new SerializerException("Simulated deserialization failure.");
+
+        return _inner.Deserialize(data, objectType);
+    }
+
+    public void Serialize(object value, Stream output)
+    {
+        if (ShouldFailOnSerialize)
+            throw new SerializerException("Simulated serialization failure.");
+
+        _inner.Serialize(value, output);
+    }
+}

--- a/src/Foundatio/Queues/QueueEntry.cs
+++ b/src/Foundatio/Queues/QueueEntry.cs
@@ -15,7 +15,7 @@ public class QueueEntry<T> : IQueueEntry<T>, IQueueEntryMetadata, IAsyncDisposab
         Id = id;
         CorrelationId = correlationId;
         _original = value;
-        Value = value.DeepClone();
+        Value = value?.DeepClone();
         _queue = queue;
         EnqueuedTimeUtc = enqueuedTimeUtc;
         Attempts = attempts;
@@ -27,7 +27,7 @@ public class QueueEntry<T> : IQueueEntry<T>, IQueueEntryMetadata, IAsyncDisposab
     public IDictionary<string, string> Properties { get; } = new Dictionary<string, string>();
     public bool IsCompleted { get; private set; }
     public bool IsAbandoned { get; private set; }
-    public Type EntryType => Value.GetType();
+    public Type EntryType => Value?.GetType();
     public object GetValue() => Value;
     public T Value { get; set; }
     public DateTime EnqueuedTimeUtc { get; set; }


### PR DESCRIPTION
## Summary

- When a message fails to deserialize during dequeue, it is now **abandoned through the normal retry flow** instead of crashing the consumer. This gives operators a window to fix transient serializer issues (e.g., missing JsonConverters) before messages are permanently dead-lettered.
- Adds **FaultInjectingSerializer** test infrastructure (implements ISerializer) for simulating serialization/deserialization failures in tests.
- Adds two new virtual test methods to **QueueTestBase**: DequeueAsync_WithPoisonMessage_MovesToDeadletterAsync and EnqueueAsync_WithSerializationError_ThrowsAndLeavesQueueEmptyAsync.
- Makes **QueueEntry** null-safe for poison message entries where deserialization yields null values.
- Documents the poison message handling flow in the **queues guide**.

## Poison Message Flow

Dequeue -> Deserialize fails -> Abandon (attempt incremented) -> Still has retries? -> Re-queued with backoff delay -> Retries exhausted? -> Moved to dead letter queue

## Changes

| File | Change |
|------|--------|
| docs/guide/queues.md | New section documenting poison message handling |
| src/Foundatio.TestHarness/Serializer/FaultInjectingSerializer.cs | New test serializer for injecting failures |
| src/Foundatio.TestHarness/Queue/QueueTestBase.cs | New virtual tests + ISerializer param on GetQueue |
| src/Foundatio/Queues/QueueEntry.cs | Null-safe Value handling |
| tests/Foundatio.Tests/Queue/InMemoryQueueTests.cs | Skip new tests (no serialization), remove #region |

## Provider implementations (separate repos)

Each provider repo has corresponding changes to wire up the poison message handling in their DequeueImplAsync:
- **Foundatio.Redis** - Catches deserialization errors, creates QueueEntry with null value, calls AbandonAsync
- **Foundatio.AzureStorage** - Catches deserialization errors, abandons with attempt tracking
- **Foundatio.AzureServiceBus** - Catches deserialization errors, abandons for retry
- **Foundatio.AWS** - Catches deserialization errors, abandons for retry

## Test plan

- [x] All 1799 tests pass in Foundatio.slnx (1786 succeeded, 13 skipped, 0 failed)
- [x] All provider repos build successfully with ReferenceFoundatioSource=true
- [x] InMemoryQueue tests skip serialization tests (InMemoryQueue does not use serialization)
- [ ] Run provider-specific tests against live services (Redis, Azure Storage, Azure Service Bus, SQS)

Made with [Cursor](https://cursor.com)