### PR TITLE
Fix NRT code smells: QueueEntry, LogEntry, conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,18 @@ docs                                  # Documentation site
 - Write complete, runnable code—no placeholders, TODOs, or `// existing code...` comments
 - Use modern C# features: pattern matching, nullable references, `is` expressions, target-typed `new()`
 - Follow SOLID, DRY principles; remove unused code and parameters
+
+### Nullable Reference Types (NRT) Conventions
+
+The codebase has NRT enabled. Follow these patterns:
+
+- **Entity/model properties** (`= null!`): Acceptable for properties set by deserialization or ORM frameworks. Prefer `required` keyword where construction is controlled.
+- **Expression tree `!`**: Required when expressions like `SortDescending(x => x.DateCreatedUtc!)` box `DateTime?` to `object?` but the delegate expects `object`. The value is never evaluated -- only used for field path extraction. This is correct and unavoidable.
+- **`.Where(x => x is not null).Select(x => x!)`**: The compiler can't prove non-null through a lambda boundary after filtering. This is the idiomatic post-filter pattern.
+- **`null!` in test `Assert.Throws` calls**: Intentional contract violation to test null guards.
+- **`[return: MaybeNull]` with `return default!`**: Idiomatic pattern for unconstrained generic methods that may return null (e.g., `Deserialize<T>`).
+- **Vendored code** (`#nullable disable`): Leave internalized third-party code (FastCloner, Nito) as-is. Ensure public API boundaries have proper null checks.
+- **Avoid `!` to forward nullable parameters**: Prefer making the parameter nullable on the interface, or calling an overload that accepts nullable (e.g., `options?.Configure()` instead of `options!`).
 - Clear, descriptive naming; prefer explicit over clever
 - Use `AnyContext()` (e.g., `ConfigureAwait(false)`) in library code (not in tests)
 - Prefer `ValueTask<T>` for hot paths that may complete synchronously

