### PR TITLE
fix: implement two-phase dispose for MessageBus subscription lifecycle

### DIFF
--- a/docs/guide/messaging.md
+++ b/docs/guide/messaging.md
@@ -995,10 +995,10 @@ services.AddSingleton<IMessageBus, InMemoryMessageBus>();
 
 Disposal follows a **two-phase** sequence to prevent message loss in durable providers:
 
-1. **Graceful drain** — In-flight handlers finish executing while subscribers and the internal cancellation token are still active. Providers that support processor-level draining (e.g., Azure Service Bus `StopProcessingAsync`) execute it here.
-2. **Teardown** — The internal cancellation token is cancelled, all subscribers are cleared, and transport infrastructure (connections, channels, clients) is closed and disposed.
+1. **Graceful drain** — In-flight handlers finish executing while subscribers and the internal cancellation token are still active. Providers that support processor-level draining (e.g., Azure Service Bus `StopProcessingAsync`) execute it here via `ShutdownAsync`.
+2. **Teardown** — The internal cancellation token is cancelled, all subscribers are cleared, and transport infrastructure (connections, channels, clients) is closed and disposed via `CleanupAsync`.
 
-This means a call to `DisposeAsync()` will not return until currently executing subscriber callbacks have completed or timed out.
+> **Note:** The base `MessageBusBase` implementation does not guarantee that all active subscriber callbacks have completed before `DisposeAsync` returns. Provider-specific draining behavior (such as Azure Service Bus `StopProcessingAsync`) is implemented in provider overrides of `ShutdownAsync`.
 
 ### Message Durability During Shutdown
 

--- a/docs/guide/messaging.md
+++ b/docs/guide/messaging.md
@@ -1027,20 +1027,20 @@ If you are extending `MessageBusBase<TOptions>` with a custom provider, override
 ```csharp
 public class MyMessageBus : MessageBusBase<MyOptions>
 {
-    protected override async Task ShutdownAsync()
-    {
-        // Phase 1: Stop accepting new messages, drain in-flight work
-        await _processor.StopAsync();
-    }
+    // Phase 1: Stop accepting new messages, drain in-flight work.
+    // When the body is a single call, return the Task directly (no extra async state machine).
+    protected override Task ShutdownAsync() => _processor.StopAsync();
 
     protected override async Task CleanupAsync()
     {
-        // Phase 2: Close connections, dispose clients
-        await _connection.CloseAsync();
+        // Phase 2: Close connections, dispose clients — ConfigureAwait(false) in library overrides
+        await _connection.CloseAsync().ConfigureAwait(false);
         _client.Dispose();
     }
 }
 ```
+
+If `ShutdownAsync` needs multiple steps, use `async`/`await` and apply `.ConfigureAwait(false)` to each await (within Foundatio provider projects, the same pattern uses the internal `AnyContext()` helper).
 
 ## Next Steps
 

