### PR TITLE
LogState LogError nullable exception + matching exception overloads for other log levels

### DIFF
--- a/src/Foundatio/Extensions/LoggerExtensions.cs
+++ b/src/Foundatio/Extensions/LoggerExtensions.cs
@@ -91,7 +91,7 @@ public static class LoggerExtensions
             logger.LogError(message, args);
     }
 
-    public static void LogError(this ILogger logger, Func<LogState, LogState> stateBuilder, Exception exception, string message, params object?[] args)
+    public static void LogError(this ILogger logger, Func<LogState, LogState> stateBuilder, Exception? exception, string message, params object?[] args)
     {
         using (BeginScope(logger, stateBuilder))
             logger.LogError(exception, message, args);

--- a/src/Foundatio/Extensions/LoggerExtensions.cs
+++ b/src/Foundatio/Extensions/LoggerExtensions.cs
@@ -67,10 +67,22 @@ public static class LoggerExtensions
             logger.LogDebug(message, args);
     }
 
+    public static void LogDebug(this ILogger logger, Func<LogState, LogState> stateBuilder, Exception? exception, string message, params object?[] args)
+    {
+        using (BeginScope(logger, stateBuilder))
+            logger.LogDebug(exception, message, args);
+    }
+
     public static void LogTrace(this ILogger logger, Func<LogState, LogState> stateBuilder, string message, params object?[] args)
     {
         using (BeginScope(logger, stateBuilder))
             logger.LogTrace(message, args);
+    }
+
+    public static void LogTrace(this ILogger logger, Func<LogState, LogState> stateBuilder, Exception? exception, string message, params object?[] args)
+    {
+        using (BeginScope(logger, stateBuilder))
+            logger.LogTrace(exception, message, args);
     }
 
     public static void LogInformation(this ILogger logger, Func<LogState, LogState> stateBuilder, string message, params object?[] args)
@@ -79,10 +91,22 @@ public static class LoggerExtensions
             logger.LogInformation(message, args);
     }
 
+    public static void LogInformation(this ILogger logger, Func<LogState, LogState> stateBuilder, Exception? exception, string message, params object?[] args)
+    {
+        using (BeginScope(logger, stateBuilder))
+            logger.LogInformation(exception, message, args);
+    }
+
     public static void LogWarning(this ILogger logger, Func<LogState, LogState> stateBuilder, string message, params object?[] args)
     {
         using (BeginScope(logger, stateBuilder))
             logger.LogWarning(message, args);
+    }
+
+    public static void LogWarning(this ILogger logger, Func<LogState, LogState> stateBuilder, Exception? exception, string message, params object?[] args)
+    {
+        using (BeginScope(logger, stateBuilder))
+            logger.LogWarning(exception, message, args);
     }
 
     public static void LogError(this ILogger logger, Func<LogState, LogState> stateBuilder, string message, params object?[] args)
@@ -101,6 +125,12 @@ public static class LoggerExtensions
     {
         using (BeginScope(logger, stateBuilder))
             logger.LogCritical(message, args);
+    }
+
+    public static void LogCritical(this ILogger logger, Func<LogState, LogState> stateBuilder, Exception? exception, string message, params object?[] args)
+    {
+        using (BeginScope(logger, stateBuilder))
+            logger.LogCritical(exception, message, args);
     }
 
     public static LogState Critical(this LogState builder, bool isCritical = true)


### PR DESCRIPTION
## What

Two related fixes to `Foundatio.LoggerExtensions` (the `LogState`-accepting log helpers).

### 1. Allow null `Exception` in the existing `LogError` overload

```diff
-public static void LogError(this ILogger logger, Func<LogState, LogState> stateBuilder, Exception exception, string message, params object?[] args)
+public static void LogError(this ILogger logger, Func<LogState, LogState> stateBuilder, Exception? exception, string message, params object?[] args)
```

Annotation-only. The body already forwards to `ILogger.LogError(Exception?, string, params object?[])`, which has always accepted null — only the wrapper's annotation forced callers into `!` suppression or splitting into an if/else over two overloads.

Real-world example from a downstream consumer (a generic error handler with `Exception? ex`):

```csharp
public override Task<bool> HandleErrorAsync(Exception? ex, ...)
{
    string message = $"Error processing action: {ex?.Message ?? ErrorMessage}";

    _logger.LogError(s => s.Client(...).Critical(IsCritical), ex, message);
    //                                                       ^^ CS8604
}
```

`AGENTS.md` explicitly calls out the workarounds as wrong:

> **Avoid `!` to forward nullable parameters**: Prefer making the parameter nullable on the interface, or calling an overload that accepts nullable.

This also matches `Microsoft.Extensions.Logging.LoggerExtensions`, where every exception-accepting overload takes `Exception?`.

### 2. Add matching `Exception?` overloads for the other levels

`LogError` was the only level with a `LogState` + `Exception` overload. Added the same shape for `LogTrace`, `LogDebug`, `LogInformation`, `LogWarning`, and `LogCritical` so callers can attach a captured exception at any severity without falling back to a plain `ILogger.LogX` call (which loses the `LogState` scope).

```csharp
public static void LogWarning(this ILogger logger, Func<LogState, LogState> stateBuilder, Exception? exception, string message, params object?[] args)
{
    using (BeginScope(logger, stateBuilder))
        logger.LogWarning(exception, message, args);
}
```

(plus the same for Trace/Debug/Information/Critical.)

## Compatibility

- (1) is annotation-only; source-compatible. Callers passing a non-null `Exception` keep compiling unchanged; callers with a nullable variable can drop their `!`.
- (2) is purely additive — six new overloads, no existing call sites change resolution.

## Test plan

- [x] `dotnet build src/Foundatio/Foundatio.csproj` (0 warnings, 0 errors on net8.0 and net10.0)