--- a/src/Foundatio.Xunit.v3/Logging/LogEntry.cs
+++ b/src/Foundatio.Xunit.v3/Logging/LogEntry.cs
@@ -7,13 +7,13 @@ namespace Foundatio.Xunit;
 public class LogEntry
 {
     public DateTimeOffset Date { get; set; }
-    public string CategoryName { get; set; } = null!;
+    public required string CategoryName { get; set; }
     public LogLevel LogLevel { get; set; }
-    public object[] Scopes { get; set; } = null!;
+    public required object[] Scopes { get; set; }
     public EventId EventId { get; set; }
     public object? State { get; set; }
     public Exception? Exception { get; set; }
-    public Func<object?, Exception?, string> Formatter { get; set; } = null!;
+    public required Func<object?, Exception?, string> Formatter { get; set; }
     public IDictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
 
     public string Message => Formatter(State, Exception);

--- a/src/Foundatio.Xunit.v3/Logging/LogEntry.cs
+++ b/src/Foundatio.Xunit.v3/Logging/LogEntry.cs
@@ -7,13 +7,13 @@ namespace Foundatio.Xunit;
 public class LogEntry
 {
     public DateTimeOffset Date { get; set; }
-    public required string CategoryName { get; set; }
+    public string CategoryName { get; set; } = string.Empty;
     public LogLevel LogLevel { get; set; }
-    public required object[] Scopes { get; set; }
+    public object[] Scopes { get; set; } = [];
     public EventId EventId { get; set; }
     public object? State { get; set; }
     public Exception? Exception { get; set; }
-    public required Func<object?, Exception?, string> Formatter { get; set; }
+    public Func<object?, Exception?, string> Formatter { get; set; } = static (s, _) => s?.ToString() ?? string.Empty;
     public IDictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
 
     public string Message => Formatter(State, Exception);

--- a/src/Foundatio.Xunit.v3/Logging/LogEntry.cs
+++ b/src/Foundatio.Xunit.v3/Logging/LogEntry.cs
@@ -7,13 +7,13 @@ namespace Foundatio.Xunit;
 public class LogEntry
 {
     public DateTimeOffset Date { get; set; }
-    public string CategoryName { get; set; } = string.Empty;
+    public required string CategoryName { get; set; }
     public LogLevel LogLevel { get; set; }
-    public object[] Scopes { get; set; } = [];
+    public required object[] Scopes { get; set; }
     public EventId EventId { get; set; }
     public object? State { get; set; }
     public Exception? Exception { get; set; }
-    public Func<object?, Exception?, string> Formatter { get; set; } = static (s, _) => s?.ToString() ?? string.Empty;
+    public required Func<object?, Exception?, string> Formatter { get; set; }
     public IDictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
 
     public string Message => Formatter(State, Exception);

--- a/src/Foundatio.Xunit/Logging/LogEntry.cs
+++ b/src/Foundatio.Xunit/Logging/LogEntry.cs
@@ -7,13 +7,13 @@ namespace Foundatio.Xunit;
 public class LogEntry
 {
     public DateTimeOffset Date { get; set; }
-    public string CategoryName { get; set; } = null!;
+    public required string CategoryName { get; set; }
     public LogLevel LogLevel { get; set; }
-    public object[] Scopes { get; set; } = null!;
+    public required object[] Scopes { get; set; }
     public EventId EventId { get; set; }
     public object? State { get; set; }
     public Exception? Exception { get; set; }
-    public Func<object?, Exception?, string> Formatter { get; set; } = null!;
+    public required Func<object?, Exception?, string> Formatter { get; set; }
     public IDictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
 
     public string Message => Formatter(State, Exception);

--- a/src/Foundatio.Xunit/Logging/LogEntry.cs
+++ b/src/Foundatio.Xunit/Logging/LogEntry.cs
@@ -7,13 +7,13 @@ namespace Foundatio.Xunit;
 public class LogEntry
 {
     public DateTimeOffset Date { get; set; }
-    public required string CategoryName { get; set; }
+    public string CategoryName { get; set; } = string.Empty;
     public LogLevel LogLevel { get; set; }
-    public required object[] Scopes { get; set; }
+    public object[] Scopes { get; set; } = [];
     public EventId EventId { get; set; }
     public object? State { get; set; }
     public Exception? Exception { get; set; }
-    public required Func<object?, Exception?, string> Formatter { get; set; }
+    public Func<object?, Exception?, string> Formatter { get; set; } = static (s, _) => s?.ToString() ?? string.Empty;
     public IDictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
 
     public string Message => Formatter(State, Exception);

--- a/src/Foundatio.Xunit/Logging/LogEntry.cs
+++ b/src/Foundatio.Xunit/Logging/LogEntry.cs
@@ -7,13 +7,13 @@ namespace Foundatio.Xunit;
 public class LogEntry
 {
     public DateTimeOffset Date { get; set; }
-    public string CategoryName { get; set; } = string.Empty;
+    public required string CategoryName { get; set; }
     public LogLevel LogLevel { get; set; }
-    public object[] Scopes { get; set; } = [];
+    public required object[] Scopes { get; set; }
     public EventId EventId { get; set; }
     public object? State { get; set; }
     public Exception? Exception { get; set; }
-    public Func<object?, Exception?, string> Formatter { get; set; } = static (s, _) => s?.ToString() ?? string.Empty;
+    public required Func<object?, Exception?, string> Formatter { get; set; }
     public IDictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
 
     public string Message => Formatter(State, Exception);

--- a/src/Foundatio/Queues/IQueueEntry.cs
+++ b/src/Foundatio/Queues/IQueueEntry.cs
@@ -29,9 +29,9 @@ public interface IQueueEntry
     /// Gets the CLR type of the message payload.
     /// </summary>
     /// <remarks>
-    /// For poison messages (deserialization failures), the return value may be <c>null</c> at runtime.
+    /// For poison messages (deserialization failures), the return value is <c>null</c>.
     /// </remarks>
-    Type EntryType { get; }
+    Type? EntryType { get; }
 
     /// <summary>
     /// Gets the message payload as an untyped object.

--- a/src/Foundatio/Queues/QueueEntry.cs
+++ b/src/Foundatio/Queues/QueueEntry.cs
@@ -28,8 +28,7 @@ public class QueueEntry<T> : IQueueEntry<T>, IQueueEntryMetadata, IAsyncDisposab
     public bool IsCompleted { get; private set; }
     public bool IsAbandoned { get; private set; }
 
-    public Type EntryType => Value?.GetType()
-        ?? throw new InvalidOperationException("Cannot get EntryType: Value is null (poison message).");
+    public Type? EntryType => Value?.GetType();
     public object GetValue() => Value;
     public T Value { get; set; }
     public DateTime EnqueuedTimeUtc { get; set; }

--- a/src/Foundatio/Queues/QueueEntry.cs
+++ b/src/Foundatio/Queues/QueueEntry.cs
@@ -28,7 +28,8 @@ public class QueueEntry<T> : IQueueEntry<T>, IQueueEntryMetadata, IAsyncDisposab
     public bool IsCompleted { get; private set; }
     public bool IsAbandoned { get; private set; }
 
-    public Type EntryType => Value?.GetType()!;
+    public Type EntryType => Value?.GetType()
+        ?? throw new InvalidOperationException("Cannot get EntryType: Value is null (poison message).");
     public object GetValue() => Value;
     public T Value { get; set; }
     public DateTime EnqueuedTimeUtc { get; set; }

--- a/tests/Foundatio.Tests/Queue/InMemoryQueueTests.cs
+++ b/tests/Foundatio.Tests/Queue/InMemoryQueueTests.cs
@@ -409,7 +409,7 @@ public class InMemoryQueueTests : QueueTestBase
 
         public IDictionary<string, string> Properties => _queueEntry.Properties;
 
-        public Type EntryType => _queueEntry.EntryType;
+        public Type? EntryType => _queueEntry.EntryType;
 
         public bool IsCompleted => _queueEntry.IsCompleted;
 


### PR DESCRIPTION
## Summary

- **QueueEntry.EntryType**: Changed from non-nullable `Type` to `Type?` on both `IQueueEntry` and `QueueEntry<T>`. Poison messages have `Value == null`, so `Value?.GetType()` legitimately returns null. All callers already use `?.` defensively (e.g., `entry.EntryType?.Name`). Updated the test wrapper in `InMemoryQueueTests.cs` to match.
- **LogEntry**: Replace `= null!` initializers with `required` keyword on `CategoryName`, `Scopes`, and `Formatter` properties (both xunit and xunit.v3). This is an intentional source-breaking change -- callers *must* provide these values. Both internal construction sites already set all three properties.
- **AGENTS.md**: Document acceptable NRT patterns (expression tree `!`, entity `null!`, post-filter `!`, vendored code) so future contributors know which `!` usages are intentional vs code smells.

## Test plan

- [x] CI passes -- 0 warnings, 0 errors on `dotnet build`
- [ ] Existing tests pass with no regressions
- [ ] QueueEntry.EntryType `Type?` doesn't break callers (verified: all callers use `?.` defensively)