--- a/docs/guide/messaging.md
+++ b/docs/guide/messaging.md
@@ -7,7 +7,7 @@ Messaging allows you to publish and subscribe to messages flowing through your a
 [View source](https://github.com/FoundatioFx/Foundatio/blob/main/src/Foundatio/Messaging/IMessageBus.cs)
 
 ```csharp
-public interface IMessageBus : IMessagePublisher, IMessageSubscriber, IDisposable
+public interface IMessageBus : IMessagePublisher, IMessageSubscriber, IDisposable, IAsyncDisposable
 {
 }
 
@@ -979,23 +979,67 @@ await messageBus.SubscribeAsync<OrderCreated>(async order =>
 
 ## Resource Management
 
-### Proper Disposal
+### Disposal Lifecycle
 
-Message buses implement `IDisposable` and should be properly disposed:
+Message buses implement both `IDisposable` and `IAsyncDisposable`. Prefer `await using` (or `DisposeAsync()`) for clean shutdown:
 
 ```csharp
-// ✅ Good: DI container manages lifetime
-services.AddSingleton<IMessageBus, InMemoryMessageBus>();
-
-// ✅ Good: Manual disposal when needed
+// Preferred: async disposal
 await using var messageBus = new InMemoryMessageBus();
-await messageBus.SubscribeAsync<MyEvent>(async e => { });
-// Disposed when scope ends
+await messageBus.SubscribeAsync<MyEvent>(async e => { /* ... */ });
+// DisposeAsync is called when scope ends
 
-// ❌ Bad: Not disposing
-var messageBus = new InMemoryMessageBus();
-// ... use it
-// Never disposed, subscriptions leak
+// DI container manages lifetime automatically
+services.AddSingleton<IMessageBus, InMemoryMessageBus>();
+```
+
+Disposal follows a **two-phase** sequence to prevent message loss in durable providers:
+
+1. **Graceful drain** — In-flight handlers finish executing while subscribers and the internal cancellation token are still active. Providers that support processor-level draining (e.g., Azure Service Bus `StopProcessingAsync`) execute it here.
+2. **Teardown** — The internal cancellation token is cancelled, all subscribers are cleared, and transport infrastructure (connections, channels, clients) is closed and disposed.
+
+This means a call to `DisposeAsync()` will not return until currently executing subscriber callbacks have completed or timed out.
+
+### Message Durability During Shutdown
+
+What happens to messages that arrive while the bus is disposing depends on the provider:
+
+| Provider | In-Flight Messages | Arriving During Dispose | After Dispose |
+|---|---|---|---|
+| **InMemoryMessageBus** | Completed normally | Dropped (no persistence) | Lost |
+| **AzureServiceBusMessageBus** | Completed; abandoned if bus disposes mid-handler (PeekLock) | Remain in topic for other subscribers | Persisted in Azure |
+| **KafkaMessageBus** | Completed; offset not committed if bus disposes mid-handler | Remain in partition (uncommitted offset) | Persisted in Kafka |
+| **RabbitMQMessageBus** | Completed; requeued if bus disposes mid-handler | Remain in queue | Persisted in RabbitMQ |
+| **RedisMessageBus** | Completed normally | Dropped (pub/sub has no persistence) | Lost |
+| **SQSMessageBus** | Completed; message not deleted if bus disposes mid-handler | Remain in SQS queue | Persisted in SQS |
+
+::: tip Fire-and-Forget Providers
+`InMemoryMessageBus` and `RedisMessageBus` use fire-and-forget delivery. Messages that arrive when no subscriber is listening are permanently lost. This is by design — if you need guaranteed delivery, use a durable provider or `IQueue<T>`.
+:::
+
+### Writing Custom Providers
+
+If you are extending `MessageBusBase<TOptions>` with a custom provider, override the lifecycle hooks:
+
+- **`ShutdownAsync()`** — Called *before* the cancellation token is cancelled and *before* subscribers are cleared. Use this to gracefully drain your transport (e.g., stop a processor, close a consumer group). Subscribers are still active and can finish processing.
+- **`CleanupAsync()`** — Called *after* the cancellation token is cancelled and *after* subscribers are cleared. Use this to tear down transport infrastructure (close connections, dispose clients, await background tasks).
+
+```csharp
+public class MyMessageBus : MessageBusBase<MyOptions>
+{
+    protected override async Task ShutdownAsync()
+    {
+        // Phase 1: Stop accepting new messages, drain in-flight work
+        await _processor.StopAsync();
+    }
+
+    protected override async Task CleanupAsync()
+    {
+        // Phase 2: Close connections, dispose clients
+        await _connection.CloseAsync();
+        _client.Dispose();
+    }
+}
 ```
 
 ## Next Steps

--- a/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
+++ b/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
@@ -37,155 +37,126 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
 
     public virtual async Task CanUseMessageOptionsAsync()
     {
-        using var messageBus = GetMessageBus();
+        await using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
         using var metrics = new InMemoryMetrics(FoundatioDiagnostics.Meter.Name, _logger);
 
-        try
+        using var listener = new ActivityListener
         {
-            using var listener = new ActivityListener
-            {
-                ShouldListenTo = s => s.Name == FoundatioDiagnostics.ActivitySource.Name,
-                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-                ActivityStarted = activity => _logger.LogInformation("Start: {ActivityDisplayName}", activity.DisplayName),
-                ActivityStopped = activity => _logger.LogInformation("Stop: {ActivityDisplayName}", activity.DisplayName),
-            };
+            ShouldListenTo = s => s.Name == FoundatioDiagnostics.ActivitySource.Name,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStarted = activity => _logger.LogInformation("Start: {ActivityDisplayName}", activity.DisplayName),
+            ActivityStopped = activity => _logger.LogInformation("Stop: {ActivityDisplayName}", activity.DisplayName),
+        };
 
-            ActivitySource.AddActivityListener(listener);
+        ActivitySource.AddActivityListener(listener);
 
-            using var activity = FoundatioDiagnostics.ActivitySource.StartActivity("Parent");
-            Assert.NotNull(activity);
-            Assert.NotNull(Activity.Current);
-            Assert.Equal(Activity.Current, activity);
+        using var activity = FoundatioDiagnostics.ActivitySource.StartActivity("Parent");
+        Assert.NotNull(activity);
+        Assert.NotNull(Activity.Current);
+        Assert.Equal(Activity.Current, activity);
 
-            var countdown = new AsyncCountdownEvent(1);
-            await messageBus.SubscribeAsync<IMessage<SimpleMessageA>>(msg =>
-            {
-                _logger.LogTrace("Got message");
-
-                Assert.Equal("Hello", msg.Body.Data);
-                Assert.True(msg.Body.Items.ContainsKey("Test"));
-
-                Assert.Equal(activity.Id, msg.CorrelationId);
-                Assert.Equal(Activity.Current.ParentId, activity.Id);
-                Assert.Single(msg.Properties);
-                Assert.Contains(msg.Properties, i => i.Key == "hey" && i.Value.ToString() == "now");
-                countdown.Signal();
-                _logger.LogTrace("Set event");
-            });
-
-            await Task.Delay(1000);
-            await messageBus.PublishAsync(new SimpleMessageA
-            {
-                Data = "Hello",
-                Items = { { "Test", "Test" } }
-            }, new MessageOptions
-            {
-                Properties = new Dictionary<string, string>
-                {
-                    { "hey", "now" }
-                }
-            }, TestCancellationToken);
-            _logger.LogTrace("Published one...");
-
-            await countdown.WaitAsync(TimeSpan.FromSeconds(5));
-            Assert.Equal(0, countdown.CurrentCount);
-        }
-        finally
+        var countdown = new AsyncCountdownEvent(1);
+        await messageBus.SubscribeAsync<IMessage<SimpleMessageA>>(msg =>
         {
-            await CleanupMessageBusAsync(messageBus);
-        }
+            _logger.LogTrace("Got message");
+
+            Assert.Equal("Hello", msg.Body.Data);
+            Assert.True(msg.Body.Items.ContainsKey("Test"));
+
+            Assert.Equal(activity.Id, msg.CorrelationId);
+            Assert.Equal(Activity.Current.ParentId, activity.Id);
+            Assert.Single(msg.Properties);
+            Assert.Contains(msg.Properties, i => i.Key == "hey" && i.Value.ToString() == "now");
+            countdown.Signal();
+            _logger.LogTrace("Set event");
+        });
+
+        await Task.Delay(1000);
+        await messageBus.PublishAsync(new SimpleMessageA
+        {
+            Data = "Hello",
+            Items = { { "Test", "Test" } }
+        }, new MessageOptions
+        {
+            Properties = new Dictionary<string, string>
+            {
+                { "hey", "now" }
+            }
+        }, TestCancellationToken);
+        _logger.LogTrace("Published one...");
+
+        await countdown.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(0, countdown.CurrentCount);
     }
 
     public virtual async Task CanSendMessageAsync()
     {
-        using var messageBus = GetMessageBus();
+        await using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        try
+        var countdown = new AsyncCountdownEvent(1);
+        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
         {
-            var countdown = new AsyncCountdownEvent(1);
-            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-            {
-                _logger.LogTrace("Got message");
-                Assert.Equal("Hello", msg.Data);
-                Assert.True(msg.Items.ContainsKey("Test"));
-                countdown.Signal();
-                _logger.LogTrace("Set event");
-            }, TestCancellationToken);
+            _logger.LogTrace("Got message");
+            Assert.Equal("Hello", msg.Data);
+            Assert.True(msg.Items.ContainsKey("Test"));
+            countdown.Signal();
+            _logger.LogTrace("Set event");
+        }, TestCancellationToken);
 
-            await Task.Delay(100, TestCancellationToken);
-            await messageBus.PublishAsync(new SimpleMessageA
-            {
-                Data = "Hello",
-                Items = { { "Test", "Test" } }
-            }, cancellationToken: TestCancellationToken);
-            _logger.LogTrace("Published one...");
-
-            await countdown.WaitAsync(TimeSpan.FromSeconds(5));
-            Assert.Equal(0, countdown.CurrentCount);
-        }
-        finally
+        await Task.Delay(100, TestCancellationToken);
+        await messageBus.PublishAsync(new SimpleMessageA
         {
-            await CleanupMessageBusAsync(messageBus);
-        }
+            Data = "Hello",
+            Items = { { "Test", "Test" } }
+        }, cancellationToken: TestCancellationToken);
+        _logger.LogTrace("Published one...");
+
+        await countdown.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(0, countdown.CurrentCount);
     }
 
     public virtual async Task CanHandleNullMessageAsync()
     {
-        using var messageBus = GetMessageBus();
+        await using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        try
-        {
-            // Publishing null should throw ArgumentNullException
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await messageBus.PublishAsync<object>(null!));
-        }
-        finally
-        {
-            await CleanupMessageBusAsync(messageBus);
-        }
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await messageBus.PublishAsync<object>(null!));
     }
 
     public virtual async Task CanSendDerivedMessageAsync()
     {
-        using var messageBus = GetMessageBus();
+        await using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        try
+        var countdown = new AsyncCountdownEvent(1);
+        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
         {
-            var countdown = new AsyncCountdownEvent(1);
-            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-            {
-                _logger.LogTrace("Got message");
-                Assert.Equal("Hello", msg.Data);
-                countdown.Signal();
-                _logger.LogTrace("Set event");
-            }, TestCancellationToken);
+            _logger.LogTrace("Got message");
+            Assert.Equal("Hello", msg.Data);
+            countdown.Signal();
+            _logger.LogTrace("Set event");
+        }, TestCancellationToken);
 
-            await Task.Delay(100, TestCancellationToken);
-            await messageBus.PublishAsync(new DerivedSimpleMessageA
-            {
-                Data = "Hello"
-            });
-            _logger.LogTrace("Published one...");
-            await countdown.WaitAsync(TimeSpan.FromSeconds(5));
-            Assert.Equal(0, countdown.CurrentCount);
-        }
-        finally
+        await Task.Delay(100, TestCancellationToken);
+        await messageBus.PublishAsync(new DerivedSimpleMessageA
         {
-            await CleanupMessageBusAsync(messageBus);
-        }
+            Data = "Hello"
+        });
+        _logger.LogTrace("Published one...");
+        await countdown.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(0, countdown.CurrentCount);
     }
 
     public virtual async Task CanSendMappedMessageAsync()
     {
-        using var messageBus = GetMessageBus(b =>
+        await using var messageBus = GetMessageBus(b =>
         {
             b.MessageTypeMappings.Add(nameof(SimpleMessageA), typeof(SimpleMessageA));
             return b;
@@ -193,131 +164,110 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
         if (messageBus == null)
             return;
 
-        try
+        var countdown = new AsyncCountdownEvent(1);
+        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
         {
-            var countdown = new AsyncCountdownEvent(1);
-            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-            {
-                _logger.LogTrace("Got message");
-                Assert.Equal("Hello", msg.Data);
-                countdown.Signal();
-                _logger.LogTrace("Set event");
-            }, TestCancellationToken);
+            _logger.LogTrace("Got message");
+            Assert.Equal("Hello", msg.Data);
+            countdown.Signal();
+            _logger.LogTrace("Set event");
+        }, TestCancellationToken);
 
-            await Task.Delay(100, TestCancellationToken);
-            await messageBus.PublishAsync(new SimpleMessageA
-            {
-                Data = "Hello"
-            }, cancellationToken: TestCancellationToken);
-            _logger.LogTrace("Published one...");
-            await countdown.WaitAsync(TimeSpan.FromSeconds(5));
-            Assert.Equal(0, countdown.CurrentCount);
-        }
-        finally
+        await Task.Delay(100, TestCancellationToken);
+        await messageBus.PublishAsync(new SimpleMessageA
         {
-            await CleanupMessageBusAsync(messageBus);
-        }
+            Data = "Hello"
+        }, cancellationToken: TestCancellationToken);
+        _logger.LogTrace("Published one...");
+        await countdown.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(0, countdown.CurrentCount);
     }
 
     public virtual async Task CanSendDelayedMessageAsync()
     {
         const int numConcurrentMessages = 1000;
-        using var messageBus = GetMessageBus();
+        await using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        try
+        // Arrange
+        var countdown = new AsyncCountdownEvent(numConcurrentMessages);
+        int messages = 0;
+        int optionsVerifiedCount = 0;
+
+        await messageBus.SubscribeAsync<IMessage<SimpleMessageA>>(msg =>
         {
-            // Arrange
-            var countdown = new AsyncCountdownEvent(numConcurrentMessages);
-            int messages = 0;
-            int optionsVerifiedCount = 0;
+            Assert.Equal("Hello", msg.Body.Data);
 
-            await messageBus.SubscribeAsync<IMessage<SimpleMessageA>>(msg =>
+            // Verify options are preserved through delayed delivery
+            if (!String.IsNullOrEmpty(msg.CorrelationId) && msg.CorrelationId.StartsWith("correlation-"))
             {
-                Assert.Equal("Hello", msg.Body.Data);
+                Assert.True(msg.Properties.TryGetValue("TestKey", out var value));
+                Assert.Equal("TestValue", value);
+                Interlocked.Increment(ref optionsVerifiedCount);
+            }
 
-                // Verify options are preserved through delayed delivery
-                if (!String.IsNullOrEmpty(msg.CorrelationId) && msg.CorrelationId.StartsWith("correlation-"))
-                {
-                    Assert.True(msg.Properties.TryGetValue("TestKey", out var value));
-                    Assert.Equal("TestValue", value);
-                    Interlocked.Increment(ref optionsVerifiedCount);
-                }
+            if (Interlocked.Increment(ref messages) % 50 == 0)
+                _logger.LogTrace("Total Processed {Messages} messages", messages);
 
-                if (Interlocked.Increment(ref messages) % 50 == 0)
-                    _logger.LogTrace("Total Processed {Messages} messages", messages);
+            countdown.Signal();
+        });
 
-                countdown.Signal();
-            });
-
-            // Act
-            var sw = Stopwatch.StartNew();
-            await Parallel.ForEachAsync(Enumerable.Range(1, numConcurrentMessages), async (i, _) =>
-            {
-                await messageBus.PublishAsync(new SimpleMessageA
-                {
-                    Data = "Hello",
-                    Count = i
-                }, new MessageOptions
-                {
-                    DeliveryDelay = TimeSpan.FromMilliseconds(RandomData.GetInt(0, 100)),
-                    CorrelationId = $"correlation-{i}",
-                    Properties = new Dictionary<string, string> { { "TestKey", "TestValue" } }
-                }, TestCancellationToken);
-
-                if (i % 500 == 0)
-                    _logger.LogTrace("Published 500 messages...");
-            });
-
-            await countdown.WaitAsync(TimeSpan.FromSeconds(30));
-            sw.Stop();
-
-            // Assert
-            _logger.LogTrace("Processed {Processed} in {Duration:g}", numConcurrentMessages - countdown.CurrentCount, sw.Elapsed);
-            Assert.Equal(0, countdown.CurrentCount);
-            Assert.InRange(sw.Elapsed.TotalMilliseconds, 50, 30000);
-            Assert.Equal(numConcurrentMessages, optionsVerifiedCount);
-        }
-        finally
+        // Act
+        var sw = Stopwatch.StartNew();
+        await Parallel.ForEachAsync(Enumerable.Range(1, numConcurrentMessages), async (i, _) =>
         {
-            await CleanupMessageBusAsync(messageBus);
-        }
+            await messageBus.PublishAsync(new SimpleMessageA
+            {
+                Data = "Hello",
+                Count = i
+            }, new MessageOptions
+            {
+                DeliveryDelay = TimeSpan.FromMilliseconds(RandomData.GetInt(0, 100)),
+                CorrelationId = $"correlation-{i}",
+                Properties = new Dictionary<string, string> { { "TestKey", "TestValue" } }
+            }, TestCancellationToken);
+
+            if (i % 500 == 0)
+                _logger.LogTrace("Published 500 messages...");
+        });
+
+        await countdown.WaitAsync(TimeSpan.FromSeconds(30));
+        sw.Stop();
+
+        // Assert
+        _logger.LogTrace("Processed {Processed} in {Duration:g}", numConcurrentMessages - countdown.CurrentCount, sw.Elapsed);
+        Assert.Equal(0, countdown.CurrentCount);
+        Assert.InRange(sw.Elapsed.TotalMilliseconds, 50, 30000);
+        Assert.Equal(numConcurrentMessages, optionsVerifiedCount);
     }
 
     public virtual async Task CanSubscribeConcurrentlyAsync()
     {
         const int iterations = 100;
-        using var messageBus = GetMessageBus();
+        await using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        try
+        var countdown = new AsyncCountdownEvent(iterations * 10);
+        await Parallel.ForEachAsync(Enumerable.Range(1, 10), async (_, ct) =>
         {
-            var countdown = new AsyncCountdownEvent(iterations * 10);
-            await Parallel.ForEachAsync(Enumerable.Range(1, 10), async (_, ct) =>
+            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
             {
-                await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-                {
-                    Assert.Equal("Hello", msg.Data);
-                    countdown.Signal();
-                }, cancellationToken: ct);
-            });
+                Assert.Equal("Hello", msg.Data);
+                countdown.Signal();
+            }, cancellationToken: ct);
+        });
 
-            await Parallel.ForEachAsync(Enumerable.Range(1, iterations), async (_, _) => await messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken));
-            await countdown.WaitAsync(TimeSpan.FromSeconds(5));
-            Assert.Equal(0, countdown.CurrentCount);
-        }
-        finally
-        {
-            await CleanupMessageBusAsync(messageBus);
-        }
+        await Parallel.ForEachAsync(Enumerable.Range(1, iterations), async (_, _) => await messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken));
+        await countdown.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(0, countdown.CurrentCount);
     }
 
     public virtual async Task CanReceiveMessagesConcurrentlyAsync()
     {
         const int iterations = 100;
-        var messageBus = GetMessageBus();
+        await using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
@@ -374,513 +324,399 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
         finally
         {
             foreach (var mb in messageBuses)
-                await CleanupMessageBusAsync(mb);
-
-            await CleanupMessageBusAsync(messageBus);
+                await mb.DisposeAsync();
         }
     }
 
     public virtual async Task CanSendMessageToMultipleSubscribersAsync()
     {
-        using var messageBus = GetMessageBus();
+        await using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        try
+        var countdown = new AsyncCountdownEvent(3);
+        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
         {
-            var countdown = new AsyncCountdownEvent(3);
-            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-            {
-                Assert.Equal("Hello", msg.Data);
-                countdown.Signal();
-            }, TestCancellationToken);
-            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-            {
-                Assert.Equal("Hello", msg.Data);
-                countdown.Signal();
-            }, TestCancellationToken);
-            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-            {
-                Assert.Equal("Hello", msg.Data);
-                countdown.Signal();
-            }, TestCancellationToken);
-            await messageBus.PublishAsync(new SimpleMessageA
-            {
-                Data = "Hello"
-            }, cancellationToken: TestCancellationToken);
+            Assert.Equal("Hello", msg.Data);
+            countdown.Signal();
+        }, TestCancellationToken);
+        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+        {
+            Assert.Equal("Hello", msg.Data);
+            countdown.Signal();
+        }, TestCancellationToken);
+        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+        {
+            Assert.Equal("Hello", msg.Data);
+            countdown.Signal();
+        }, TestCancellationToken);
+        await messageBus.PublishAsync(new SimpleMessageA
+        {
+            Data = "Hello"
+        }, cancellationToken: TestCancellationToken);
 
-            await countdown.WaitAsync(TimeSpan.FromSeconds(2));
-            Assert.Equal(0, countdown.CurrentCount);
-        }
-        finally
-        {
-            await CleanupMessageBusAsync(messageBus);
-        }
+        await countdown.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(0, countdown.CurrentCount);
     }
 
     public virtual async Task CanTolerateSubscriberFailureAsync()
     {
-        using var messageBus = GetMessageBus();
+        await using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        try
+        var countdown = new AsyncCountdownEvent(4);
+        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
         {
-            var countdown = new AsyncCountdownEvent(4);
-            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-            {
-                Assert.Equal("Hello", msg.Data);
-                countdown.Signal();
-            }, TestCancellationToken);
-            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-            {
-                Assert.Equal("Hello", msg.Data);
-                countdown.Signal();
-            }, TestCancellationToken);
-            await messageBus.SubscribeAsync<SimpleMessageA>(msg => throw new Exception());
-            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-            {
-                Assert.Equal("Hello", msg.Data);
-                countdown.Signal();
-            }, TestCancellationToken);
-            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-            {
-                Assert.Equal("Hello", msg.Data);
-                countdown.Signal();
-            }, TestCancellationToken);
-            await messageBus.PublishAsync(new SimpleMessageA
-            {
-                Data = "Hello"
-            }, cancellationToken: TestCancellationToken);
+            Assert.Equal("Hello", msg.Data);
+            countdown.Signal();
+        }, TestCancellationToken);
+        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+        {
+            Assert.Equal("Hello", msg.Data);
+            countdown.Signal();
+        }, TestCancellationToken);
+        await messageBus.SubscribeAsync<SimpleMessageA>(msg => throw new Exception());
+        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+        {
+            Assert.Equal("Hello", msg.Data);
+            countdown.Signal();
+        }, TestCancellationToken);
+        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+        {
+            Assert.Equal("Hello", msg.Data);
+            countdown.Signal();
+        }, TestCancellationToken);
+        await messageBus.PublishAsync(new SimpleMessageA
+        {
+            Data = "Hello"
+        }, cancellationToken: TestCancellationToken);
 
-            await countdown.WaitAsync(TimeSpan.FromSeconds(2));
-            Assert.Equal(0, countdown.CurrentCount);
-        }
-        finally
-        {
-            await CleanupMessageBusAsync(messageBus);
-        }
+        await countdown.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(0, countdown.CurrentCount);
     }
 
     public virtual async Task WillOnlyReceiveSubscribedMessageTypeAsync()
     {
-        using var messageBus = GetMessageBus();
+        await using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        try
+        var countdown = new AsyncCountdownEvent(1);
+        await messageBus.SubscribeAsync<SimpleMessageB>(msg =>
         {
-            var countdown = new AsyncCountdownEvent(1);
-            await messageBus.SubscribeAsync<SimpleMessageB>(msg =>
-            {
-                Assert.Fail("Received wrong message type");
-            }, TestCancellationToken);
-            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-            {
-                Assert.Equal("Hello", msg.Data);
-                countdown.Signal();
-            }, TestCancellationToken);
-            await messageBus.PublishAsync(new SimpleMessageA
-            {
-                Data = "Hello"
-            }, cancellationToken: TestCancellationToken);
+            Assert.Fail("Received wrong message type");
+        }, TestCancellationToken);
+        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+        {
+            Assert.Equal("Hello", msg.Data);
+            countdown.Signal();
+        }, TestCancellationToken);
+        await messageBus.PublishAsync(new SimpleMessageA
+        {
+            Data = "Hello"
+        }, cancellationToken: TestCancellationToken);
 
-            await countdown.WaitAsync(TimeSpan.FromSeconds(2));
-            Assert.Equal(0, countdown.CurrentCount);
-        }
-        finally
-        {
-            await CleanupMessageBusAsync(messageBus);
-        }
+        await countdown.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(0, countdown.CurrentCount);
     }
 
     public virtual async Task WillReceiveDerivedMessageTypesAsync()
     {
-        using var messageBus = GetMessageBus();
+        await using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        try
+        var countdown = new AsyncCountdownEvent(2);
+        await messageBus.SubscribeAsync<ISimpleMessage>(msg =>
         {
-            var countdown = new AsyncCountdownEvent(2);
-            await messageBus.SubscribeAsync<ISimpleMessage>(msg =>
-            {
-                Assert.Equal("Hello", msg.Data);
-                countdown.Signal();
-            });
-            await messageBus.PublishAsync(new SimpleMessageA
-            {
-                Data = "Hello"
-            }, cancellationToken: TestCancellationToken);
-            await messageBus.PublishAsync(new SimpleMessageB
-            {
-                Data = "Hello"
-            }, cancellationToken: TestCancellationToken);
-            await messageBus.PublishAsync(new SimpleMessageC
-            {
-                Data = "Hello"
-            }, cancellationToken: TestCancellationToken);
+            Assert.Equal("Hello", msg.Data);
+            countdown.Signal();
+        });
+        await messageBus.PublishAsync(new SimpleMessageA
+        {
+            Data = "Hello"
+        }, cancellationToken: TestCancellationToken);
+        await messageBus.PublishAsync(new SimpleMessageB
+        {
+            Data = "Hello"
+        }, cancellationToken: TestCancellationToken);
+        await messageBus.PublishAsync(new SimpleMessageC
+        {
+            Data = "Hello"
+        }, cancellationToken: TestCancellationToken);
 
-            await countdown.WaitAsync(TimeSpan.FromSeconds(5));
-            Assert.Equal(0, countdown.CurrentCount);
-        }
-        finally
-        {
-            await CleanupMessageBusAsync(messageBus);
-        }
+        await countdown.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(0, countdown.CurrentCount);
     }
 
     public virtual async Task CanSubscribeToRawMessagesAsync()
     {
-        using var messageBus = GetMessageBus();
+        await using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        try
+        var countdown = new AsyncCountdownEvent(3);
+        await messageBus.SubscribeAsync(msg =>
         {
-            var countdown = new AsyncCountdownEvent(3);
-            await messageBus.SubscribeAsync(msg =>
-            {
-                Assert.NotNull(msg.Type);
-                Assert.True(msg.Type.Contains(nameof(SimpleMessageA))
-                            || msg.Type.Contains(nameof(SimpleMessageB))
-                            || msg.Type.Contains(nameof(SimpleMessageC)));
-                countdown.Signal();
-            });
-            await messageBus.PublishAsync(new SimpleMessageA
-            {
-                Data = "Hello"
-            }, cancellationToken: TestCancellationToken);
-            await messageBus.PublishAsync(new SimpleMessageB
-            {
-                Data = "Hello"
-            }, cancellationToken: TestCancellationToken);
-            await messageBus.PublishAsync(new SimpleMessageC
-            {
-                Data = "Hello"
-            }, cancellationToken: TestCancellationToken);
+            Assert.NotNull(msg.Type);
+            Assert.True(msg.Type.Contains(nameof(SimpleMessageA))
+                        || msg.Type.Contains(nameof(SimpleMessageB))
+                        || msg.Type.Contains(nameof(SimpleMessageC)));
+            countdown.Signal();
+        });
+        await messageBus.PublishAsync(new SimpleMessageA
+        {
+            Data = "Hello"
+        }, cancellationToken: TestCancellationToken);
+        await messageBus.PublishAsync(new SimpleMessageB
+        {
+            Data = "Hello"
+        }, cancellationToken: TestCancellationToken);
+        await messageBus.PublishAsync(new SimpleMessageC
+        {
+            Data = "Hello"
+        }, cancellationToken: TestCancellationToken);
 
-            await countdown.WaitAsync(TimeSpan.FromSeconds(5));
-            Assert.Equal(0, countdown.CurrentCount);
-        }
-        finally
-        {
-            await CleanupMessageBusAsync(messageBus);
-        }
+        await countdown.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(0, countdown.CurrentCount);
     }
 
     public virtual async Task CanSubscribeToAllMessageTypesAsync()
     {
-        using var messageBus = GetMessageBus();
+        await using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        try
+        var countdown = new AsyncCountdownEvent(3);
+        await messageBus.SubscribeAsync<object>(msg =>
         {
-            var countdown = new AsyncCountdownEvent(3);
-            await messageBus.SubscribeAsync<object>(msg =>
-            {
-                countdown.Signal();
-            }, TestCancellationToken);
-            await messageBus.PublishAsync(new SimpleMessageA
-            {
-                Data = "Hello"
-            }, cancellationToken: TestCancellationToken);
-            await messageBus.PublishAsync(new SimpleMessageB
-            {
-                Data = "Hello"
-            }, cancellationToken: TestCancellationToken);
-            await messageBus.PublishAsync(new SimpleMessageC
-            {
-                Data = "Hello"
-            }, cancellationToken: TestCancellationToken);
+            countdown.Signal();
+        }, TestCancellationToken);
+        await messageBus.PublishAsync(new SimpleMessageA
+        {
+            Data = "Hello"
+        }, cancellationToken: TestCancellationToken);
+        await messageBus.PublishAsync(new SimpleMessageB
+        {
+            Data = "Hello"
+        }, cancellationToken: TestCancellationToken);
+        await messageBus.PublishAsync(new SimpleMessageC
+        {
+            Data = "Hello"
+        }, cancellationToken: TestCancellationToken);
 
-            await countdown.WaitAsync(TimeSpan.FromSeconds(2));
-            Assert.Equal(0, countdown.CurrentCount);
-        }
-        finally
-        {
-            await CleanupMessageBusAsync(messageBus);
-        }
+        await countdown.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(0, countdown.CurrentCount);
     }
 
     public virtual async Task WontKeepMessagesWithNoSubscribersAsync()
     {
-        using var messageBus = GetMessageBus();
+        await using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        try
+        var countdown = new AsyncCountdownEvent(1);
+        await messageBus.PublishAsync(new SimpleMessageA
         {
-            var countdown = new AsyncCountdownEvent(1);
-            await messageBus.PublishAsync(new SimpleMessageA
-            {
-                Data = "Hello"
-            }, cancellationToken: TestCancellationToken);
+            Data = "Hello"
+        }, cancellationToken: TestCancellationToken);
 
-            await Task.Delay(100, TestCancellationToken);
-            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-            {
-                Assert.Equal("Hello", msg.Data);
-                countdown.Signal();
-            }, TestCancellationToken);
-
-            await Assert.ThrowsAsync<TimeoutException>(async () => await countdown.WaitAsync(TimeSpan.FromMilliseconds(100)));
-            Assert.Equal(1, countdown.CurrentCount);
-        }
-        finally
+        await Task.Delay(100, TestCancellationToken);
+        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
         {
-            await CleanupMessageBusAsync(messageBus);
-        }
+            Assert.Equal("Hello", msg.Data);
+            countdown.Signal();
+        }, TestCancellationToken);
+
+        await Assert.ThrowsAsync<TimeoutException>(async () => await countdown.WaitAsync(TimeSpan.FromMilliseconds(100)));
+        Assert.Equal(1, countdown.CurrentCount);
     }
 
     public virtual async Task CanCancelSubscriptionAsync()
     {
-        using var messageBus = GetMessageBus();
+        await using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        try
+        var countdown = new AsyncCountdownEvent(2);
+
+        long messageCount = 0;
+        using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(TestCancellationToken);
+        await messageBus.SubscribeAsync<SimpleMessageA>(async msg =>
         {
-            var countdown = new AsyncCountdownEvent(2);
+            _logger.LogTrace("SimpleAMessage received");
+            Interlocked.Increment(ref messageCount);
+            await cancellationTokenSource.CancelAsync();
+            countdown.Signal();
+        }, cancellationTokenSource.Token);
 
-            long messageCount = 0;
-            using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(TestCancellationToken);
-            await messageBus.SubscribeAsync<SimpleMessageA>(async msg =>
-            {
-                _logger.LogTrace("SimpleAMessage received");
-                Interlocked.Increment(ref messageCount);
-                await cancellationTokenSource.CancelAsync();
-                countdown.Signal();
-            }, cancellationTokenSource.Token);
-
-            // NOTE: This subscriber will not be canceled.
-            await messageBus.SubscribeAsync<object>(_ => countdown.Signal(), TestCancellationToken);
-            await messageBus.PublishAsync(new SimpleMessageA
-            {
-                Data = "Hello"
-            }, cancellationToken: TestCancellationToken);
-
-            await countdown.WaitAsync(TimeSpan.FromSeconds(2));
-            Assert.Equal(0, countdown.CurrentCount);
-            Assert.Equal(1, messageCount);
-
-            countdown.AddCount(1);
-            await messageBus.PublishAsync(new SimpleMessageA
-            {
-                Data = "Hello"
-            }, cancellationToken: TestCancellationToken);
-
-            await countdown.WaitAsync(TimeSpan.FromSeconds(2));
-            Assert.Equal(0, countdown.CurrentCount);
-            Assert.Equal(1, messageCount);
-        }
-        finally
+        // NOTE: This subscriber will not be canceled.
+        await messageBus.SubscribeAsync<object>(_ => countdown.Signal(), TestCancellationToken);
+        await messageBus.PublishAsync(new SimpleMessageA
         {
-            await CleanupMessageBusAsync(messageBus);
-        }
+            Data = "Hello"
+        }, cancellationToken: TestCancellationToken);
+
+        await countdown.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(0, countdown.CurrentCount);
+        Assert.Equal(1, messageCount);
+
+        countdown.AddCount(1);
+        await messageBus.PublishAsync(new SimpleMessageA
+        {
+            Data = "Hello"
+        }, cancellationToken: TestCancellationToken);
+
+        await countdown.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(0, countdown.CurrentCount);
+        Assert.Equal(1, messageCount);
     }
 
     public virtual async Task CanReceiveFromMultipleSubscribersAsync()
     {
-        using var messageBus1 = GetMessageBus();
+        await using var messageBus1 = GetMessageBus();
         if (messageBus1 == null)
             return;
 
-        try
+        var countdown1 = new AsyncCountdownEvent(1);
+        await messageBus1.SubscribeAsync<SimpleMessageA>(msg =>
         {
-            var countdown1 = new AsyncCountdownEvent(1);
-            await messageBus1.SubscribeAsync<SimpleMessageA>(msg =>
-            {
-                Assert.Equal("Hello", msg.Data);
-                countdown1.Signal();
-            }, TestCancellationToken);
+            Assert.Equal("Hello", msg.Data);
+            countdown1.Signal();
+        }, TestCancellationToken);
 
-            using var messageBus2 = GetMessageBus();
-            Assert.NotNull(messageBus2);
+        await using var messageBus2 = GetMessageBus();
+        Assert.NotNull(messageBus2);
 
-            try
-            {
-                var countdown2 = new AsyncCountdownEvent(1);
-                await messageBus2.SubscribeAsync<SimpleMessageA>(msg =>
-                {
-                    Assert.Equal("Hello", msg.Data);
-                    countdown2.Signal();
-                }, TestCancellationToken);
-
-                await messageBus1.PublishAsync(new SimpleMessageA
-                {
-                    Data = "Hello"
-                }, cancellationToken: TestCancellationToken);
-
-                await countdown1.WaitAsync(TimeSpan.FromSeconds(5));
-                Assert.Equal(0, countdown1.CurrentCount);
-                await countdown2.WaitAsync(TimeSpan.FromSeconds(5));
-                Assert.Equal(0, countdown2.CurrentCount);
-            }
-            finally
-            {
-                await CleanupMessageBusAsync(messageBus2);
-            }
-        }
-        finally
+        var countdown2 = new AsyncCountdownEvent(1);
+        await messageBus2.SubscribeAsync<SimpleMessageA>(msg =>
         {
-            await CleanupMessageBusAsync(messageBus1);
-        }
+            Assert.Equal("Hello", msg.Data);
+            countdown2.Signal();
+        }, TestCancellationToken);
+
+        await messageBus1.PublishAsync(new SimpleMessageA
+        {
+            Data = "Hello"
+        }, cancellationToken: TestCancellationToken);
+
+        await countdown1.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(0, countdown1.CurrentCount);
+        await countdown2.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(0, countdown2.CurrentCount);
     }
 
-    public virtual void CanDisposeWithNoSubscribersOrPublishers()
+    public virtual async Task CanDisposeWithNoSubscribersOrPublishersAsync()
     {
-        using var messageBus = GetMessageBus();
-        if (messageBus == null)
-            return;
-
-        using (messageBus)
-        {
-            // Empty using statement to ensure Dispose is called
-        }
+        await using var messageBus = GetMessageBus();
     }
 
     public virtual async Task CanHandlePoisonedMessageAsync()
     {
-        using var messageBus = GetMessageBus();
+        await using var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
 
         long handlerInvocations = 0;
 
-        try
+        await messageBus.SubscribeAsync<SimpleMessageA>(_ =>
         {
-            await messageBus.SubscribeAsync<SimpleMessageA>(_ =>
-            {
-                _logger.LogTrace("SimpleAMessage received");
-                Interlocked.Increment(ref handlerInvocations);
-                throw new Exception("Poisoned message");
-            });
+            _logger.LogTrace("SimpleAMessage received");
+            Interlocked.Increment(ref handlerInvocations);
+            throw new Exception("Poisoned message");
+        });
 
-            await messageBus.PublishAsync(new SimpleMessageA(), cancellationToken: TestCancellationToken);
-            _logger.LogTrace("Published one...");
+        await messageBus.PublishAsync(new SimpleMessageA(), cancellationToken: TestCancellationToken);
+        _logger.LogTrace("Published one...");
 
-            await Task.Delay(TimeSpan.FromSeconds(3));
-            Assert.InRange(handlerInvocations, 1, 5);
-        }
-        finally
-        {
-            await CleanupMessageBusAsync(messageBus);
-        }
+        await Task.Delay(TimeSpan.FromSeconds(3));
+        Assert.InRange(handlerInvocations, 1, 5);
     }
 
     public virtual async Task SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync()
     {
         // Arrange
         var faultSerializer = new FaultInjectingSerializer();
-        using var messageBus = GetMessageBus(o => { o.Serializer = faultSerializer; return o; });
+        await using var messageBus = GetMessageBus(o => { o.Serializer = faultSerializer; return o; });
         if (messageBus is null)
             return;
 
         long handlerInvocations = 0;
         var messageReceived = new AsyncAutoResetEvent(false);
 
-        try
+        await messageBus.SubscribeAsync<SimpleMessageA>(_ =>
         {
-            await messageBus.SubscribeAsync<SimpleMessageA>(_ =>
-            {
-                _logger.LogTrace("SimpleAMessage received");
-                Interlocked.Increment(ref handlerInvocations);
-                messageReceived.Set();
-            });
+            _logger.LogTrace("SimpleAMessage received");
+            Interlocked.Increment(ref handlerInvocations);
+            messageReceived.Set();
+        });
 
-            // Publish a valid message first (serializer works normally)
-            await messageBus.PublishAsync(new SimpleMessageA { Data = "valid" }, cancellationToken: TestCancellationToken);
-            await messageReceived.WaitAsync(TestCancellationToken);
-            Assert.Equal(1, handlerInvocations);
+        // Publish a valid message first (serializer works normally)
+        await messageBus.PublishAsync(new SimpleMessageA { Data = "valid" }, cancellationToken: TestCancellationToken);
+        await messageReceived.WaitAsync(TestCancellationToken);
+        Assert.Equal(1, handlerInvocations);
 
-            // Flip the flag so deserialization throws on the next message
-            faultSerializer.ShouldFailOnDeserialize = true;
+        // Flip the flag so deserialization throws on the next message
+        faultSerializer.ShouldFailOnDeserialize = true;
 
-            // Act: publish a message that will fail deserialization on receive
-            await messageBus.PublishAsync(new SimpleMessageA { Data = "poison" }, cancellationToken: TestCancellationToken);
+        // Act: publish a message that will fail deserialization on receive
+        await messageBus.PublishAsync(new SimpleMessageA { Data = "poison" }, cancellationToken: TestCancellationToken);
 
-            // Wait a reasonable time for the message to be processed (or skipped)
-            await Task.Delay(TimeSpan.FromSeconds(2), TestCancellationToken);
+        // Wait a reasonable time for the message to be processed (or skipped)
+        await Task.Delay(TimeSpan.FromSeconds(2), TestCancellationToken);
 
-            // Assert: handler should still have been invoked only once (for the valid message)
-            Assert.Equal(1, handlerInvocations);
-        }
-        finally
-        {
-            await CleanupMessageBusAsync(messageBus);
-        }
+        // Assert: handler should still have been invoked only once (for the valid message)
+        Assert.Equal(1, handlerInvocations);
     }
 
     public virtual async Task PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync()
     {
         // Arrange
         var faultSerializer = new FaultInjectingSerializer { ShouldFailOnSerialize = true };
-        using var messageBus = GetMessageBus(o => { o.Serializer = faultSerializer; return o; });
+        await using var messageBus = GetMessageBus(o => { o.Serializer = faultSerializer; return o; });
         if (messageBus is null)
             return;
 
-        try
-        {
-            await messageBus.SubscribeAsync<SimpleMessageA>(_ => { });
+        await messageBus.SubscribeAsync<SimpleMessageA>(_ => { });
 
-            // Act & Assert: publishing with a broken serializer should throw
-            await Assert.ThrowsAsync<MessageBusException>(async () =>
-                await messageBus.PublishAsync(new SimpleMessageA { Data = "test" }, cancellationToken: TestCancellationToken));
-        }
-        finally
-        {
-            await CleanupMessageBusAsync(messageBus);
-        }
+        // Act & Assert: publishing with a broken serializer should throw
+        await Assert.ThrowsAsync<MessageBusException>(async () =>
+            await messageBus.PublishAsync(new SimpleMessageA { Data = "test" }, cancellationToken: TestCancellationToken));
     }
 
     public virtual async Task SubscribeAsync_WithDeserializationFailure_SkipsMessageAsync()
     {
         // Arrange
         var faultSerializer = new FaultInjectingSerializer { ShouldFailOnDeserialize = true };
-        using var messageBus = GetMessageBus(o => { o.Serializer = faultSerializer; return o; });
+        await using var messageBus = GetMessageBus(o => { o.Serializer = faultSerializer; return o; });
         if (messageBus is null)
             return;
 
         long handlerInvocations = 0;
 
-        try
+        await messageBus.SubscribeAsync<SimpleMessageA>(_ =>
         {
-            await messageBus.SubscribeAsync<SimpleMessageA>(_ =>
-            {
-                Interlocked.Increment(ref handlerInvocations);
-            });
+            Interlocked.Increment(ref handlerInvocations);
+        });
 
-            // Act: publish a message that will fail deserialization on receive
-            await messageBus.PublishAsync(new SimpleMessageA { Data = "poison" }, cancellationToken: TestCancellationToken);
-            await Task.Delay(TimeSpan.FromSeconds(2), TestCancellationToken);
+        // Act: publish a message that will fail deserialization on receive
+        await messageBus.PublishAsync(new SimpleMessageA { Data = "poison" }, cancellationToken: TestCancellationToken);
+        await Task.Delay(TimeSpan.FromSeconds(2), TestCancellationToken);
 
-            // Assert: handler should never be invoked for a poisoned message
-            Assert.Equal(0, handlerInvocations);
-        }
-        finally
-        {
-            await CleanupMessageBusAsync(messageBus);
-        }
+        // Assert: handler should never be invoked for a poisoned message
+        Assert.Equal(0, handlerInvocations);
     }
 
     public virtual async Task PublishAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
     {
-        using var messageBus = GetMessageBus();
+        await using var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
 
-        try
-        {
-            // Act & Assert - cancelled token should throw OperationCanceledException, not MessageBusException
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
-                await messageBus.PublishAsync(new SimpleMessageA(), cancellationToken: new CancellationToken(true)));
-        }
-        finally
-        {
-            await CleanupMessageBusAsync(messageBus);
-        }
+        // Act & Assert - cancelled token should throw OperationCanceledException, not MessageBusException
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await messageBus.PublishAsync(new SimpleMessageA(), cancellationToken: new CancellationToken(true)));
     }
 
     public virtual async Task PublishAsync_WithDelayedMessageAndDisposeBeforeDelivery_DiscardsMessageAsync()
@@ -923,20 +759,13 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
 
     public virtual async Task SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
     {
-        using var messageBus = GetMessageBus();
+        await using var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
 
-        try
-        {
-            // Act & Assert - cancelled token should throw OperationCanceledException
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
-                await messageBus.SubscribeAsync<SimpleMessageA>(_ => { }, cancellationToken: new CancellationToken(true)));
-        }
-        finally
-        {
-            await CleanupMessageBusAsync(messageBus);
-        }
+        // Act & Assert - cancelled token should throw OperationCanceledException
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await messageBus.SubscribeAsync<SimpleMessageA>(_ => { }, cancellationToken: new CancellationToken(true)));
     }
 
     public virtual async Task DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync()
@@ -968,42 +797,35 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
     public virtual async Task SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync()
     {
         // Arrange
-        using var messageBus = GetMessageBus();
+        await using var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
 
-        try
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestCancellationToken);
+        var countdown = new AsyncCountdownEvent(1);
+
+        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
         {
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestCancellationToken);
-            var countdown = new AsyncCountdownEvent(1);
+            Assert.Equal("Hello", msg.Data);
+            countdown.Signal();
+        }, cts.Token);
 
-            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-            {
-                Assert.Equal("Hello", msg.Data);
-                countdown.Signal();
-            }, cts.Token);
+        // Act - cancel the subscription
+        await cts.CancelAsync();
+        await Task.Delay(100, TestCancellationToken);
 
-            // Act - cancel the subscription
-            await cts.CancelAsync();
-            await Task.Delay(100, TestCancellationToken);
-
-            // Subscribe again with a fresh token
-            var countdown2 = new AsyncCountdownEvent(1);
-            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-            {
-                Assert.Equal("Hello", msg.Data);
-                countdown2.Signal();
-            }, TestCancellationToken);
-
-            // Assert - new subscriber receives messages (infrastructure was not torn down)
-            await messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken);
-            await countdown2.WaitAsync(TimeSpan.FromSeconds(5));
-            Assert.Equal(0, countdown2.CurrentCount);
-        }
-        finally
+        // Subscribe again with a fresh token
+        var countdown2 = new AsyncCountdownEvent(1);
+        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
         {
-            await CleanupMessageBusAsync(messageBus);
-        }
+            Assert.Equal("Hello", msg.Data);
+            countdown2.Signal();
+        }, TestCancellationToken);
+
+        // Assert - new subscriber receives messages (infrastructure was not torn down)
+        await messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken);
+        await countdown2.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(0, countdown2.CurrentCount);
     }
 
     public virtual async Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()

--- a/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
+++ b/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
@@ -271,61 +271,53 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
         if (messageBus == null)
             return;
 
-        var messageBuses = new List<IMessageBus>(10);
-        try
+        await using var extraBuses = new MessageBusCollectionDisposable(CleanupMessageBusAsync);
+        var countdown = new AsyncCountdownEvent(iterations * 10);
+        await Parallel.ForEachAsync(Enumerable.Range(1, 10), async (_, ct) =>
         {
-            var countdown = new AsyncCountdownEvent(iterations * 10);
-            await Parallel.ForEachAsync(Enumerable.Range(1, 10), async (_, ct) =>
+            var bus = GetMessageBus();
+            Assert.NotNull(bus);
+            await bus.SubscribeAsync<SimpleMessageA>(msg =>
             {
-                var bus = GetMessageBus();
-                Assert.NotNull(bus);
-                await bus.SubscribeAsync<SimpleMessageA>(msg =>
-                {
-                    Assert.Equal("Hello", msg.Data);
-                    countdown.Signal();
-                }, cancellationToken: ct);
+                Assert.Equal("Hello", msg.Data);
+                countdown.Signal();
+            }, cancellationToken: ct);
 
-                messageBuses.Add(bus);
-            });
+            extraBuses.Add(bus);
+        });
 
-            var subscribe = Parallel.ForEachAsync(Enumerable.Range(1, iterations), async (i, ct) =>
-            {
-                await Task.Delay(RandomData.GetInt(0, 10), ct);
-                var randomBus = messageBuses.Random();
-                Assert.NotNull(randomBus);
-                await randomBus.SubscribeAsync<NeverPublishedMessage>(msg => Task.CompletedTask, cancellationToken: ct);
-            });
-
-            var publish = Parallel.ForEachAsync(Enumerable.Range(1, iterations + 3), async (i, _) =>
-            {
-                await (i switch
-                {
-                    1 => messageBus.PublishAsync(new DerivedSimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                    2 => messageBus.PublishAsync(new Derived2SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                    3 => messageBus.PublishAsync(new Derived3SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                    4 => messageBus.PublishAsync(new Derived4SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                    5 => messageBus.PublishAsync(new Derived5SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                    6 => messageBus.PublishAsync(new Derived6SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                    7 => messageBus.PublishAsync(new Derived7SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                    8 => messageBus.PublishAsync(new Derived8SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                    9 => messageBus.PublishAsync(new Derived9SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                    10 => messageBus.PublishAsync(new Derived10SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                    iterations + 1 => messageBus.PublishAsync(new { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                    iterations + 2 => messageBus.PublishAsync(new SimpleMessageC { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                    iterations + 3 => messageBus.PublishAsync(new SimpleMessageB { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                    _ => messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken)
-                });
-            });
-
-            await Task.WhenAll(subscribe, publish);
-            await countdown.WaitAsync(TimeSpan.FromSeconds(4));
-            Assert.Equal(0, countdown.CurrentCount);
-        }
-        finally
+        var subscribe = Parallel.ForEachAsync(Enumerable.Range(1, iterations), async (i, ct) =>
         {
-            foreach (var mb in messageBuses)
-                await mb.DisposeAsync();
-        }
+            await Task.Delay(RandomData.GetInt(0, 10), ct);
+            var randomBus = extraBuses.GetRandomBus();
+            Assert.NotNull(randomBus);
+            await randomBus.SubscribeAsync<NeverPublishedMessage>(msg => Task.CompletedTask, cancellationToken: ct);
+        });
+
+        var publish = Parallel.ForEachAsync(Enumerable.Range(1, iterations + 3), async (i, _) =>
+        {
+            await (i switch
+            {
+                1 => messageBus.PublishAsync(new DerivedSimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                2 => messageBus.PublishAsync(new Derived2SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                3 => messageBus.PublishAsync(new Derived3SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                4 => messageBus.PublishAsync(new Derived4SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                5 => messageBus.PublishAsync(new Derived5SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                6 => messageBus.PublishAsync(new Derived6SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                7 => messageBus.PublishAsync(new Derived7SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                8 => messageBus.PublishAsync(new Derived8SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                9 => messageBus.PublishAsync(new Derived9SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                10 => messageBus.PublishAsync(new Derived10SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                iterations + 1 => messageBus.PublishAsync(new { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                iterations + 2 => messageBus.PublishAsync(new SimpleMessageC { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                iterations + 3 => messageBus.PublishAsync(new SimpleMessageB { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                _ => messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken)
+            });
+        });
+
+        await Task.WhenAll(subscribe, publish);
+        await countdown.WaitAsync(TimeSpan.FromSeconds(4));
+        Assert.Equal(0, countdown.CurrentCount);
     }
 
     public virtual async Task CanSendMessageToMultipleSubscribersAsync()
@@ -721,9 +713,8 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
 
     public virtual async Task PublishAsync_WithDelayedMessageAndDisposeBeforeDelivery_DiscardsMessageAsync()
     {
-        // Arrange
         var messageReceived = new AsyncAutoResetEvent(false);
-        var messageBus = GetMessageBus();
+        IMessageBus? messageBus = GetMessageBus();
         if (messageBus is null)
             return;
 
@@ -735,7 +726,6 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
                 messageReceived.Set();
             }, TestCancellationToken);
 
-            // Act - publish with short delay, then dispose immediately before delay expires
             await messageBus.PublishAsync(new SimpleMessageA
             {
                 Data = "ShouldBeDiscarded"
@@ -743,9 +733,8 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
 
             _logger.LogTrace("Published delayed message, disposing immediately...");
             messageBus.Dispose();
-            messageBus = null; // Mark as disposed to skip cleanup
+            messageBus = null;
 
-            // Assert - wait slightly longer than the delay; message should NOT be delivered
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestCancellationToken);
             cts.CancelAfter(TimeSpan.FromMilliseconds(250));
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => messageReceived.WaitAsync(cts.Token));
@@ -768,17 +757,6 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
             await messageBus.SubscribeAsync<SimpleMessageA>(_ => { }, cancellationToken: new CancellationToken(true)));
     }
 
-    public virtual async Task DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync()
-    {
-        // Arrange
-        var messageBus = GetMessageBus();
-        if (messageBus is null)
-            return;
-
-        // Act & Assert
-        await messageBus.DisposeAsync();
-    }
-
     public virtual async Task DisposeAsync_CalledMultipleTimes_IsIdempotentAsync()
     {
         // Arrange
@@ -792,6 +770,68 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
         await messageBus.DisposeAsync();
 
         // Assert - no exception thrown
+    }
+
+    public virtual async Task DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync()
+    {
+        // Arrange
+        var messageBus = GetMessageBus();
+        if (messageBus is null)
+            return;
+
+        var subscriberStarted = new AsyncAutoResetEvent(false);
+
+        await messageBus.SubscribeAsync<SimpleMessageA>(async msg =>
+        {
+            subscriberStarted.Set();
+            await Task.Delay(500, TestCancellationToken);
+        });
+
+        // Act - publish a message, then dispose while the subscriber is still processing
+        _ = messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken);
+        await subscriberStarted.WaitAsync(TestCancellationToken);
+
+        // Assert - dispose completes without deadlock (the test itself will timeout if it deadlocks)
+        await messageBus.DisposeAsync();
+    }
+
+    public virtual async Task DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync()
+    {
+        // Arrange
+        var messageBus = GetMessageBus();
+        if (messageBus is null)
+            return;
+
+        // Act & Assert
+        await messageBus.DisposeAsync();
+    }
+
+    public virtual async Task PublishAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+    {
+        // Arrange
+        var messageBus = GetMessageBus();
+        if (messageBus is null)
+            return;
+
+        await messageBus.DisposeAsync();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<MessageBusException>(async () =>
+            await messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }));
+    }
+
+    public virtual async Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+    {
+        // Arrange
+        var messageBus = GetMessageBus();
+        if (messageBus is null)
+            return;
+
+        await messageBus.DisposeAsync();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<MessageBusException>(async () =>
+            await messageBus.SubscribeAsync<SimpleMessageA>(_ => { }));
     }
 
     public virtual async Task SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync()
@@ -827,55 +867,35 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
         await countdown2.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.Equal(0, countdown2.CurrentCount);
     }
+}
 
-    public virtual async Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+/// <summary>
+/// Owns additional <see cref="IMessageBus"/> instances created during a test (e.g. concurrent scenarios).
+/// Disposal order is the reverse of <see cref="IAsyncDisposable"/> / <c>await using</c> — this type is
+/// typically declared after the primary bus so extra instances are disposed first.
+/// </summary>
+public sealed class MessageBusCollectionDisposable : IAsyncDisposable
+{
+    private readonly List<IMessageBus> _buses = new();
+    private readonly Func<IMessageBus, Task>? _cleanupAsync;
+
+    public MessageBusCollectionDisposable(Func<IMessageBus, Task>? cleanupAsync = null)
     {
-        // Arrange
-        var messageBus = GetMessageBus();
-        if (messageBus is null)
-            return;
-
-        await messageBus.DisposeAsync();
-
-        // Act & Assert
-        await Assert.ThrowsAsync<MessageBusException>(async () =>
-            await messageBus.SubscribeAsync<SimpleMessageA>(_ => { }));
+        _cleanupAsync = cleanupAsync;
     }
 
-    public virtual async Task PublishAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+    public void Add(IMessageBus bus) => _buses.Add(bus);
+
+    public IMessageBus GetRandomBus() => _buses[RandomData.GetInt(0, _buses.Count - 1)];
+
+    public async ValueTask DisposeAsync()
     {
-        // Arrange
-        var messageBus = GetMessageBus();
-        if (messageBus is null)
-            return;
-
-        await messageBus.DisposeAsync();
-
-        // Act & Assert
-        await Assert.ThrowsAsync<MessageBusException>(async () =>
-            await messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }));
-    }
-
-    public virtual async Task DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync()
-    {
-        // Arrange
-        var messageBus = GetMessageBus();
-        if (messageBus is null)
-            return;
-
-        var subscriberStarted = new AsyncAutoResetEvent(false);
-
-        await messageBus.SubscribeAsync<SimpleMessageA>(async msg =>
+        foreach (var mb in _buses)
         {
-            subscriberStarted.Set();
-            await Task.Delay(500, TestCancellationToken);
-        });
-
-        // Act - publish a message, then dispose while the subscriber is still processing
-        _ = messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken);
-        await subscriberStarted.WaitAsync(TestCancellationToken);
-
-        // Assert - dispose completes without deadlock (the test itself will timeout if it deadlocks)
-        await messageBus.DisposeAsync();
+            if (_cleanupAsync is not null)
+                await _cleanupAsync(mb);
+            else
+                await mb.DisposeAsync();
+        }
     }
 }

--- a/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
+++ b/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
@@ -731,18 +731,11 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
 
     public virtual async Task CanDisposeWithNoSubscribersOrPublishersAsync()
     {
-        var messageBus = GetMessageBus();
+        await using var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
 
-        try
-        {
-            await messageBus.DisposeAsync();
-        }
-        finally
-        {
-            await CleanupMessageBusAsync(messageBus);
-        }
+        await CleanupMessageBusAsync(messageBus);
     }
 
     public virtual async Task CanHandlePoisonedMessageAsync()

--- a/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
+++ b/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
@@ -731,9 +731,14 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
 
     public virtual async Task CanDisposeWithNoSubscribersOrPublishersAsync()
     {
-        await using var messageBus = GetMessageBus();
+        using var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
+
+        using (messageBus)
+        {
+            // Empty using statement to ensure Dispose is called
+        }
 
         await CleanupMessageBusAsync(messageBus);
     }

--- a/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
+++ b/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
@@ -939,4 +939,121 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
         }
     }
 
+    public virtual async Task DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync()
+    {
+        // Arrange
+        var messageBus = GetMessageBus();
+        if (messageBus is null)
+            return;
+
+        // Act & Assert
+        await messageBus.DisposeAsync();
+    }
+
+    public virtual async Task DisposeAsync_CalledMultipleTimes_IsIdempotentAsync()
+    {
+        // Arrange
+        var messageBus = GetMessageBus();
+        if (messageBus is null)
+            return;
+
+        // Act
+        await messageBus.DisposeAsync();
+        await messageBus.DisposeAsync();
+        await messageBus.DisposeAsync();
+
+        // Assert - no exception thrown
+    }
+
+    public virtual async Task SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync()
+    {
+        // Arrange
+        using var messageBus = GetMessageBus();
+        if (messageBus is null)
+            return;
+
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestCancellationToken);
+            var countdown = new AsyncCountdownEvent(1);
+
+            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            {
+                Assert.Equal("Hello", msg.Data);
+                countdown.Signal();
+            }, cts.Token);
+
+            // Act - cancel the subscription
+            await cts.CancelAsync();
+            await Task.Delay(100, TestCancellationToken);
+
+            // Subscribe again with a fresh token
+            var countdown2 = new AsyncCountdownEvent(1);
+            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            {
+                Assert.Equal("Hello", msg.Data);
+                countdown2.Signal();
+            }, TestCancellationToken);
+
+            // Assert - new subscriber receives messages (infrastructure was not torn down)
+            await messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken);
+            await countdown2.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(0, countdown2.CurrentCount);
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
+        }
+    }
+
+    public virtual async Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+    {
+        // Arrange
+        var messageBus = GetMessageBus();
+        if (messageBus is null)
+            return;
+
+        await messageBus.DisposeAsync();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<MessageBusException>(async () =>
+            await messageBus.SubscribeAsync<SimpleMessageA>(_ => { }));
+    }
+
+    public virtual async Task PublishAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+    {
+        // Arrange
+        var messageBus = GetMessageBus();
+        if (messageBus is null)
+            return;
+
+        await messageBus.DisposeAsync();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<MessageBusException>(async () =>
+            await messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }));
+    }
+
+    public virtual async Task DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync()
+    {
+        // Arrange
+        var messageBus = GetMessageBus();
+        if (messageBus is null)
+            return;
+
+        var subscriberStarted = new AsyncAutoResetEvent(false);
+
+        await messageBus.SubscribeAsync<SimpleMessageA>(async msg =>
+        {
+            subscriberStarted.Set();
+            await Task.Delay(500, TestCancellationToken);
+        });
+
+        // Act - publish a message, then dispose while the subscriber is still processing
+        _ = messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken);
+        await subscriberStarted.WaitAsync(TestCancellationToken);
+
+        // Assert - dispose completes without deadlock (the test itself will timeout if it deadlocks)
+        await messageBus.DisposeAsync();
+    }
 }

--- a/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
+++ b/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
@@ -37,126 +37,155 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
 
     public virtual async Task CanUseMessageOptionsAsync()
     {
-        await using var messageBus = GetMessageBus();
+        using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
         using var metrics = new InMemoryMetrics(FoundatioDiagnostics.Meter.Name, _logger);
 
-        using var listener = new ActivityListener
+        try
         {
-            ShouldListenTo = s => s.Name == FoundatioDiagnostics.ActivitySource.Name,
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-            ActivityStarted = activity => _logger.LogInformation("Start: {ActivityDisplayName}", activity.DisplayName),
-            ActivityStopped = activity => _logger.LogInformation("Stop: {ActivityDisplayName}", activity.DisplayName),
-        };
-
-        ActivitySource.AddActivityListener(listener);
-
-        using var activity = FoundatioDiagnostics.ActivitySource.StartActivity("Parent");
-        Assert.NotNull(activity);
-        Assert.NotNull(Activity.Current);
-        Assert.Equal(Activity.Current, activity);
-
-        var countdown = new AsyncCountdownEvent(1);
-        await messageBus.SubscribeAsync<IMessage<SimpleMessageA>>(msg =>
-        {
-            _logger.LogTrace("Got message");
-
-            Assert.Equal("Hello", msg.Body.Data);
-            Assert.True(msg.Body.Items.ContainsKey("Test"));
-
-            Assert.Equal(activity.Id, msg.CorrelationId);
-            Assert.Equal(Activity.Current.ParentId, activity.Id);
-            Assert.Single(msg.Properties);
-            Assert.Contains(msg.Properties, i => i.Key == "hey" && i.Value.ToString() == "now");
-            countdown.Signal();
-            _logger.LogTrace("Set event");
-        });
-
-        await Task.Delay(1000);
-        await messageBus.PublishAsync(new SimpleMessageA
-        {
-            Data = "Hello",
-            Items = { { "Test", "Test" } }
-        }, new MessageOptions
-        {
-            Properties = new Dictionary<string, string>
+            using var listener = new ActivityListener
             {
-                { "hey", "now" }
-            }
-        }, TestCancellationToken);
-        _logger.LogTrace("Published one...");
+                ShouldListenTo = s => s.Name == FoundatioDiagnostics.ActivitySource.Name,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStarted = activity => _logger.LogInformation("Start: {ActivityDisplayName}", activity.DisplayName),
+                ActivityStopped = activity => _logger.LogInformation("Stop: {ActivityDisplayName}", activity.DisplayName),
+            };
 
-        await countdown.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.Equal(0, countdown.CurrentCount);
+            ActivitySource.AddActivityListener(listener);
+
+            using var activity = FoundatioDiagnostics.ActivitySource.StartActivity("Parent");
+            Assert.NotNull(activity);
+            Assert.NotNull(Activity.Current);
+            Assert.Equal(Activity.Current, activity);
+
+            var countdown = new AsyncCountdownEvent(1);
+            await messageBus.SubscribeAsync<IMessage<SimpleMessageA>>(msg =>
+            {
+                _logger.LogTrace("Got message");
+
+                Assert.Equal("Hello", msg.Body.Data);
+                Assert.True(msg.Body.Items.ContainsKey("Test"));
+
+                Assert.Equal(activity.Id, msg.CorrelationId);
+                Assert.Equal(Activity.Current.ParentId, activity.Id);
+                Assert.Single(msg.Properties);
+                Assert.Contains(msg.Properties, i => i.Key == "hey" && i.Value.ToString() == "now");
+                countdown.Signal();
+                _logger.LogTrace("Set event");
+            });
+
+            await Task.Delay(1000);
+            await messageBus.PublishAsync(new SimpleMessageA
+            {
+                Data = "Hello",
+                Items = { { "Test", "Test" } }
+            }, new MessageOptions
+            {
+                Properties = new Dictionary<string, string>
+                {
+                    { "hey", "now" }
+                }
+            }, TestCancellationToken);
+            _logger.LogTrace("Published one...");
+
+            await countdown.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(0, countdown.CurrentCount);
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task CanSendMessageAsync()
     {
-        await using var messageBus = GetMessageBus();
+        using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        var countdown = new AsyncCountdownEvent(1);
-        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+        try
         {
-            _logger.LogTrace("Got message");
-            Assert.Equal("Hello", msg.Data);
-            Assert.True(msg.Items.ContainsKey("Test"));
-            countdown.Signal();
-            _logger.LogTrace("Set event");
-        }, TestCancellationToken);
+            var countdown = new AsyncCountdownEvent(1);
+            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            {
+                _logger.LogTrace("Got message");
+                Assert.Equal("Hello", msg.Data);
+                Assert.True(msg.Items.ContainsKey("Test"));
+                countdown.Signal();
+                _logger.LogTrace("Set event");
+            }, TestCancellationToken);
 
-        await Task.Delay(100, TestCancellationToken);
-        await messageBus.PublishAsync(new SimpleMessageA
+            await Task.Delay(100, TestCancellationToken);
+            await messageBus.PublishAsync(new SimpleMessageA
+            {
+                Data = "Hello",
+                Items = { { "Test", "Test" } }
+            }, cancellationToken: TestCancellationToken);
+            _logger.LogTrace("Published one...");
+
+            await countdown.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(0, countdown.CurrentCount);
+        }
+        finally
         {
-            Data = "Hello",
-            Items = { { "Test", "Test" } }
-        }, cancellationToken: TestCancellationToken);
-        _logger.LogTrace("Published one...");
-
-        await countdown.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.Equal(0, countdown.CurrentCount);
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task CanHandleNullMessageAsync()
     {
-        await using var messageBus = GetMessageBus();
+        using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await messageBus.PublishAsync<object>(null!));
+        try
+        {
+            // Publishing null should throw ArgumentNullException
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await messageBus.PublishAsync<object>(null!));
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task CanSendDerivedMessageAsync()
     {
-        await using var messageBus = GetMessageBus();
+        using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        var countdown = new AsyncCountdownEvent(1);
-        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+        try
         {
-            _logger.LogTrace("Got message");
-            Assert.Equal("Hello", msg.Data);
-            countdown.Signal();
-            _logger.LogTrace("Set event");
-        }, TestCancellationToken);
+            var countdown = new AsyncCountdownEvent(1);
+            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            {
+                _logger.LogTrace("Got message");
+                Assert.Equal("Hello", msg.Data);
+                countdown.Signal();
+                _logger.LogTrace("Set event");
+            }, TestCancellationToken);
 
-        await Task.Delay(100, TestCancellationToken);
-        await messageBus.PublishAsync(new DerivedSimpleMessageA
+            await Task.Delay(100, TestCancellationToken);
+            await messageBus.PublishAsync(new DerivedSimpleMessageA
+            {
+                Data = "Hello"
+            });
+            _logger.LogTrace("Published one...");
+            await countdown.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(0, countdown.CurrentCount);
+        }
+        finally
         {
-            Data = "Hello"
-        });
-        _logger.LogTrace("Published one...");
-        await countdown.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.Equal(0, countdown.CurrentCount);
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task CanSendMappedMessageAsync()
     {
-        await using var messageBus = GetMessageBus(b =>
+        using var messageBus = GetMessageBus(b =>
         {
             b.MessageTypeMappings.Add(nameof(SimpleMessageA), typeof(SimpleMessageA));
             return b;
@@ -164,617 +193,591 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
         if (messageBus == null)
             return;
 
-        var countdown = new AsyncCountdownEvent(1);
-        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+        try
         {
-            _logger.LogTrace("Got message");
-            Assert.Equal("Hello", msg.Data);
-            countdown.Signal();
-            _logger.LogTrace("Set event");
-        }, TestCancellationToken);
+            var countdown = new AsyncCountdownEvent(1);
+            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            {
+                _logger.LogTrace("Got message");
+                Assert.Equal("Hello", msg.Data);
+                countdown.Signal();
+                _logger.LogTrace("Set event");
+            }, TestCancellationToken);
 
-        await Task.Delay(100, TestCancellationToken);
-        await messageBus.PublishAsync(new SimpleMessageA
+            await Task.Delay(100, TestCancellationToken);
+            await messageBus.PublishAsync(new SimpleMessageA
+            {
+                Data = "Hello"
+            }, cancellationToken: TestCancellationToken);
+            _logger.LogTrace("Published one...");
+            await countdown.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(0, countdown.CurrentCount);
+        }
+        finally
         {
-            Data = "Hello"
-        }, cancellationToken: TestCancellationToken);
-        _logger.LogTrace("Published one...");
-        await countdown.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.Equal(0, countdown.CurrentCount);
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task CanSendDelayedMessageAsync()
     {
         const int numConcurrentMessages = 1000;
-        await using var messageBus = GetMessageBus();
+        using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        // Arrange
-        var countdown = new AsyncCountdownEvent(numConcurrentMessages);
-        int messages = 0;
-        int optionsVerifiedCount = 0;
-
-        await messageBus.SubscribeAsync<IMessage<SimpleMessageA>>(msg =>
+        try
         {
-            Assert.Equal("Hello", msg.Body.Data);
+            // Arrange
+            var countdown = new AsyncCountdownEvent(numConcurrentMessages);
+            int messages = 0;
+            int optionsVerifiedCount = 0;
 
-            // Verify options are preserved through delayed delivery
-            if (!String.IsNullOrEmpty(msg.CorrelationId) && msg.CorrelationId.StartsWith("correlation-"))
+            await messageBus.SubscribeAsync<IMessage<SimpleMessageA>>(msg =>
             {
-                Assert.True(msg.Properties.TryGetValue("TestKey", out var value));
-                Assert.Equal("TestValue", value);
-                Interlocked.Increment(ref optionsVerifiedCount);
-            }
+                Assert.Equal("Hello", msg.Body.Data);
 
-            if (Interlocked.Increment(ref messages) % 50 == 0)
-                _logger.LogTrace("Total Processed {Messages} messages", messages);
+                // Verify options are preserved through delayed delivery
+                if (!String.IsNullOrEmpty(msg.CorrelationId) && msg.CorrelationId.StartsWith("correlation-"))
+                {
+                    Assert.True(msg.Properties.TryGetValue("TestKey", out var value));
+                    Assert.Equal("TestValue", value);
+                    Interlocked.Increment(ref optionsVerifiedCount);
+                }
 
-            countdown.Signal();
-        });
+                if (Interlocked.Increment(ref messages) % 50 == 0)
+                    _logger.LogTrace("Total Processed {Messages} messages", messages);
 
-        // Act
-        var sw = Stopwatch.StartNew();
-        await Parallel.ForEachAsync(Enumerable.Range(1, numConcurrentMessages), async (i, _) =>
+                countdown.Signal();
+            });
+
+            // Act
+            var sw = Stopwatch.StartNew();
+            await Parallel.ForEachAsync(Enumerable.Range(1, numConcurrentMessages), async (i, _) =>
+            {
+                await messageBus.PublishAsync(new SimpleMessageA
+                {
+                    Data = "Hello",
+                    Count = i
+                }, new MessageOptions
+                {
+                    DeliveryDelay = TimeSpan.FromMilliseconds(RandomData.GetInt(0, 100)),
+                    CorrelationId = $"correlation-{i}",
+                    Properties = new Dictionary<string, string> { { "TestKey", "TestValue" } }
+                }, TestCancellationToken);
+
+                if (i % 500 == 0)
+                    _logger.LogTrace("Published 500 messages...");
+            });
+
+            await countdown.WaitAsync(TimeSpan.FromSeconds(30));
+            sw.Stop();
+
+            // Assert
+            _logger.LogTrace("Processed {Processed} in {Duration:g}", numConcurrentMessages - countdown.CurrentCount, sw.Elapsed);
+            Assert.Equal(0, countdown.CurrentCount);
+            Assert.InRange(sw.Elapsed.TotalMilliseconds, 50, 30000);
+            Assert.Equal(numConcurrentMessages, optionsVerifiedCount);
+        }
+        finally
         {
-            await messageBus.PublishAsync(new SimpleMessageA
-            {
-                Data = "Hello",
-                Count = i
-            }, new MessageOptions
-            {
-                DeliveryDelay = TimeSpan.FromMilliseconds(RandomData.GetInt(0, 100)),
-                CorrelationId = $"correlation-{i}",
-                Properties = new Dictionary<string, string> { { "TestKey", "TestValue" } }
-            }, TestCancellationToken);
-
-            if (i % 500 == 0)
-                _logger.LogTrace("Published 500 messages...");
-        });
-
-        await countdown.WaitAsync(TimeSpan.FromSeconds(30));
-        sw.Stop();
-
-        // Assert
-        _logger.LogTrace("Processed {Processed} in {Duration:g}", numConcurrentMessages - countdown.CurrentCount, sw.Elapsed);
-        Assert.Equal(0, countdown.CurrentCount);
-        Assert.InRange(sw.Elapsed.TotalMilliseconds, 50, 30000);
-        Assert.Equal(numConcurrentMessages, optionsVerifiedCount);
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task CanSubscribeConcurrentlyAsync()
     {
         const int iterations = 100;
-        await using var messageBus = GetMessageBus();
+        using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        var countdown = new AsyncCountdownEvent(iterations * 10);
-        await Parallel.ForEachAsync(Enumerable.Range(1, 10), async (_, ct) =>
+        try
         {
-            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            var countdown = new AsyncCountdownEvent(iterations * 10);
+            await Parallel.ForEachAsync(Enumerable.Range(1, 10), async (_, ct) =>
             {
-                Assert.Equal("Hello", msg.Data);
-                countdown.Signal();
-            }, cancellationToken: ct);
-        });
+                await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+                {
+                    Assert.Equal("Hello", msg.Data);
+                    countdown.Signal();
+                }, cancellationToken: ct);
+            });
 
-        await Parallel.ForEachAsync(Enumerable.Range(1, iterations), async (_, _) => await messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken));
-        await countdown.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.Equal(0, countdown.CurrentCount);
+            await Parallel.ForEachAsync(Enumerable.Range(1, iterations), async (_, _) => await messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken));
+            await countdown.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(0, countdown.CurrentCount);
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task CanReceiveMessagesConcurrentlyAsync()
     {
         const int iterations = 100;
-        await using var messageBus = GetMessageBus();
+        var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        await using var extraBuses = new MessageBusCollectionDisposable(CleanupMessageBusAsync);
-        var countdown = new AsyncCountdownEvent(iterations * 10);
-        await Parallel.ForEachAsync(Enumerable.Range(1, 10), async (_, ct) =>
+        var messageBuses = new List<IMessageBus>(10);
+        try
         {
-            var bus = GetMessageBus();
-            Assert.NotNull(bus);
-            await bus.SubscribeAsync<SimpleMessageA>(msg =>
+            var countdown = new AsyncCountdownEvent(iterations * 10);
+            await Parallel.ForEachAsync(Enumerable.Range(1, 10), async (_, ct) =>
             {
-                Assert.Equal("Hello", msg.Data);
-                countdown.Signal();
-            }, cancellationToken: ct);
+                var bus = GetMessageBus();
+                Assert.NotNull(bus);
+                await bus.SubscribeAsync<SimpleMessageA>(msg =>
+                {
+                    Assert.Equal("Hello", msg.Data);
+                    countdown.Signal();
+                }, cancellationToken: ct);
 
-            extraBuses.Add(bus);
-        });
-
-        var subscribe = Parallel.ForEachAsync(Enumerable.Range(1, iterations), async (i, ct) =>
-        {
-            await Task.Delay(RandomData.GetInt(0, 10), ct);
-            var randomBus = extraBuses.GetRandomBus();
-            Assert.NotNull(randomBus);
-            await randomBus.SubscribeAsync<NeverPublishedMessage>(msg => Task.CompletedTask, cancellationToken: ct);
-        });
-
-        var publish = Parallel.ForEachAsync(Enumerable.Range(1, iterations + 3), async (i, _) =>
-        {
-            await (i switch
-            {
-                1 => messageBus.PublishAsync(new DerivedSimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                2 => messageBus.PublishAsync(new Derived2SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                3 => messageBus.PublishAsync(new Derived3SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                4 => messageBus.PublishAsync(new Derived4SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                5 => messageBus.PublishAsync(new Derived5SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                6 => messageBus.PublishAsync(new Derived6SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                7 => messageBus.PublishAsync(new Derived7SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                8 => messageBus.PublishAsync(new Derived8SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                9 => messageBus.PublishAsync(new Derived9SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                10 => messageBus.PublishAsync(new Derived10SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                iterations + 1 => messageBus.PublishAsync(new { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                iterations + 2 => messageBus.PublishAsync(new SimpleMessageC { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                iterations + 3 => messageBus.PublishAsync(new SimpleMessageB { Data = "Hello" }, cancellationToken: TestCancellationToken),
-                _ => messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken)
+                messageBuses.Add(bus);
             });
-        });
 
-        await Task.WhenAll(subscribe, publish);
-        await countdown.WaitAsync(TimeSpan.FromSeconds(4));
-        Assert.Equal(0, countdown.CurrentCount);
+            var subscribe = Parallel.ForEachAsync(Enumerable.Range(1, iterations), async (i, ct) =>
+            {
+                await Task.Delay(RandomData.GetInt(0, 10), ct);
+                var randomBus = messageBuses.Random();
+                Assert.NotNull(randomBus);
+                await randomBus.SubscribeAsync<NeverPublishedMessage>(msg => Task.CompletedTask, cancellationToken: ct);
+            });
+
+            var publish = Parallel.ForEachAsync(Enumerable.Range(1, iterations + 3), async (i, _) =>
+            {
+                await (i switch
+                {
+                    1 => messageBus.PublishAsync(new DerivedSimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                    2 => messageBus.PublishAsync(new Derived2SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                    3 => messageBus.PublishAsync(new Derived3SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                    4 => messageBus.PublishAsync(new Derived4SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                    5 => messageBus.PublishAsync(new Derived5SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                    6 => messageBus.PublishAsync(new Derived6SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                    7 => messageBus.PublishAsync(new Derived7SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                    8 => messageBus.PublishAsync(new Derived8SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                    9 => messageBus.PublishAsync(new Derived9SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                    10 => messageBus.PublishAsync(new Derived10SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                    iterations + 1 => messageBus.PublishAsync(new { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                    iterations + 2 => messageBus.PublishAsync(new SimpleMessageC { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                    iterations + 3 => messageBus.PublishAsync(new SimpleMessageB { Data = "Hello" }, cancellationToken: TestCancellationToken),
+                    _ => messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken)
+                });
+            });
+
+            await Task.WhenAll(subscribe, publish);
+            await countdown.WaitAsync(TimeSpan.FromSeconds(4));
+            Assert.Equal(0, countdown.CurrentCount);
+        }
+        finally
+        {
+            foreach (var mb in messageBuses)
+                await CleanupMessageBusAsync(mb);
+
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task CanSendMessageToMultipleSubscribersAsync()
     {
-        await using var messageBus = GetMessageBus();
+        using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        var countdown = new AsyncCountdownEvent(3);
-        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+        try
         {
-            Assert.Equal("Hello", msg.Data);
-            countdown.Signal();
-        }, TestCancellationToken);
-        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-        {
-            Assert.Equal("Hello", msg.Data);
-            countdown.Signal();
-        }, TestCancellationToken);
-        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-        {
-            Assert.Equal("Hello", msg.Data);
-            countdown.Signal();
-        }, TestCancellationToken);
-        await messageBus.PublishAsync(new SimpleMessageA
-        {
-            Data = "Hello"
-        }, cancellationToken: TestCancellationToken);
+            var countdown = new AsyncCountdownEvent(3);
+            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            {
+                Assert.Equal("Hello", msg.Data);
+                countdown.Signal();
+            }, TestCancellationToken);
+            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            {
+                Assert.Equal("Hello", msg.Data);
+                countdown.Signal();
+            }, TestCancellationToken);
+            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            {
+                Assert.Equal("Hello", msg.Data);
+                countdown.Signal();
+            }, TestCancellationToken);
+            await messageBus.PublishAsync(new SimpleMessageA
+            {
+                Data = "Hello"
+            }, cancellationToken: TestCancellationToken);
 
-        await countdown.WaitAsync(TimeSpan.FromSeconds(2));
-        Assert.Equal(0, countdown.CurrentCount);
+            await countdown.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.Equal(0, countdown.CurrentCount);
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task CanTolerateSubscriberFailureAsync()
     {
-        await using var messageBus = GetMessageBus();
+        using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        var countdown = new AsyncCountdownEvent(4);
-        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+        try
         {
-            Assert.Equal("Hello", msg.Data);
-            countdown.Signal();
-        }, TestCancellationToken);
-        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-        {
-            Assert.Equal("Hello", msg.Data);
-            countdown.Signal();
-        }, TestCancellationToken);
-        await messageBus.SubscribeAsync<SimpleMessageA>(msg => throw new Exception());
-        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-        {
-            Assert.Equal("Hello", msg.Data);
-            countdown.Signal();
-        }, TestCancellationToken);
-        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-        {
-            Assert.Equal("Hello", msg.Data);
-            countdown.Signal();
-        }, TestCancellationToken);
-        await messageBus.PublishAsync(new SimpleMessageA
-        {
-            Data = "Hello"
-        }, cancellationToken: TestCancellationToken);
+            var countdown = new AsyncCountdownEvent(4);
+            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            {
+                Assert.Equal("Hello", msg.Data);
+                countdown.Signal();
+            }, TestCancellationToken);
+            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            {
+                Assert.Equal("Hello", msg.Data);
+                countdown.Signal();
+            }, TestCancellationToken);
+            await messageBus.SubscribeAsync<SimpleMessageA>(msg => throw new Exception());
+            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            {
+                Assert.Equal("Hello", msg.Data);
+                countdown.Signal();
+            }, TestCancellationToken);
+            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            {
+                Assert.Equal("Hello", msg.Data);
+                countdown.Signal();
+            }, TestCancellationToken);
+            await messageBus.PublishAsync(new SimpleMessageA
+            {
+                Data = "Hello"
+            }, cancellationToken: TestCancellationToken);
 
-        await countdown.WaitAsync(TimeSpan.FromSeconds(2));
-        Assert.Equal(0, countdown.CurrentCount);
+            await countdown.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.Equal(0, countdown.CurrentCount);
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task WillOnlyReceiveSubscribedMessageTypeAsync()
     {
-        await using var messageBus = GetMessageBus();
+        using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        var countdown = new AsyncCountdownEvent(1);
-        await messageBus.SubscribeAsync<SimpleMessageB>(msg =>
+        try
         {
-            Assert.Fail("Received wrong message type");
-        }, TestCancellationToken);
-        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
-        {
-            Assert.Equal("Hello", msg.Data);
-            countdown.Signal();
-        }, TestCancellationToken);
-        await messageBus.PublishAsync(new SimpleMessageA
-        {
-            Data = "Hello"
-        }, cancellationToken: TestCancellationToken);
+            var countdown = new AsyncCountdownEvent(1);
+            await messageBus.SubscribeAsync<SimpleMessageB>(msg =>
+            {
+                Assert.Fail("Received wrong message type");
+            }, TestCancellationToken);
+            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            {
+                Assert.Equal("Hello", msg.Data);
+                countdown.Signal();
+            }, TestCancellationToken);
+            await messageBus.PublishAsync(new SimpleMessageA
+            {
+                Data = "Hello"
+            }, cancellationToken: TestCancellationToken);
 
-        await countdown.WaitAsync(TimeSpan.FromSeconds(2));
-        Assert.Equal(0, countdown.CurrentCount);
+            await countdown.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.Equal(0, countdown.CurrentCount);
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task WillReceiveDerivedMessageTypesAsync()
     {
-        await using var messageBus = GetMessageBus();
+        using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        var countdown = new AsyncCountdownEvent(2);
-        await messageBus.SubscribeAsync<ISimpleMessage>(msg =>
+        try
         {
-            Assert.Equal("Hello", msg.Data);
-            countdown.Signal();
-        });
-        await messageBus.PublishAsync(new SimpleMessageA
-        {
-            Data = "Hello"
-        }, cancellationToken: TestCancellationToken);
-        await messageBus.PublishAsync(new SimpleMessageB
-        {
-            Data = "Hello"
-        }, cancellationToken: TestCancellationToken);
-        await messageBus.PublishAsync(new SimpleMessageC
-        {
-            Data = "Hello"
-        }, cancellationToken: TestCancellationToken);
+            var countdown = new AsyncCountdownEvent(2);
+            await messageBus.SubscribeAsync<ISimpleMessage>(msg =>
+            {
+                Assert.Equal("Hello", msg.Data);
+                countdown.Signal();
+            });
+            await messageBus.PublishAsync(new SimpleMessageA
+            {
+                Data = "Hello"
+            }, cancellationToken: TestCancellationToken);
+            await messageBus.PublishAsync(new SimpleMessageB
+            {
+                Data = "Hello"
+            }, cancellationToken: TestCancellationToken);
+            await messageBus.PublishAsync(new SimpleMessageC
+            {
+                Data = "Hello"
+            }, cancellationToken: TestCancellationToken);
 
-        await countdown.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.Equal(0, countdown.CurrentCount);
+            await countdown.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(0, countdown.CurrentCount);
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task CanSubscribeToRawMessagesAsync()
     {
-        await using var messageBus = GetMessageBus();
+        using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        var countdown = new AsyncCountdownEvent(3);
-        await messageBus.SubscribeAsync(msg =>
+        try
         {
-            Assert.NotNull(msg.Type);
-            Assert.True(msg.Type.Contains(nameof(SimpleMessageA))
-                        || msg.Type.Contains(nameof(SimpleMessageB))
-                        || msg.Type.Contains(nameof(SimpleMessageC)));
-            countdown.Signal();
-        });
-        await messageBus.PublishAsync(new SimpleMessageA
-        {
-            Data = "Hello"
-        }, cancellationToken: TestCancellationToken);
-        await messageBus.PublishAsync(new SimpleMessageB
-        {
-            Data = "Hello"
-        }, cancellationToken: TestCancellationToken);
-        await messageBus.PublishAsync(new SimpleMessageC
-        {
-            Data = "Hello"
-        }, cancellationToken: TestCancellationToken);
+            var countdown = new AsyncCountdownEvent(3);
+            await messageBus.SubscribeAsync(msg =>
+            {
+                Assert.NotNull(msg.Type);
+                Assert.True(msg.Type.Contains(nameof(SimpleMessageA))
+                            || msg.Type.Contains(nameof(SimpleMessageB))
+                            || msg.Type.Contains(nameof(SimpleMessageC)));
+                countdown.Signal();
+            });
+            await messageBus.PublishAsync(new SimpleMessageA
+            {
+                Data = "Hello"
+            }, cancellationToken: TestCancellationToken);
+            await messageBus.PublishAsync(new SimpleMessageB
+            {
+                Data = "Hello"
+            }, cancellationToken: TestCancellationToken);
+            await messageBus.PublishAsync(new SimpleMessageC
+            {
+                Data = "Hello"
+            }, cancellationToken: TestCancellationToken);
 
-        await countdown.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.Equal(0, countdown.CurrentCount);
+            await countdown.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(0, countdown.CurrentCount);
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task CanSubscribeToAllMessageTypesAsync()
     {
-        await using var messageBus = GetMessageBus();
+        using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        var countdown = new AsyncCountdownEvent(3);
-        await messageBus.SubscribeAsync<object>(msg =>
+        try
         {
-            countdown.Signal();
-        }, TestCancellationToken);
-        await messageBus.PublishAsync(new SimpleMessageA
-        {
-            Data = "Hello"
-        }, cancellationToken: TestCancellationToken);
-        await messageBus.PublishAsync(new SimpleMessageB
-        {
-            Data = "Hello"
-        }, cancellationToken: TestCancellationToken);
-        await messageBus.PublishAsync(new SimpleMessageC
-        {
-            Data = "Hello"
-        }, cancellationToken: TestCancellationToken);
+            var countdown = new AsyncCountdownEvent(3);
+            await messageBus.SubscribeAsync<object>(msg =>
+            {
+                countdown.Signal();
+            }, TestCancellationToken);
+            await messageBus.PublishAsync(new SimpleMessageA
+            {
+                Data = "Hello"
+            }, cancellationToken: TestCancellationToken);
+            await messageBus.PublishAsync(new SimpleMessageB
+            {
+                Data = "Hello"
+            }, cancellationToken: TestCancellationToken);
+            await messageBus.PublishAsync(new SimpleMessageC
+            {
+                Data = "Hello"
+            }, cancellationToken: TestCancellationToken);
 
-        await countdown.WaitAsync(TimeSpan.FromSeconds(2));
-        Assert.Equal(0, countdown.CurrentCount);
+            await countdown.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.Equal(0, countdown.CurrentCount);
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task WontKeepMessagesWithNoSubscribersAsync()
     {
-        await using var messageBus = GetMessageBus();
+        using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        var countdown = new AsyncCountdownEvent(1);
-        await messageBus.PublishAsync(new SimpleMessageA
+        try
         {
-            Data = "Hello"
-        }, cancellationToken: TestCancellationToken);
+            var countdown = new AsyncCountdownEvent(1);
+            await messageBus.PublishAsync(new SimpleMessageA
+            {
+                Data = "Hello"
+            }, cancellationToken: TestCancellationToken);
 
-        await Task.Delay(100, TestCancellationToken);
-        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            await Task.Delay(100, TestCancellationToken);
+            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            {
+                Assert.Equal("Hello", msg.Data);
+                countdown.Signal();
+            }, TestCancellationToken);
+
+            await Assert.ThrowsAsync<TimeoutException>(async () => await countdown.WaitAsync(TimeSpan.FromMilliseconds(100)));
+            Assert.Equal(1, countdown.CurrentCount);
+        }
+        finally
         {
-            Assert.Equal("Hello", msg.Data);
-            countdown.Signal();
-        }, TestCancellationToken);
-
-        await Assert.ThrowsAsync<TimeoutException>(async () => await countdown.WaitAsync(TimeSpan.FromMilliseconds(100)));
-        Assert.Equal(1, countdown.CurrentCount);
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task CanCancelSubscriptionAsync()
     {
-        await using var messageBus = GetMessageBus();
+        using var messageBus = GetMessageBus();
         if (messageBus == null)
             return;
 
-        var countdown = new AsyncCountdownEvent(2);
-
-        long messageCount = 0;
-        using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(TestCancellationToken);
-        await messageBus.SubscribeAsync<SimpleMessageA>(async msg =>
+        try
         {
-            _logger.LogTrace("SimpleAMessage received");
-            Interlocked.Increment(ref messageCount);
-            await cancellationTokenSource.CancelAsync();
-            countdown.Signal();
-        }, cancellationTokenSource.Token);
+            var countdown = new AsyncCountdownEvent(2);
 
-        // NOTE: This subscriber will not be canceled.
-        await messageBus.SubscribeAsync<object>(_ => countdown.Signal(), TestCancellationToken);
-        await messageBus.PublishAsync(new SimpleMessageA
+            long messageCount = 0;
+            using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(TestCancellationToken);
+            await messageBus.SubscribeAsync<SimpleMessageA>(async msg =>
+            {
+                _logger.LogTrace("SimpleAMessage received");
+                Interlocked.Increment(ref messageCount);
+                await cancellationTokenSource.CancelAsync();
+                countdown.Signal();
+            }, cancellationTokenSource.Token);
+
+            // NOTE: This subscriber will not be canceled.
+            await messageBus.SubscribeAsync<object>(_ => countdown.Signal(), TestCancellationToken);
+            await messageBus.PublishAsync(new SimpleMessageA
+            {
+                Data = "Hello"
+            }, cancellationToken: TestCancellationToken);
+
+            await countdown.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.Equal(0, countdown.CurrentCount);
+            Assert.Equal(1, messageCount);
+
+            countdown.AddCount(1);
+            await messageBus.PublishAsync(new SimpleMessageA
+            {
+                Data = "Hello"
+            }, cancellationToken: TestCancellationToken);
+
+            await countdown.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.Equal(0, countdown.CurrentCount);
+            Assert.Equal(1, messageCount);
+        }
+        finally
         {
-            Data = "Hello"
-        }, cancellationToken: TestCancellationToken);
-
-        await countdown.WaitAsync(TimeSpan.FromSeconds(2));
-        Assert.Equal(0, countdown.CurrentCount);
-        Assert.Equal(1, messageCount);
-
-        countdown.AddCount(1);
-        await messageBus.PublishAsync(new SimpleMessageA
-        {
-            Data = "Hello"
-        }, cancellationToken: TestCancellationToken);
-
-        await countdown.WaitAsync(TimeSpan.FromSeconds(2));
-        Assert.Equal(0, countdown.CurrentCount);
-        Assert.Equal(1, messageCount);
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task CanReceiveFromMultipleSubscribersAsync()
     {
-        await using var messageBus1 = GetMessageBus();
+        using var messageBus1 = GetMessageBus();
         if (messageBus1 == null)
             return;
 
-        var countdown1 = new AsyncCountdownEvent(1);
-        await messageBus1.SubscribeAsync<SimpleMessageA>(msg =>
+        try
         {
-            Assert.Equal("Hello", msg.Data);
-            countdown1.Signal();
-        }, TestCancellationToken);
+            var countdown1 = new AsyncCountdownEvent(1);
+            await messageBus1.SubscribeAsync<SimpleMessageA>(msg =>
+            {
+                Assert.Equal("Hello", msg.Data);
+                countdown1.Signal();
+            }, TestCancellationToken);
 
-        await using var messageBus2 = GetMessageBus();
-        Assert.NotNull(messageBus2);
+            using var messageBus2 = GetMessageBus();
+            Assert.NotNull(messageBus2);
 
-        var countdown2 = new AsyncCountdownEvent(1);
-        await messageBus2.SubscribeAsync<SimpleMessageA>(msg =>
+            try
+            {
+                var countdown2 = new AsyncCountdownEvent(1);
+                await messageBus2.SubscribeAsync<SimpleMessageA>(msg =>
+                {
+                    Assert.Equal("Hello", msg.Data);
+                    countdown2.Signal();
+                }, TestCancellationToken);
+
+                await messageBus1.PublishAsync(new SimpleMessageA
+                {
+                    Data = "Hello"
+                }, cancellationToken: TestCancellationToken);
+
+                await countdown1.WaitAsync(TimeSpan.FromSeconds(5));
+                Assert.Equal(0, countdown1.CurrentCount);
+                await countdown2.WaitAsync(TimeSpan.FromSeconds(5));
+                Assert.Equal(0, countdown2.CurrentCount);
+            }
+            finally
+            {
+                await CleanupMessageBusAsync(messageBus2);
+            }
+        }
+        finally
         {
-            Assert.Equal("Hello", msg.Data);
-            countdown2.Signal();
-        }, TestCancellationToken);
-
-        await messageBus1.PublishAsync(new SimpleMessageA
-        {
-            Data = "Hello"
-        }, cancellationToken: TestCancellationToken);
-
-        await countdown1.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.Equal(0, countdown1.CurrentCount);
-        await countdown2.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.Equal(0, countdown2.CurrentCount);
+            await CleanupMessageBusAsync(messageBus1);
+        }
     }
 
     public virtual async Task CanDisposeWithNoSubscribersOrPublishersAsync()
     {
         await using var messageBus = GetMessageBus();
+        if (messageBus is null)
+            return;
     }
 
     public virtual async Task CanHandlePoisonedMessageAsync()
     {
-        await using var messageBus = GetMessageBus();
+        using var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
 
         long handlerInvocations = 0;
-
-        await messageBus.SubscribeAsync<SimpleMessageA>(_ =>
-        {
-            _logger.LogTrace("SimpleAMessage received");
-            Interlocked.Increment(ref handlerInvocations);
-            throw new Exception("Poisoned message");
-        });
-
-        await messageBus.PublishAsync(new SimpleMessageA(), cancellationToken: TestCancellationToken);
-        _logger.LogTrace("Published one...");
-
-        await Task.Delay(TimeSpan.FromSeconds(3));
-        Assert.InRange(handlerInvocations, 1, 5);
-    }
-
-    public virtual async Task SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync()
-    {
-        // Arrange
-        var faultSerializer = new FaultInjectingSerializer();
-        await using var messageBus = GetMessageBus(o => { o.Serializer = faultSerializer; return o; });
-        if (messageBus is null)
-            return;
-
-        long handlerInvocations = 0;
-        var messageReceived = new AsyncAutoResetEvent(false);
-
-        await messageBus.SubscribeAsync<SimpleMessageA>(_ =>
-        {
-            _logger.LogTrace("SimpleAMessage received");
-            Interlocked.Increment(ref handlerInvocations);
-            messageReceived.Set();
-        });
-
-        // Publish a valid message first (serializer works normally)
-        await messageBus.PublishAsync(new SimpleMessageA { Data = "valid" }, cancellationToken: TestCancellationToken);
-        await messageReceived.WaitAsync(TestCancellationToken);
-        Assert.Equal(1, handlerInvocations);
-
-        // Flip the flag so deserialization throws on the next message
-        faultSerializer.ShouldFailOnDeserialize = true;
-
-        // Act: publish a message that will fail deserialization on receive
-        await messageBus.PublishAsync(new SimpleMessageA { Data = "poison" }, cancellationToken: TestCancellationToken);
-
-        // Wait a reasonable time for the message to be processed (or skipped)
-        await Task.Delay(TimeSpan.FromSeconds(2), TestCancellationToken);
-
-        // Assert: handler should still have been invoked only once (for the valid message)
-        Assert.Equal(1, handlerInvocations);
-    }
-
-    public virtual async Task PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync()
-    {
-        // Arrange
-        var faultSerializer = new FaultInjectingSerializer { ShouldFailOnSerialize = true };
-        await using var messageBus = GetMessageBus(o => { o.Serializer = faultSerializer; return o; });
-        if (messageBus is null)
-            return;
-
-        await messageBus.SubscribeAsync<SimpleMessageA>(_ => { });
-
-        // Act & Assert: publishing with a broken serializer should throw
-        await Assert.ThrowsAsync<MessageBusException>(async () =>
-            await messageBus.PublishAsync(new SimpleMessageA { Data = "test" }, cancellationToken: TestCancellationToken));
-    }
-
-    public virtual async Task SubscribeAsync_WithDeserializationFailure_SkipsMessageAsync()
-    {
-        // Arrange
-        var faultSerializer = new FaultInjectingSerializer { ShouldFailOnDeserialize = true };
-        await using var messageBus = GetMessageBus(o => { o.Serializer = faultSerializer; return o; });
-        if (messageBus is null)
-            return;
-
-        long handlerInvocations = 0;
-
-        await messageBus.SubscribeAsync<SimpleMessageA>(_ =>
-        {
-            Interlocked.Increment(ref handlerInvocations);
-        });
-
-        // Act: publish a message that will fail deserialization on receive
-        await messageBus.PublishAsync(new SimpleMessageA { Data = "poison" }, cancellationToken: TestCancellationToken);
-        await Task.Delay(TimeSpan.FromSeconds(2), TestCancellationToken);
-
-        // Assert: handler should never be invoked for a poisoned message
-        Assert.Equal(0, handlerInvocations);
-    }
-
-    public virtual async Task PublishAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
-    {
-        await using var messageBus = GetMessageBus();
-        if (messageBus is null)
-            return;
-
-        // Act & Assert - cancelled token should throw OperationCanceledException, not MessageBusException
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
-            await messageBus.PublishAsync(new SimpleMessageA(), cancellationToken: new CancellationToken(true)));
-    }
-
-    public virtual async Task PublishAsync_WithDelayedMessageAndDisposeBeforeDelivery_DiscardsMessageAsync()
-    {
-        var messageReceived = new AsyncAutoResetEvent(false);
-        IMessageBus? messageBus = GetMessageBus();
-        if (messageBus is null)
-            return;
 
         try
         {
-            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            await messageBus.SubscribeAsync<SimpleMessageA>(_ =>
             {
-                _logger.LogTrace("Got message - this should NOT happen");
-                messageReceived.Set();
-            }, TestCancellationToken);
+                _logger.LogTrace("SimpleAMessage received");
+                Interlocked.Increment(ref handlerInvocations);
+                throw new Exception("Poisoned message");
+            });
 
-            await messageBus.PublishAsync(new SimpleMessageA
-            {
-                Data = "ShouldBeDiscarded"
-            }, new MessageOptions { DeliveryDelay = TimeSpan.FromSeconds(1) }, TestCancellationToken);
+            await messageBus.PublishAsync(new SimpleMessageA(), cancellationToken: TestCancellationToken);
+            _logger.LogTrace("Published one...");
 
-            _logger.LogTrace("Published delayed message, disposing immediately...");
-            messageBus.Dispose();
-            messageBus = null;
-
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestCancellationToken);
-            cts.CancelAfter(TimeSpan.FromMilliseconds(250));
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => messageReceived.WaitAsync(cts.Token));
+            await Task.Delay(TimeSpan.FromSeconds(3));
+            Assert.InRange(handlerInvocations, 1, 5);
         }
         finally
         {
-            if (messageBus is not null)
-                await CleanupMessageBusAsync(messageBus);
+            await CleanupMessageBusAsync(messageBus);
         }
-    }
-
-    public virtual async Task SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
-    {
-        await using var messageBus = GetMessageBus();
-        if (messageBus is null)
-            return;
-
-        // Act & Assert - cancelled token should throw OperationCanceledException
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
-            await messageBus.SubscribeAsync<SimpleMessageA>(_ => { }, cancellationToken: new CancellationToken(true)));
     }
 
     public virtual async Task DisposeAsync_CalledMultipleTimes_IsIdempotentAsync()
     {
-        // Arrange
         var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
 
-        // Act
         await messageBus.DisposeAsync();
         await messageBus.DisposeAsync();
         await messageBus.DisposeAsync();
-
-        // Assert - no exception thrown
     }
 
     public virtual async Task DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync()
     {
-        // Arrange
         var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
@@ -787,56 +790,47 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
             await Task.Delay(500, TestCancellationToken);
         });
 
-        // Act - publish a message, then dispose while the subscriber is still processing
         _ = messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken);
         await subscriberStarted.WaitAsync(TestCancellationToken);
 
-        // Assert - dispose completes without deadlock (the test itself will timeout if it deadlocks)
         await messageBus.DisposeAsync();
     }
 
     public virtual async Task DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync()
     {
-        // Arrange
         var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
 
-        // Act & Assert
         await messageBus.DisposeAsync();
     }
 
     public virtual async Task PublishAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
     {
-        // Arrange
         var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
 
         await messageBus.DisposeAsync();
 
-        // Act & Assert
         await Assert.ThrowsAsync<MessageBusException>(async () =>
             await messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }));
     }
 
     public virtual async Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
     {
-        // Arrange
         var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
 
         await messageBus.DisposeAsync();
 
-        // Act & Assert
         await Assert.ThrowsAsync<MessageBusException>(async () =>
             await messageBus.SubscribeAsync<SimpleMessageA>(_ => { }));
     }
 
     public virtual async Task SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync()
     {
-        // Arrange
         await using var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
@@ -850,11 +844,9 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
             countdown.Signal();
         }, cts.Token);
 
-        // Act - cancel the subscription
         await cts.CancelAsync();
         await Task.Delay(100, TestCancellationToken);
 
-        // Subscribe again with a fresh token
         var countdown2 = new AsyncCountdownEvent(1);
         await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
         {
@@ -862,36 +854,178 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
             countdown2.Signal();
         }, TestCancellationToken);
 
-        // Assert - new subscriber receives messages (infrastructure was not torn down)
         await messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken);
         await countdown2.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.Equal(0, countdown2.CurrentCount);
     }
-}
 
-/// <summary>Disposes a set of message buses created during a test; optional cleanup matches <see cref="MessageBusTestBase.CleanupMessageBusAsync"/>.</summary>
-public sealed class MessageBusCollectionDisposable : IAsyncDisposable
-{
-    private readonly List<IMessageBus> _buses = new();
-    private readonly Func<IMessageBus, Task>? _cleanupAsync;
-
-    public MessageBusCollectionDisposable(Func<IMessageBus, Task>? cleanupAsync = null)
+    public virtual async Task SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync()
     {
-        _cleanupAsync = cleanupAsync;
-    }
+        // Arrange
+        var faultSerializer = new FaultInjectingSerializer();
+        using var messageBus = GetMessageBus(o => { o.Serializer = faultSerializer; return o; });
+        if (messageBus is null)
+            return;
 
-    public void Add(IMessageBus bus) => _buses.Add(bus);
+        long handlerInvocations = 0;
+        var messageReceived = new AsyncAutoResetEvent(false);
 
-    public IMessageBus GetRandomBus() => _buses[RandomData.GetInt(0, _buses.Count - 1)];
-
-    public async ValueTask DisposeAsync()
-    {
-        foreach (var mb in _buses)
+        try
         {
-            if (_cleanupAsync is not null)
-                await _cleanupAsync(mb);
-            else
-                await mb.DisposeAsync();
+            await messageBus.SubscribeAsync<SimpleMessageA>(_ =>
+            {
+                _logger.LogTrace("SimpleAMessage received");
+                Interlocked.Increment(ref handlerInvocations);
+                messageReceived.Set();
+            });
+
+            // Publish a valid message first (serializer works normally)
+            await messageBus.PublishAsync(new SimpleMessageA { Data = "valid" }, cancellationToken: TestCancellationToken);
+            await messageReceived.WaitAsync(TestCancellationToken);
+            Assert.Equal(1, handlerInvocations);
+
+            // Flip the flag so deserialization throws on the next message
+            faultSerializer.ShouldFailOnDeserialize = true;
+
+            // Act: publish a message that will fail deserialization on receive
+            await messageBus.PublishAsync(new SimpleMessageA { Data = "poison" }, cancellationToken: TestCancellationToken);
+
+            // Wait a reasonable time for the message to be processed (or skipped)
+            await Task.Delay(TimeSpan.FromSeconds(2), TestCancellationToken);
+
+            // Assert: handler should still have been invoked only once (for the valid message)
+            Assert.Equal(1, handlerInvocations);
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
         }
     }
+
+    public virtual async Task PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync()
+    {
+        // Arrange
+        var faultSerializer = new FaultInjectingSerializer { ShouldFailOnSerialize = true };
+        using var messageBus = GetMessageBus(o => { o.Serializer = faultSerializer; return o; });
+        if (messageBus is null)
+            return;
+
+        try
+        {
+            await messageBus.SubscribeAsync<SimpleMessageA>(_ => { });
+
+            // Act & Assert: publishing with a broken serializer should throw
+            await Assert.ThrowsAsync<MessageBusException>(async () =>
+                await messageBus.PublishAsync(new SimpleMessageA { Data = "test" }, cancellationToken: TestCancellationToken));
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
+        }
+    }
+
+    public virtual async Task SubscribeAsync_WithDeserializationFailure_SkipsMessageAsync()
+    {
+        // Arrange
+        var faultSerializer = new FaultInjectingSerializer { ShouldFailOnDeserialize = true };
+        using var messageBus = GetMessageBus(o => { o.Serializer = faultSerializer; return o; });
+        if (messageBus is null)
+            return;
+
+        long handlerInvocations = 0;
+
+        try
+        {
+            await messageBus.SubscribeAsync<SimpleMessageA>(_ =>
+            {
+                Interlocked.Increment(ref handlerInvocations);
+            });
+
+            // Act: publish a message that will fail deserialization on receive
+            await messageBus.PublishAsync(new SimpleMessageA { Data = "poison" }, cancellationToken: TestCancellationToken);
+            await Task.Delay(TimeSpan.FromSeconds(2), TestCancellationToken);
+
+            // Assert: handler should never be invoked for a poisoned message
+            Assert.Equal(0, handlerInvocations);
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
+        }
+    }
+
+    public virtual async Task PublishAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
+    {
+        using var messageBus = GetMessageBus();
+        if (messageBus is null)
+            return;
+
+        try
+        {
+            // Act & Assert - cancelled token should throw OperationCanceledException, not MessageBusException
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+                await messageBus.PublishAsync(new SimpleMessageA(), cancellationToken: new CancellationToken(true)));
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
+        }
+    }
+
+    public virtual async Task PublishAsync_WithDelayedMessageAndDisposeBeforeDelivery_DiscardsMessageAsync()
+    {
+        // Arrange
+        var messageReceived = new AsyncAutoResetEvent(false);
+        var messageBus = GetMessageBus();
+        if (messageBus is null)
+            return;
+
+        try
+        {
+            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            {
+                _logger.LogTrace("Got message - this should NOT happen");
+                messageReceived.Set();
+            }, TestCancellationToken);
+
+            // Act - publish with short delay, then dispose immediately before delay expires
+            await messageBus.PublishAsync(new SimpleMessageA
+            {
+                Data = "ShouldBeDiscarded"
+            }, new MessageOptions { DeliveryDelay = TimeSpan.FromSeconds(1) }, TestCancellationToken);
+
+            _logger.LogTrace("Published delayed message, disposing immediately...");
+            messageBus.Dispose();
+            messageBus = null; // Mark as disposed to skip cleanup
+
+            // Assert - wait slightly longer than the delay; message should NOT be delivered
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestCancellationToken);
+            cts.CancelAfter(TimeSpan.FromMilliseconds(250));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => messageReceived.WaitAsync(cts.Token));
+        }
+        finally
+        {
+            if (messageBus is not null)
+                await CleanupMessageBusAsync(messageBus);
+        }
+    }
+
+    public virtual async Task SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
+    {
+        using var messageBus = GetMessageBus();
+        if (messageBus is null)
+            return;
+
+        try
+        {
+            // Act & Assert - cancelled token should throw OperationCanceledException
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+                await messageBus.SubscribeAsync<SimpleMessageA>(_ => { }, cancellationToken: new CancellationToken(true)));
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
+        }
+    }
+
 }

--- a/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
+++ b/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
@@ -869,11 +869,7 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
     }
 }
 
-/// <summary>
-/// Owns additional <see cref="IMessageBus"/> instances created during a test (e.g. concurrent scenarios).
-/// Disposal order is the reverse of <see cref="IAsyncDisposable"/> / <c>await using</c> — this type is
-/// typically declared after the primary bus so extra instances are disposed first.
-/// </summary>
+/// <summary>Disposes a set of message buses created during a test; optional cleanup matches <see cref="MessageBusTestBase.CleanupMessageBusAsync"/>.</summary>
 public sealed class MessageBusCollectionDisposable : IAsyncDisposable
 {
     private readonly List<IMessageBus> _buses = new();

--- a/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
+++ b/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
@@ -880,27 +880,27 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
         try
         {
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestCancellationToken);
-            var countdown = new AsyncCountdownEvent(1);
+            var cancelledHandlerCount = new AsyncCountdownEvent(1);
 
             await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
             {
-                Assert.Equal("Hello", msg.Data);
-                countdown.Signal();
+                cancelledHandlerCount.Signal();
             }, cts.Token);
 
             await cts.CancelAsync();
-            await Task.Delay(100, TestCancellationToken);
 
-            var countdown2 = new AsyncCountdownEvent(1);
+            var activeHandlerReceived = new AsyncCountdownEvent(1);
             await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
             {
                 Assert.Equal("Hello", msg.Data);
-                countdown2.Signal();
+                activeHandlerReceived.Signal();
             }, TestCancellationToken);
 
             await messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken);
-            await countdown2.WaitAsync(TimeSpan.FromSeconds(5));
-            Assert.Equal(0, countdown2.CurrentCount);
+            await activeHandlerReceived.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(0, activeHandlerReceived.CurrentCount);
+            Assert.Equal(1, cancelledHandlerCount.CurrentCount);
         }
         finally
         {

--- a/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
+++ b/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
@@ -771,9 +771,16 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
         if (messageBus is null)
             return;
 
-        await messageBus.DisposeAsync();
-        await messageBus.DisposeAsync();
-        await messageBus.DisposeAsync();
+        try
+        {
+            await messageBus.DisposeAsync();
+            await messageBus.DisposeAsync();
+            await messageBus.DisposeAsync();
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync()
@@ -782,18 +789,25 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
         if (messageBus is null)
             return;
 
-        var subscriberStarted = new AsyncAutoResetEvent(false);
-
-        await messageBus.SubscribeAsync<SimpleMessageA>(async msg =>
+        try
         {
-            subscriberStarted.Set();
-            await Task.Delay(500, TestCancellationToken);
-        });
+            var subscriberStarted = new AsyncAutoResetEvent(false);
 
-        _ = messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken);
-        await subscriberStarted.WaitAsync(TestCancellationToken);
+            await messageBus.SubscribeAsync<SimpleMessageA>(async msg =>
+            {
+                subscriberStarted.Set();
+                await Task.Delay(500, TestCancellationToken);
+            });
 
-        await messageBus.DisposeAsync();
+            _ = messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken);
+            await subscriberStarted.WaitAsync(TestCancellationToken);
+
+            await messageBus.DisposeAsync();
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync()
@@ -802,7 +816,14 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
         if (messageBus is null)
             return;
 
-        await messageBus.DisposeAsync();
+        try
+        {
+            await messageBus.DisposeAsync();
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task PublishAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
@@ -811,10 +832,17 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
         if (messageBus is null)
             return;
 
-        await messageBus.DisposeAsync();
+        try
+        {
+            await messageBus.DisposeAsync();
 
-        await Assert.ThrowsAsync<MessageBusException>(async () =>
-            await messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }));
+            await Assert.ThrowsAsync<MessageBusException>(async () =>
+                await messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }));
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
@@ -823,40 +851,54 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
         if (messageBus is null)
             return;
 
-        await messageBus.DisposeAsync();
+        try
+        {
+            await messageBus.DisposeAsync();
 
-        await Assert.ThrowsAsync<MessageBusException>(async () =>
-            await messageBus.SubscribeAsync<SimpleMessageA>(_ => { }));
+            await Assert.ThrowsAsync<MessageBusException>(async () =>
+                await messageBus.SubscribeAsync<SimpleMessageA>(_ => { }));
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync()
     {
-        await using var messageBus = GetMessageBus();
+        var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
 
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestCancellationToken);
-        var countdown = new AsyncCountdownEvent(1);
-
-        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+        try
         {
-            Assert.Equal("Hello", msg.Data);
-            countdown.Signal();
-        }, cts.Token);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestCancellationToken);
+            var countdown = new AsyncCountdownEvent(1);
 
-        await cts.CancelAsync();
-        await Task.Delay(100, TestCancellationToken);
+            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            {
+                Assert.Equal("Hello", msg.Data);
+                countdown.Signal();
+            }, cts.Token);
 
-        var countdown2 = new AsyncCountdownEvent(1);
-        await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            await cts.CancelAsync();
+            await Task.Delay(100, TestCancellationToken);
+
+            var countdown2 = new AsyncCountdownEvent(1);
+            await messageBus.SubscribeAsync<SimpleMessageA>(msg =>
+            {
+                Assert.Equal("Hello", msg.Data);
+                countdown2.Signal();
+            }, TestCancellationToken);
+
+            await messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken);
+            await countdown2.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(0, countdown2.CurrentCount);
+        }
+        finally
         {
-            Assert.Equal("Hello", msg.Data);
-            countdown2.Signal();
-        }, TestCancellationToken);
-
-        await messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken);
-        await countdown2.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.Equal(0, countdown2.CurrentCount);
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync()

--- a/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
+++ b/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
@@ -731,9 +731,18 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
 
     public virtual async Task CanDisposeWithNoSubscribersOrPublishersAsync()
     {
-        await using var messageBus = GetMessageBus();
+        var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
+
+        try
+        {
+            await messageBus.DisposeAsync();
+        }
+        finally
+        {
+            await CleanupMessageBusAsync(messageBus);
+        }
     }
 
     public virtual async Task CanHandlePoisonedMessageAsync()

--- a/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
+++ b/src/Foundatio.TestHarness/Messaging/MessageBusTestBase.cs
@@ -745,6 +745,7 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
 
     public virtual async Task CanHandlePoisonedMessageAsync()
     {
+        // Arrange
         using var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
@@ -760,10 +761,13 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
                 throw new Exception("Poisoned message");
             });
 
+            // Act
             await messageBus.PublishAsync(new SimpleMessageA(), cancellationToken: TestCancellationToken);
             _logger.LogTrace("Published one...");
 
             await Task.Delay(TimeSpan.FromSeconds(3));
+
+            // Assert
             Assert.InRange(handlerInvocations, 1, 5);
         }
         finally
@@ -774,15 +778,19 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
 
     public virtual async Task DisposeAsync_CalledMultipleTimes_IsIdempotentAsync()
     {
+        // Arrange
         var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
 
         try
         {
+            // Act
             await messageBus.DisposeAsync();
             await messageBus.DisposeAsync();
             await messageBus.DisposeAsync();
+
+            // Assert - no exception thrown
         }
         finally
         {
@@ -792,6 +800,7 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
 
     public virtual async Task DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync()
     {
+        // Arrange
         var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
@@ -806,10 +815,13 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
                 await Task.Delay(500, TestCancellationToken);
             });
 
+            // Act
             _ = messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken);
             await subscriberStarted.WaitAsync(TestCancellationToken);
 
             await messageBus.DisposeAsync();
+
+            // Assert - no deadlock or exception thrown
         }
         finally
         {
@@ -819,13 +831,17 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
 
     public virtual async Task DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync()
     {
+        // Arrange
         var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
 
         try
         {
+            // Act
             await messageBus.DisposeAsync();
+
+            // Assert - no exception thrown
         }
         finally
         {
@@ -835,6 +851,7 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
 
     public virtual async Task PublishAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
     {
+        // Arrange
         var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
@@ -843,6 +860,7 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
         {
             await messageBus.DisposeAsync();
 
+            // Act & Assert
             await Assert.ThrowsAsync<MessageBusException>(async () =>
                 await messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }));
         }
@@ -854,6 +872,7 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
 
     public virtual async Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
     {
+        // Arrange
         var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
@@ -862,6 +881,7 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
         {
             await messageBus.DisposeAsync();
 
+            // Act & Assert
             await Assert.ThrowsAsync<MessageBusException>(async () =>
                 await messageBus.SubscribeAsync<SimpleMessageA>(_ => { }));
         }
@@ -873,6 +893,7 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
 
     public virtual async Task SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync()
     {
+        // Arrange
         var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
@@ -896,9 +917,11 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
                 activeHandlerReceived.Signal();
             }, TestCancellationToken);
 
+            // Act
             await messageBus.PublishAsync(new SimpleMessageA { Data = "Hello" }, cancellationToken: TestCancellationToken);
             await activeHandlerReceived.WaitAsync(TimeSpan.FromSeconds(5));
 
+            // Assert
             Assert.Equal(0, activeHandlerReceived.CurrentCount);
             Assert.Equal(1, cancelledHandlerCount.CurrentCount);
         }
@@ -1005,13 +1028,14 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
 
     public virtual async Task PublishAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
     {
+        // Arrange
         using var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
 
         try
         {
-            // Act & Assert - cancelled token should throw OperationCanceledException, not MessageBusException
+            // Act & Assert
             await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
                 await messageBus.PublishAsync(new SimpleMessageA(), cancellationToken: new CancellationToken(true)));
         }
@@ -1061,13 +1085,14 @@ public abstract class MessageBusTestBase : TestWithLoggingBase
 
     public virtual async Task SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
     {
+        // Arrange
         using var messageBus = GetMessageBus();
         if (messageBus is null)
             return;
 
         try
         {
-            // Act & Assert - cancelled token should throw OperationCanceledException
+            // Act & Assert
             await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
                 await messageBus.SubscribeAsync<SimpleMessageA>(_ => { }, cancellationToken: new CancellationToken(true)));
         }

--- a/src/Foundatio/Messaging/IMessageBus.cs
+++ b/src/Foundatio/Messaging/IMessageBus.cs
@@ -6,7 +6,7 @@ namespace Foundatio.Messaging;
 /// <summary>
 /// Represents a message bus that supports both publishing and subscribing to messages.
 /// </summary>
-public interface IMessageBus : IMessagePublisher, IMessageSubscriber, IDisposable
+public interface IMessageBus : IMessagePublisher, IMessageSubscriber, IDisposable, IAsyncDisposable
 {
 }
 

--- a/src/Foundatio/Messaging/InMemoryMessageBus.cs
+++ b/src/Foundatio/Messaging/InMemoryMessageBus.cs
@@ -92,4 +92,10 @@ public class InMemoryMessageBus : MessageBusBase<InMemoryMessageBusOptions>
         _messageCounts.Clear();
         base.Dispose();
     }
+
+    public override ValueTask DisposeAsync()
+    {
+        _messageCounts.Clear();
+        return base.DisposeAsync();
+    }
 }

--- a/src/Foundatio/Messaging/MessageBusBase.cs
+++ b/src/Foundatio/Messaging/MessageBusBase.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Foundatio.Messaging;
 
-public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHaveLoggerFactory, IHaveTimeProvider, IHaveResiliencePolicyProvider, IDisposable where TOptions : SharedMessageBusOptions
+public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHaveLoggerFactory, IHaveTimeProvider, IHaveResiliencePolicyProvider, IDisposable, IAsyncDisposable where TOptions : SharedMessageBusOptions
 {
     protected readonly ConcurrentDictionary<string, Subscriber> _subscribers = new();
     protected readonly TOptions _options;
@@ -172,7 +172,20 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
         return resolvedType;
     }
 
-    protected virtual Task RemoveTopicSubscriptionAsync() => Task.CompletedTask;
+    /// <summary>
+    /// Called during the first phase of disposal, BEFORE DisposedCancellationToken is cancelled
+    /// and BEFORE subscribers are cleared. Override to gracefully drain in-flight work
+    /// (e.g., StopProcessingAsync for Azure SB). Subscribers and token are still active here.
+    /// </summary>
+    protected virtual Task ShutdownAsync() => Task.CompletedTask;
+
+    /// <summary>
+    /// Called during the second phase of disposal, AFTER DisposedCancellationToken is cancelled
+    /// and AFTER subscribers are cleared. Override to tear down transport infrastructure
+    /// (close connections, await background tasks, dispose clients).
+    /// </summary>
+    protected virtual Task CleanupAsync() => Task.CompletedTask;
+
     /// <summary>
     /// Called after subscribing to ensure the topic subscription infrastructure exists. The
     /// <paramref name="cancellationToken"/> is always <see cref="MaintenanceBase.DisposedCancellationToken"/>;
@@ -208,25 +221,6 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
             cancellationToken.Register(() =>
             {
                 _subscribers.TryRemove(subscriber.Id, out _);
-                if (_subscribers.Count > 0)
-                    return;
-
-                _logger.LogDebug("Removing topic subscription for {MessageBusId}: No subscribers", MessageBusId);
-                // CancellationToken.Register only accepts synchronous callbacks, so we fire-and-forget
-                // to avoid blocking on the async method which causes deadlocks during disposal.
-                // Tracked at https://github.com/dotnet/runtime/issues/31315
-                _ = Task.Run(async () =>
-                {
-                    try
-                    {
-                        await RemoveTopicSubscriptionAsync().AnyContext();
-                        _logger.LogDebug("Topic subscription removed for {MessageBusId}", MessageBusId);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogWarning(ex, "Error removing topic subscription for {MessageBusId}: {Message}", MessageBusId, ex.Message);
-                    }
-                });
             });
         }
 
@@ -308,6 +302,9 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
 
     protected async Task SendMessageToSubscribersAsync(IMessage message)
     {
+        if (_isDisposed)
+            throw new OperationCanceledException("Message bus is disposing.");
+
         var subscribers = GetMessageSubscribers(message);
 
         _logger.LogTrace("Found {SubscriberCount} subscribers for message type: ClrType={MessageClrType} Type={MessageType}", subscribers.Count, message.ClrType, message.Type);
@@ -487,6 +484,32 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
 
     public string MessageBusId { get; init; }
 
+    public virtual async ValueTask DisposeAsync()
+    {
+        if (_isDisposed)
+            return;
+
+        _isDisposed = true;
+        _logger.LogTrace("MessageBus {MessageBusId} async dispose", MessageBusId);
+
+        try { await ShutdownAsync().AnyContext(); }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error during shutdown for {MessageBusId}: {Message}", MessageBusId, ex.Message);
+        }
+
+        _subscribers?.Clear();
+        _disposedCancellationTokenSource.Cancel();
+
+        try { await CleanupAsync().AnyContext(); }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error during cleanup for {MessageBusId}: {Message}", MessageBusId, ex.Message);
+        }
+
+        _disposedCancellationTokenSource.Dispose();
+    }
+
     public virtual void Dispose()
     {
         if (_isDisposed)
@@ -496,10 +519,23 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
         }
 
         _isDisposed = true;
-
         _logger.LogTrace("MessageBus {MessageBusId} dispose", MessageBusId);
+
+        try { ShutdownAsync().GetAwaiter().GetResult(); }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error during shutdown for {MessageBusId}: {Message}", MessageBusId, ex.Message);
+        }
+
         _subscribers?.Clear();
         _disposedCancellationTokenSource.Cancel();
+
+        try { CleanupAsync().GetAwaiter().GetResult(); }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error during cleanup for {MessageBusId}: {Message}", MessageBusId, ex.Message);
+        }
+
         _disposedCancellationTokenSource.Dispose();
     }
 

--- a/src/Foundatio/Messaging/MessageBusBase.cs
+++ b/src/Foundatio/Messaging/MessageBusBase.cs
@@ -518,7 +518,10 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
         _isDisposed = true;
         _logger.LogTrace("MessageBus {MessageBusId} async dispose", MessageBusId);
 
-        try { await ShutdownAsync().AnyContext(); }
+        try
+        {
+            await ShutdownAsync().AnyContext();
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error during shutdown for {MessageBusId}: {Message}", MessageBusId, ex.Message);
@@ -527,7 +530,10 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
         _subscribers?.Clear();
         _disposedCancellationTokenSource.Cancel();
 
-        try { await CleanupAsync().AnyContext(); }
+        try
+        {
+            await CleanupAsync().AnyContext();
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error during cleanup for {MessageBusId}: {Message}", MessageBusId, ex.Message);
@@ -547,7 +553,10 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
         _isDisposed = true;
         _logger.LogTrace("MessageBus {MessageBusId} dispose", MessageBusId);
 
-        try { ShutdownAsync().GetAwaiter().GetResult(); }
+        try
+        {
+            ShutdownAsync().AnyContext().GetAwaiter().GetResult();
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error during shutdown for {MessageBusId}: {Message}", MessageBusId, ex.Message);
@@ -556,7 +565,10 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
         _subscribers?.Clear();
         _disposedCancellationTokenSource.Cancel();
 
-        try { CleanupAsync().GetAwaiter().GetResult(); }
+        try
+        {
+            CleanupAsync().AnyContext().GetAwaiter().GetResult();
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error during cleanup for {MessageBusId}: {Message}", MessageBusId, ex.Message);

--- a/src/Foundatio/Messaging/MessageBusBase.cs
+++ b/src/Foundatio/Messaging/MessageBusBase.cs
@@ -524,7 +524,15 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
         {
             await ShutdownAsync().AnyContext();
         }
-        catch (Exception ex)
+        catch (OperationCanceledException ex)
+        {
+            _logger.LogTrace(ex, "Shutdown cancelled for {MessageBusId}", MessageBusId);
+        }
+        catch (ObjectDisposedException ex)
+        {
+            _logger.LogTrace(ex, "Resource already disposed during shutdown for {MessageBusId}", MessageBusId);
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
         {
             _logger.LogWarning(ex, "Error during shutdown for {MessageBusId}: {Message}", MessageBusId, ex.Message);
         }
@@ -536,7 +544,15 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
         {
             await CleanupAsync().AnyContext();
         }
-        catch (Exception ex)
+        catch (OperationCanceledException ex)
+        {
+            _logger.LogTrace(ex, "Cleanup cancelled for {MessageBusId}", MessageBusId);
+        }
+        catch (ObjectDisposedException ex)
+        {
+            _logger.LogTrace(ex, "Resource already disposed during cleanup for {MessageBusId}", MessageBusId);
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
         {
             _logger.LogWarning(ex, "Error during cleanup for {MessageBusId}: {Message}", MessageBusId, ex.Message);
         }
@@ -558,7 +574,19 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
         {
             ShutdownAsync().AnyContext().GetAwaiter().GetResult();
         }
-        catch (Exception ex)
+        catch (OperationCanceledException ex)
+        {
+            _logger.LogTrace(ex, "Shutdown cancelled for {MessageBusId}", MessageBusId);
+        }
+        catch (AggregateException ex)
+        {
+            _logger.LogWarning(ex, "Error during shutdown for {MessageBusId}: {Message}", MessageBusId, ex.Message);
+        }
+        catch (ObjectDisposedException ex)
+        {
+            _logger.LogTrace(ex, "Resource already disposed during shutdown for {MessageBusId}", MessageBusId);
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
         {
             _logger.LogWarning(ex, "Error during shutdown for {MessageBusId}: {Message}", MessageBusId, ex.Message);
         }
@@ -570,7 +598,19 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
         {
             CleanupAsync().AnyContext().GetAwaiter().GetResult();
         }
-        catch (Exception ex)
+        catch (OperationCanceledException ex)
+        {
+            _logger.LogTrace(ex, "Cleanup cancelled for {MessageBusId}", MessageBusId);
+        }
+        catch (AggregateException ex)
+        {
+            _logger.LogWarning(ex, "Error during cleanup for {MessageBusId}: {Message}", MessageBusId, ex.Message);
+        }
+        catch (ObjectDisposedException ex)
+        {
+            _logger.LogTrace(ex, "Resource already disposed during cleanup for {MessageBusId}", MessageBusId);
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
         {
             _logger.LogWarning(ex, "Error during cleanup for {MessageBusId}: {Message}", MessageBusId, ex.Message);
         }

--- a/src/Foundatio/Messaging/MessageBusBase.cs
+++ b/src/Foundatio/Messaging/MessageBusBase.cs
@@ -530,11 +530,11 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
         }
         catch (ObjectDisposedException ex)
         {
-            _logger.LogTrace(ex, "Resource already disposed during shutdown for {MessageBusId}", MessageBusId);
+            _logger.LogDebug(ex, "Resource already disposed during shutdown for {MessageBusId}", MessageBusId);
         }
-        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+        catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error during shutdown for {MessageBusId}: {Message}", MessageBusId, ex.Message);
+            _logger.LogError(ex, "Error during shutdown for {MessageBusId}: {Message}", MessageBusId, ex.Message);
         }
 
         _subscribers?.Clear();
@@ -550,11 +550,11 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
         }
         catch (ObjectDisposedException ex)
         {
-            _logger.LogTrace(ex, "Resource already disposed during cleanup for {MessageBusId}", MessageBusId);
+            _logger.LogDebug(ex, "Resource already disposed during cleanup for {MessageBusId}", MessageBusId);
         }
-        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+        catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error during cleanup for {MessageBusId}: {Message}", MessageBusId, ex.Message);
+            _logger.LogError(ex, "Error during cleanup for {MessageBusId}: {Message}", MessageBusId, ex.Message);
         }
 
         _disposedCancellationTokenSource.Dispose();
@@ -578,17 +578,13 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
         {
             _logger.LogTrace(ex, "Shutdown cancelled for {MessageBusId}", MessageBusId);
         }
-        catch (AggregateException ex)
-        {
-            _logger.LogWarning(ex, "Error during shutdown for {MessageBusId}: {Message}", MessageBusId, ex.Message);
-        }
         catch (ObjectDisposedException ex)
         {
-            _logger.LogTrace(ex, "Resource already disposed during shutdown for {MessageBusId}", MessageBusId);
+            _logger.LogDebug(ex, "Resource already disposed during shutdown for {MessageBusId}", MessageBusId);
         }
-        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+        catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error during shutdown for {MessageBusId}: {Message}", MessageBusId, ex.Message);
+            _logger.LogError(ex, "Error during shutdown for {MessageBusId}: {Message}", MessageBusId, ex.Message);
         }
 
         _subscribers?.Clear();
@@ -602,17 +598,13 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
         {
             _logger.LogTrace(ex, "Cleanup cancelled for {MessageBusId}", MessageBusId);
         }
-        catch (AggregateException ex)
-        {
-            _logger.LogWarning(ex, "Error during cleanup for {MessageBusId}: {Message}", MessageBusId, ex.Message);
-        }
         catch (ObjectDisposedException ex)
         {
-            _logger.LogTrace(ex, "Resource already disposed during cleanup for {MessageBusId}", MessageBusId);
+            _logger.LogDebug(ex, "Resource already disposed during cleanup for {MessageBusId}", MessageBusId);
         }
-        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+        catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error during cleanup for {MessageBusId}: {Message}", MessageBusId, ex.Message);
+            _logger.LogError(ex, "Error during cleanup for {MessageBusId}: {Message}", MessageBusId, ex.Message);
         }
 
         _disposedCancellationTokenSource.Dispose();

--- a/src/Foundatio/Messaging/MessageBusBase.cs
+++ b/src/Foundatio/Messaging/MessageBusBase.cs
@@ -25,8 +25,8 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
     protected readonly IResiliencePolicy _resiliencePolicy;
     protected readonly ISerializer _serializer;
     private readonly CancellationTokenSource _disposedCancellationTokenSource = new();
-    private bool _isDisposed;
-    protected bool IsDisposed => _isDisposed;
+    private int _disposeState;
+    protected bool IsDisposed => _disposeState != 0;
 
     public MessageBusBase(TOptions options)
     {
@@ -328,8 +328,11 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
 
     protected async Task SendMessageToSubscribersAsync(IMessage message)
     {
-        if (_isDisposed)
-            throw new OperationCanceledException("Message bus is disposing.");
+        if (IsDisposed)
+        {
+            _logger.LogTrace("Message bus {MessageBusId} is disposed, skipping message delivery for type {MessageType}", MessageBusId, message.Type);
+            return;
+        }
 
         var subscribers = GetMessageSubscribers(message);
 
@@ -512,10 +515,9 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
 
     public virtual async ValueTask DisposeAsync()
     {
-        if (_isDisposed)
+        if (Interlocked.CompareExchange(ref _disposeState, 1, 0) != 0)
             return;
 
-        _isDisposed = true;
         _logger.LogTrace("MessageBus {MessageBusId} async dispose", MessageBusId);
 
         try
@@ -544,13 +546,12 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
 
     public virtual void Dispose()
     {
-        if (_isDisposed)
+        if (Interlocked.CompareExchange(ref _disposeState, 1, 0) != 0)
         {
             _logger.LogTrace("MessageBus {MessageBusId} dispose was already called", MessageBusId);
             return;
         }
 
-        _isDisposed = true;
         _logger.LogTrace("MessageBus {MessageBusId} dispose", MessageBusId);
 
         try

--- a/src/Foundatio/Messaging/MessageBusBase.cs
+++ b/src/Foundatio/Messaging/MessageBusBase.cs
@@ -173,18 +173,39 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
     }
 
     /// <summary>
-    /// Called during the first phase of disposal, BEFORE DisposedCancellationToken is cancelled
-    /// and BEFORE subscribers are cleared. Override to gracefully drain in-flight work
-    /// (e.g., StopProcessingAsync for Azure SB). Subscribers and token are still active here.
+    /// Called during the first phase of disposal, <b>before</b> <see cref="DisposedCancellationToken"/>
+    /// is cancelled and <b>before</b> subscribers are cleared.
     /// </summary>
-    protected virtual Task ShutdownAsync() => Task.CompletedTask;
+    /// <remarks>
+    /// <para>
+    /// Override this method to gracefully drain in-flight work (stop processors, close consumer
+    /// groups, flush buffers). Subscribers are still registered and the cancellation token is
+    /// still active, so handlers can finish processing normally.
+    /// </para>
+    /// <para>
+    /// The base implementation delegates to <see cref="RemoveTopicSubscriptionAsync"/> so that
+    /// existing provider overrides continue to work without changes.
+    /// </para>
+    /// </remarks>
+    protected virtual Task ShutdownAsync() => RemoveTopicSubscriptionAsync();
 
     /// <summary>
-    /// Called during the second phase of disposal, AFTER DisposedCancellationToken is cancelled
-    /// and AFTER subscribers are cleared. Override to tear down transport infrastructure
-    /// (close connections, await background tasks, dispose clients).
+    /// Called during the second phase of disposal, <b>after</b> <see cref="DisposedCancellationToken"/>
+    /// is cancelled and <b>after</b> subscribers are cleared.
     /// </summary>
+    /// <remarks>
+    /// Override this method to tear down transport infrastructure — close connections,
+    /// dispose clients, await background listener tasks. No subscribers remain at this point
+    /// and the cancellation token has been signaled, so background loops should have exited.
+    /// </remarks>
     protected virtual Task CleanupAsync() => Task.CompletedTask;
+
+    /// <summary>
+    /// Called during the first phase of disposal to remove transport-level topic subscriptions.
+    /// New providers should prefer overriding <see cref="ShutdownAsync"/> instead, which calls
+    /// this method by default.
+    /// </summary>
+    protected virtual Task RemoveTopicSubscriptionAsync() => Task.CompletedTask;
 
     /// <summary>
     /// Called after subscribing to ensure the topic subscription infrastructure exists. The
@@ -218,6 +239,11 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
 
         if (cancellationToken != CancellationToken.None)
         {
+            // CancellationToken.Register only accepts synchronous callbacks, so we cannot safely
+            // call RemoveTopicSubscriptionAsync here. The async-capable CancelAsync was added in
+            // .NET 8 but still does not support async callbacks — see:
+            // https://github.com/dotnet/runtime/issues/31315
+            // Topic subscription teardown is handled during DisposeAsync via ShutdownAsync/CleanupAsync.
             cancellationToken.Register(() =>
             {
                 _subscribers.TryRemove(subscriber.Id, out _);

--- a/src/Foundatio/Messaging/NullMessageBus.cs
+++ b/src/Foundatio/Messaging/NullMessageBus.cs
@@ -19,4 +19,6 @@ public class NullMessageBus : IMessageBus
     }
 
     public void Dispose() { }
+
+    public ValueTask DisposeAsync() => default;
 }

--- a/tests/Foundatio.Tests/Messaging/InMemoryMessageBusTests.cs
+++ b/tests/Foundatio.Tests/Messaging/InMemoryMessageBusTests.cs
@@ -150,9 +150,9 @@ public class InMemoryMessageBusTests : MessageBusTestBase, IDisposable
     }
 
     [Fact]
-    public override void CanDisposeWithNoSubscribersOrPublishers()
+    public override Task CanDisposeWithNoSubscribersOrPublishersAsync()
     {
-        base.CanDisposeWithNoSubscribersOrPublishers();
+        return base.CanDisposeWithNoSubscribersOrPublishersAsync();
     }
 
     [Fact]

--- a/tests/Foundatio.Tests/Messaging/InMemoryMessageBusTests.cs
+++ b/tests/Foundatio.Tests/Messaging/InMemoryMessageBusTests.cs
@@ -180,27 +180,21 @@ public class InMemoryMessageBusTests : MessageBusTestBase, IDisposable
     }
 
     [Fact]
-    public override Task DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync()
-    {
-        return base.DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync();
-    }
-
-    [Fact]
     public override Task DisposeAsync_CalledMultipleTimes_IsIdempotentAsync()
     {
         return base.DisposeAsync_CalledMultipleTimes_IsIdempotentAsync();
     }
 
     [Fact]
-    public override Task SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync()
+    public override Task DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync()
     {
-        return base.SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync();
+        return base.DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync();
     }
 
     [Fact]
-    public override Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+    public override Task DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync()
     {
-        return base.SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
+        return base.DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync();
     }
 
     [Fact]
@@ -210,9 +204,15 @@ public class InMemoryMessageBusTests : MessageBusTestBase, IDisposable
     }
 
     [Fact]
-    public override Task DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync()
+    public override Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
     {
-        return base.DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync();
+        return base.SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
+    }
+
+    [Fact]
+    public override Task SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync()
+    {
+        return base.SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync();
     }
 
     [Fact]

--- a/tests/Foundatio.Tests/Messaging/InMemoryMessageBusTests.cs
+++ b/tests/Foundatio.Tests/Messaging/InMemoryMessageBusTests.cs
@@ -78,6 +78,18 @@ public class InMemoryMessageBusTests : MessageBusTestBase, IDisposable
     }
 
     [Fact]
+    public override Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+    {
+        return base.SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
+    }
+
+    [Fact]
+    public override Task SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync()
+    {
+        return base.SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync();
+    }
+
+    [Fact]
     public override Task SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync()
     {
         return base.SubscribeAsync_WithCancellation_ThrowsOperationCanceledExceptionAsync();
@@ -162,24 +174,6 @@ public class InMemoryMessageBusTests : MessageBusTestBase, IDisposable
     }
 
     [Fact]
-    public override Task SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync()
-    {
-        return base.SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync();
-    }
-
-    [Fact]
-    public override Task PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync()
-    {
-        return base.PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync();
-    }
-
-    [Fact]
-    public override Task SubscribeAsync_WithDeserializationFailure_SkipsMessageAsync()
-    {
-        return base.SubscribeAsync_WithDeserializationFailure_SkipsMessageAsync();
-    }
-
-    [Fact]
     public override Task DisposeAsync_CalledMultipleTimes_IsIdempotentAsync()
     {
         return base.DisposeAsync_CalledMultipleTimes_IsIdempotentAsync();
@@ -204,15 +198,21 @@ public class InMemoryMessageBusTests : MessageBusTestBase, IDisposable
     }
 
     [Fact]
-    public override Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+    public override Task SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync()
     {
-        return base.SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
+        return base.SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync();
     }
 
     [Fact]
-    public override Task SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync()
+    public override Task PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync()
     {
-        return base.SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync();
+        return base.PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync();
+    }
+
+    [Fact]
+    public override Task SubscribeAsync_WithDeserializationFailure_SkipsMessageAsync()
+    {
+        return base.SubscribeAsync_WithDeserializationFailure_SkipsMessageAsync();
     }
 
     [Fact]

--- a/tests/Foundatio.Tests/Messaging/InMemoryMessageBusTests.cs
+++ b/tests/Foundatio.Tests/Messaging/InMemoryMessageBusTests.cs
@@ -180,6 +180,42 @@ public class InMemoryMessageBusTests : MessageBusTestBase, IDisposable
     }
 
     [Fact]
+    public override Task DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync()
+    {
+        return base.DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync();
+    }
+
+    [Fact]
+    public override Task DisposeAsync_CalledMultipleTimes_IsIdempotentAsync()
+    {
+        return base.DisposeAsync_CalledMultipleTimes_IsIdempotentAsync();
+    }
+
+    [Fact]
+    public override Task SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync()
+    {
+        return base.SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync();
+    }
+
+    [Fact]
+    public override Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+    {
+        return base.SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
+    }
+
+    [Fact]
+    public override Task PublishAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+    {
+        return base.PublishAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
+    }
+
+    [Fact]
+    public override Task DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync()
+    {
+        return base.DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync();
+    }
+
+    [Fact]
     public async Task CanCheckMessageCounts()
     {
         var messageBus = new InMemoryMessageBus(o => o.LoggerFactory(Log));


### PR DESCRIPTION
## Summary

- **Add \IAsyncDisposable\ to \IMessageBus\** interface for proper async cleanup
- **Implement two-phase dispose** in \MessageBusBase\: \ShutdownAsync\ (graceful drain) then \CleanupAsync\ (resource teardown)
- **Add disposal guard** in \SendMessageToSubscribersAsync\ to prevent message processing during dispose
- **Simplify \CancellationToken.Register\** callbacks to only remove from subscriber dictionary
- **Add \NullMessageBus.DisposeAsync\** to satisfy interface contract
- **Add 6 shared lifecycle tests** to \MessageBusTestBase\ (dispose without exceptions, idempotent dispose, cancel token without teardown, subscribe/publish after dispose, dispose while publishing)
- **Update messaging docs** with disposal lifecycle, message durability table by provider, and custom provider guidance

## Test plan

- [x] All 1845 Foundatio core tests pass (0 failures)
- [ ] CI verifies no regressions
- [ ] Provider PRs pass CI with integration tests

## Related Provider PRs

- RabbitMQ: FoundatioFx/Foundatio.RabbitMQ#73
- AWS (SQS): FoundatioFx/Foundatio.AWS#400
- Azure Service Bus: FoundatioFx/Foundatio.AzureServiceBus#77
- Kafka: FoundatioFx/Foundatio.Kafka#54
- Redis: FoundatioFx/Foundatio.Redis#161