### PR TITLE
Default JobResult.Message to empty string

### DIFF
--- a/src/Foundatio/Jobs/JobResult.cs
+++ b/src/Foundatio/Jobs/JobResult.cs
@@ -7,7 +7,7 @@ public class JobResult
 {
     public bool IsCancelled { get; set; }
     public Exception? Error { get; set; }
-    public string Message { get; set; } = string.Empty;
+    public string Message { get; set; } = String.Empty;
     public bool IsSuccess { get; set; }
 
     public static readonly JobResult None = new()

--- a/src/Foundatio/Jobs/JobResult.cs
+++ b/src/Foundatio/Jobs/JobResult.cs
@@ -7,13 +7,12 @@ public class JobResult
 {
     public bool IsCancelled { get; set; }
     public Exception? Error { get; set; }
-    public string? Message { get; set; }
+    public string Message { get; set; } = string.Empty;
     public bool IsSuccess { get; set; }
 
     public static readonly JobResult None = new()
     {
-        IsSuccess = true,
-        Message = String.Empty
+        IsSuccess = true
     };
 
     public static readonly JobResult Cancelled = new()

--- a/src/Foundatio/Jobs/QueueJobBase.cs
+++ b/src/Foundatio/Jobs/QueueJobBase.cs
@@ -129,8 +129,9 @@ public abstract class QueueJobBase<T> : IQueueJob<T>, IHaveLogger, IHaveLoggerFa
             }
             else
             {
-                if (result.Error != null || result.Message != null)
-                    _logger.LogError(result.Error, "{QueueName} queue entry {QueueEntryId} returned an unsuccessful response: {Message}", _queueName, queueEntry.Id, result.Message ?? result.Error?.Message);
+                string? message = !String.IsNullOrEmpty(result.Message) ? result.Message : result.Error?.Message;
+                if (result.Error != null || !String.IsNullOrEmpty(message))
+                    _logger.LogError(result.Error, "{QueueName} queue entry {QueueEntryId} returned an unsuccessful response: {Message}", _queueName, queueEntry.Id, message);
 
                 _logger.LogTrace("Processing was not successful. Auto Abandoning {QueueName} queue entry: {QueueEntryId}", _queueName, queueEntry.Id);
                 await queueEntry.AbandonAsync().AnyContext();


### PR DESCRIPTION
## What

```diff
-public string? Message { get; set; }
+public string Message { get; set; } = string.Empty;
```

(plus dropping the now-redundant `Message = String.Empty` initializer on `JobResult.None`, and updating `QueueJobBase` to use `String.IsNullOrEmpty` instead of null comparisons.)

## Why

`JobResult.Message` was annotated nullable with no default. Every consumer that forwarded it into a non-null string parameter — a downstream result-model field, a log line, a test assertion message — had to write `result.Message ?? string.Empty` at the call site to satisfy NRT.

Real example from a downstream consumer (a script runner mapping `JobResult` → `RunScriptResult`):

```csharp
return jobResult.IsSuccess
    ? new RunScriptResult { SuccessMessage = jobResult.Message ?? string.Empty, SuccessCount = 1 }
    : RunScriptResult.Fail(jobResult.Message ?? string.Empty);
```

That `?? string.Empty` is meaningless — "the job ran and emitted no message" is naturally an empty string, not null. Defaulting to `string.Empty` lets the field do what every consumer wanted anyway.

`JobResult.None` already initialized `Message = String.Empty` explicitly; that line is now redundant and removed.

## Behavior change

- `JobResult.Cancelled` and `JobResult.Success` static instances: `Message` was previously `null`, now `string.Empty`. The only consumer in this repo (`JobResultExtensions.LogJobResult`) gates on `String.IsNullOrEmpty(result.Message)`, so behavior is unchanged.
- `QueueJobBase.cs:132-133` previously used `result.Message != null` and `result.Message ?? result.Error?.Message`. Updated to use `String.IsNullOrEmpty` so the "no message, fall through to Error.Message" branch keeps working.

## Compatibility

- Source: callers passing `string` keep compiling. Callers reading `Message` and treating it as nullable (`result.Message ?? ...`, `result.Message?.Foo`) keep compiling — the `?` becomes redundant but isn't an error.
- Binary: property type signature changes from `string?` to `string` (NRT annotation only, IL-identical for reference types). Callers that branched on `result.Message == null` will now hit the false branch instead of true when no message was set; covered by the `QueueJobBase` update above.

## Test plan

- [x] `dotnet build Foundatio.slnx` (0 warnings, 0 errors on net8.0 and net10.0)
- [x] `dotnet test tests/Foundatio.Tests/Foundatio.Tests.csproj` — 1845 passed, 13 skipped, 0 failed