### PR TITLE
Make AcquireAsync throw on failure to fix the silent-null lock footgun

### DIFF
--- a/docs/guide/locks.md
+++ b/docs/guide/locks.md
@@ -9,9 +9,9 @@ Locks ensure a resource is only accessed by one consumer at any given time. Foun
 ```csharp
 public interface ILockProvider
 {
-    Task<ILock?> AcquireAsync(string resource, TimeSpan? timeUntilExpires = null,
-                               bool releaseOnDispose = true,
-                               CancellationToken cancellationToken = default);
+    Task<ILock?> TryAcquireAsync(string resource, TimeSpan? timeUntilExpires = null,
+                                  bool releaseOnDispose = true,
+                                  CancellationToken cancellationToken = default);
     Task<bool> IsLockedAsync(string resource);
     Task ReleaseAsync(string resource, string lockId);
     Task ReleaseAsync(string resource);
@@ -30,6 +30,17 @@ public interface ILock : IAsyncDisposable
 }
 ```
 
+### Choosing Between `AcquireAsync` and `TryAcquireAsync`
+
+`ILockProvider` exposes two acquisition shapes:
+
+| API | Returns | Use when |
+| --- | --- | --- |
+| `TryAcquireAsync` | `Task<ILock?>` — `null` on failure | Lock unavailability is a normal control-flow outcome (best-effort dedupe, opportunistic work) |
+| `AcquireAsync` | `Task<ILock>` — throws `LockAcquisitionTimeoutException` on failure | The work cannot safely run without the lock — failure is genuinely exceptional |
+
+The throwing `AcquireAsync` is provided as an extension method on `ILockProvider`. Pick whichever one matches the caller's intent — they share the same underlying acquisition logic.
+
 ## Implementations
 
 ### CacheLockProvider
@@ -47,8 +58,8 @@ var cache = new InMemoryCacheClient();
 var messageBus = new InMemoryMessageBus();
 var locker = new CacheLockProvider(cache, messageBus);
 
-await using var lck = await locker.AcquireAsync("my-resource");
-if (lck != null)
+await using var lck = await locker.TryAcquireAsync("my-resource");
+if (lck is not null)
 {
     // Exclusive access to resource
     await DoExclusiveWorkAsync();
@@ -80,8 +91,8 @@ var throttledLocker = new ThrottlingLockProvider(
 );
 
 // Only allows 10 operations per minute across all instances
-var lck = await throttledLocker.AcquireAsync("api-rate-limit");
-if (lck != null)
+var lck = await throttledLocker.TryAcquireAsync("api-rate-limit");
+if (lck is not null)
 {
     await CallExternalApiAsync();
     await lck.ReleaseAsync();
@@ -106,7 +117,7 @@ var baseLock = new CacheLockProvider(cache, messageBus);
 var tenantLock = new ScopedLockProvider(baseLock, "tenant:abc");
 
 // Lock key becomes: "tenant:abc:resource-1"
-await using var lck = await tenantLock.AcquireAsync("resource-1");
+await using var lck = await tenantLock.TryAcquireAsync("resource-1");
 ```
 
 ## Basic Usage
@@ -116,10 +127,10 @@ await using var lck = await tenantLock.AcquireAsync("resource-1");
 ```csharp
 var locker = new CacheLockProvider(cache, messageBus);
 
-// Acquire lock
-var lck = await locker.AcquireAsync("my-resource");
+// Best-effort acquire — null when held elsewhere
+var lck = await locker.TryAcquireAsync("my-resource");
 
-if (lck != null)
+if (lck is not null)
 {
     try
     {
@@ -139,8 +150,8 @@ if (lck != null)
 The recommended pattern uses `await using` for automatic release:
 
 ```csharp
-await using var lck = await locker.AcquireAsync("my-resource");
-if (lck != null)
+await using var lck = await locker.TryAcquireAsync("my-resource");
+if (lck is not null)
 {
     // Lock is automatically released when scope ends
     await DoExclusiveWorkAsync();
@@ -149,11 +160,11 @@ if (lck != null)
 
 ### Non-Blocking Acquire
 
-Check if lock was acquired:
+Try to acquire without waiting:
 
 ```csharp
-await using var lck = await locker.AcquireAsync("my-resource");
-if (lck == null)
+await using var lck = await locker.TryAcquireAsync("my-resource");
+if (lck is null)
 {
     // Resource is locked by another process
     return;
@@ -165,28 +176,38 @@ await DoWorkAsync();
 
 ### Blocking Acquire with Timeout
 
-Wait for lock with cancellation:
+Wait up to a timeout, throwing on failure:
 
 ```csharp
-using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-
 try
 {
     await using var lck = await locker.AcquireAsync(
         "my-resource",
-        cancellationToken: cts.Token
-    );
+        acquireTimeout: TimeSpan.FromSeconds(30));
 
-    if (lck != null)
-    {
-        await DoWorkAsync();
-    }
+    await DoWorkAsync();
 }
-catch (OperationCanceledException)
+catch (LockAcquisitionTimeoutException)
 {
-    // Timeout waiting for lock
+    // Lock could not be acquired before the timeout elapsed.
     _logger.LogWarning("Timed out waiting for lock");
 }
+```
+
+If the failure is expected control flow, prefer `TryAcquireAsync` so you don't pay for an exception:
+
+```csharp
+await using var lck = await locker.TryAcquireAsync(
+    "my-resource",
+    acquireTimeout: TimeSpan.FromSeconds(30));
+
+if (lck is null)
+{
+    _logger.LogWarning("Could not acquire lock");
+    return;
+}
+
+await DoWorkAsync();
 ```
 
 ## Lock Expiration
@@ -197,7 +218,7 @@ Locks expire automatically to prevent deadlocks:
 
 ```csharp
 // Lock expires after 5 minutes
-await using var lck = await locker.AcquireAsync(
+await using var lck = await locker.TryAcquireAsync(
     "my-resource",
     timeUntilExpires: TimeSpan.FromMinutes(5)
 );
@@ -208,12 +229,12 @@ await using var lck = await locker.AcquireAsync(
 For long-running operations, renew the lock:
 
 ```csharp
-await using var lck = await locker.AcquireAsync(
+await using var lck = await locker.TryAcquireAsync(
     "my-resource",
     timeUntilExpires: TimeSpan.FromMinutes(1)
 );
 
-if (lck != null)
+if (lck is not null)
 {
     // Do some work
     await DoPartOneAsync();
@@ -231,8 +252,8 @@ if (lck != null)
 For very long operations, set up automatic renewal:
 
 ```csharp
-await using var lck = await locker.AcquireAsync("my-resource");
-if (lck == null) return;
+await using var lck = await locker.TryAcquireAsync("my-resource");
+if (lck is null) return;
 
 using var cts = new CancellationTokenSource();
 
@@ -265,9 +286,9 @@ Ensure only one instance processes a resource:
 ```csharp
 public async Task ProcessOrderAsync(int orderId)
 {
-    await using var lck = await _locker.AcquireAsync($"order:{orderId}");
+    await using var lck = await _locker.TryAcquireAsync($"order:{orderId}");
 
-    if (lck == null)
+    if (lck is null)
     {
         _logger.LogInformation("Order {OrderId} is being processed elsewhere", orderId);
         return;
@@ -287,9 +308,9 @@ public async Task RunAsLeaderAsync(CancellationToken ct)
 {
     while (!ct.IsCancellationRequested)
     {
-        await using var lck = await _locker.AcquireAsync("leader:job-runner");
+        await using var lck = await _locker.TryAcquireAsync("leader:job-runner");
 
-        if (lck != null)
+        if (lck is not null)
         {
             _logger.LogInformation("This instance is now the leader");
 
@@ -315,16 +336,12 @@ public async Task RunAsLeaderAsync(CancellationToken ct)
 ```csharp
 public async Task<Order> CreateOrderAsync(CreateOrderRequest request)
 {
-    // Prevent duplicate orders for same customer
+    // Prevent duplicate orders for same customer; throw if we can't lock.
     await using var lck = await _locker.AcquireAsync(
         $"create-order:{request.CustomerId}",
-        timeUntilExpires: TimeSpan.FromSeconds(30)
+        timeUntilExpires: TimeSpan.FromSeconds(30),
+        acquireTimeout: TimeSpan.FromSeconds(5)
     );
-
-    if (lck == null)
-    {
-        throw new ConcurrencyException("Another order is being created");
-    }
 
     // Check for recent duplicates
     var recentOrder = await _db.GetRecentOrderAsync(request.CustomerId);
@@ -380,9 +397,9 @@ public class RateLimitedApiClient
 
     public async Task<T> GetAsync<T>(string endpoint)
     {
-        await using var lck = await _throttler.AcquireAsync("external-api");
+        await using var lck = await _throttler.TryAcquireAsync("external-api");
 
-        if (lck == null)
+        if (lck is null)
         {
             throw new RateLimitExceededException();
         }
@@ -399,9 +416,9 @@ public class RateLimitedApiClient
 public async Task<IActionResult> ProcessRequest(string userId)
 {
     // 10 requests per minute per user
-    await using var lck = await _throttler.AcquireAsync($"user:{userId}:api");
+    await using var lck = await _throttler.TryAcquireAsync($"user:{userId}:api");
 
-    if (lck == null)
+    if (lck is null)
     {
         return StatusCode(429, "Too many requests");
     }
@@ -476,57 +493,37 @@ services.AddKeyedSingleton<ILockProvider>("throttle", (sp, _) =>
 
 ## Best Practices
 
-### 1. Always Handle Null Lock
+### 1. Pick the API That Matches Your Intent
 
-**Critical:** `AcquireAsync` returns `null` when the lock cannot be acquired. You **must** handle this case.
+If failure to acquire is **normal control flow** (best-effort dedupe, opportunistic work), call `TryAcquireAsync` and check for `null`. If failure is **genuinely exceptional** (the work cannot run safely without the lock), call `AcquireAsync` and let it throw.
 
 ```csharp
-// ✅ Good: Check for null and handle appropriately
-await using var lck = await locker.AcquireAsync("resource");
-
+// ✅ Best-effort: skip work when lock is held elsewhere
+await using var lck = await locker.TryAcquireAsync("resource");
 if (lck is null)
-{
-    _logger.LogWarning("Could not acquire lock for resource");
-    return; // or throw, or retry
-}
+    return;
 
 await DoWork();
 
-// ✅ Good: Throw when lock is required
-await using var lck = await locker.AcquireAsync("resource");
-
-if (lck is null)
-    throw new InvalidOperationException("Failed to acquire lock on 'resource'");
-
+// ✅ Required lock: throw if we can't get it
+await using var lck = await locker.AcquireAsync("resource",
+    acquireTimeout: TimeSpan.FromSeconds(5));
 await DoWork();
-
-// ❌ Bad: Assume lock acquired
-await using var lck = await locker.AcquireAsync("resource");
-await DoWork(); // May not have the lock!
+// ↑ If acquisition fails, LockAcquisitionTimeoutException propagates.
 ```
 
-### 2. Common Null-Handling Patterns
+::: warning
+Do not catch `LockAcquisitionTimeoutException` to convert "couldn't acquire" into a normal control-flow path — that is exactly the case `TryAcquireAsync` is designed for. Use the right method up front.
+:::
 
-**Pattern: Throw Exception**
+### 2. Common Patterns
 
-```csharp
-public async Task ProcessOrderAsync(int orderId)
-{
-    await using var lck = await _locker.AcquireAsync($"order:{orderId}");
-
-    if (lck is null)
-        throw new ConcurrencyException($"Order {orderId} is being processed by another worker");
-
-    await DoProcessingAsync(orderId);
-}
-```
-
-**Pattern: Skip Processing**
+**Pattern: Skip Processing (best-effort)**
 
 ```csharp
 public async Task TryProcessOrderAsync(int orderId)
 {
-    await using var lck = await _locker.AcquireAsync($"order:{orderId}");
+    await using var lck = await _locker.TryAcquireAsync($"order:{orderId}");
 
     if (lck is null)
     {
@@ -538,32 +535,42 @@ public async Task TryProcessOrderAsync(int orderId)
 }
 ```
 
-**Pattern: Retry with Timeout**
+**Pattern: Required Lock (throws)**
 
 ```csharp
-public async Task ProcessOrderWithRetryAsync(int orderId, CancellationToken ct)
+public async Task ProcessOrderAsync(int orderId)
+{
+    // Throws LockAcquisitionTimeoutException if the lock can't be acquired.
+    await using var lck = await _locker.AcquireAsync(
+        $"order:{orderId}",
+        acquireTimeout: TimeSpan.FromSeconds(30));
+
+    await DoProcessingAsync(orderId);
+}
+```
+
+**Pattern: Wait with Cancellation**
+
+```csharp
+public async Task ProcessOrderAsync(int orderId, CancellationToken ct)
 {
     using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
     timeoutCts.CancelAfter(TimeSpan.FromSeconds(30));
 
     await using var lck = await _locker.AcquireAsync(
         $"order:{orderId}",
-        cancellationToken: timeoutCts.Token
-    );
-
-    if (lck is null)
-        throw new TimeoutException($"Timed out waiting for lock on order {orderId}");
+        cancellationToken: timeoutCts.Token);
 
     await DoProcessingAsync(orderId);
 }
 ```
 
-**Pattern: Return Result**
+**Pattern: Return Result (best-effort)**
 
 ```csharp
 public async Task<LockResult<T>> TryWithLockAsync<T>(string resource, Func<Task<T>> work)
 {
-    await using var lck = await _locker.AcquireAsync(resource);
+    await using var lck = await _locker.TryAcquireAsync(resource);
 
     if (lck is null)
         return LockResult<T>.NotAcquired();
@@ -577,20 +584,20 @@ public async Task<LockResult<T>> TryWithLockAsync<T>(string resource, Func<Task<
 
 ```csharp
 // ✅ Good: Descriptive, hierarchical
-await locker.AcquireAsync($"order:process:{orderId}");
-await locker.AcquireAsync($"user:{userId}:balance:update");
+await locker.TryAcquireAsync($"order:process:{orderId}");
+await locker.TryAcquireAsync($"user:{userId}:balance:update");
 
 // ❌ Bad: Generic, ambiguous
-await locker.AcquireAsync("lock1");
-await locker.AcquireAsync("resource");
+await locker.TryAcquireAsync("lock1");
+await locker.TryAcquireAsync("resource");
 ```
 
 ### 4. Set Appropriate Expiration
 
 ```csharp
 // Match expiration to expected operation duration + buffer
-await locker.AcquireAsync("quick-op", TimeSpan.FromSeconds(30));   // 10s operation + buffer
-await locker.AcquireAsync("long-op", TimeSpan.FromMinutes(10));    // 5min operation + buffer
+await locker.TryAcquireAsync("quick-op", TimeSpan.FromSeconds(30));   // 10s operation + buffer
+await locker.TryAcquireAsync("long-op", TimeSpan.FromMinutes(10));    // 5min operation + buffer
 ```
 
 ::: tip Default Expiration
@@ -603,7 +610,7 @@ Locks implement `IAsyncDisposable`. Using `await using` ensures the lock is rele
 
 ```csharp
 // ✅ Good: Automatic release on dispose
-await using var lck = await locker.AcquireAsync("resource");
+await using var lck = await locker.TryAcquireAsync("resource");
 
 if (lck is null)
     return;
@@ -612,7 +619,7 @@ await DoWork();
 // Lock is automatically released when scope ends
 
 // ✅ Good: Manual release when needed
-var lck = await locker.AcquireAsync("resource", releaseOnDispose: false);
+var lck = await locker.TryAcquireAsync("resource", releaseOnDispose: false);
 
 if (lck is null)
     return;
@@ -627,7 +634,7 @@ finally
 }
 
 // ❌ Bad: Not using dispose pattern
-var lck = await locker.AcquireAsync("resource");
+var lck = await locker.TryAcquireAsync("resource");
 
 if (lck is null)
     return;
@@ -648,8 +655,8 @@ var tenantLock = new ScopedLockProvider(baseLock, $"tenant:{tenantId}");
 Access lock metadata:
 
 ```csharp
-await using var lck = await locker.AcquireAsync("resource");
-if (lck != null)
+await using var lck = await locker.TryAcquireAsync("resource");
+if (lck is not null)
 {
     Console.WriteLine($"Lock ID: {lck.LockId}");
     Console.WriteLine($"Resource: {lck.Resource}");

--- a/docs/guide/locks.md
+++ b/docs/guide/locks.md
@@ -9,6 +9,9 @@ Locks ensure a resource is only accessed by one consumer at any given time. Foun
 ```csharp
 public interface ILockProvider
 {
+    Task<ILock> AcquireAsync(string resource, TimeSpan? timeUntilExpires = null,
+                              bool releaseOnDispose = true,
+                              CancellationToken cancellationToken = default);
     Task<ILock?> TryAcquireAsync(string resource, TimeSpan? timeUntilExpires = null,
                                   bool releaseOnDispose = true,
                                   CancellationToken cancellationToken = default);
@@ -36,10 +39,10 @@ public interface ILock : IAsyncDisposable
 
 | API | Returns | Use when |
 | --- | --- | --- |
-| `TryAcquireAsync` | `Task<ILock?>` — `null` on failure | Lock unavailability is a normal control-flow outcome (best-effort dedupe, opportunistic work) |
 | `AcquireAsync` | `Task<ILock>` — throws `LockAcquisitionTimeoutException` on failure | The work cannot safely run without the lock — failure is genuinely exceptional |
+| `TryAcquireAsync` | `Task<ILock?>` — `null` on failure | Lock unavailability is a normal control-flow outcome (best-effort dedupe, opportunistic work) |
 
-The throwing `AcquireAsync` is provided as an extension method on `ILockProvider`. Pick whichever one matches the caller's intent — they share the same underlying acquisition logic.
+Both are interface methods backed by the same acquisition logic — pick whichever one matches the caller's intent. `AcquireAsync` is the safer default: there is no null return to forget about, so the type system makes "ran the work without holding the lock" impossible to write by accident.
 
 ## Implementations
 

--- a/src/Foundatio.Extensions.Hosting/Jobs/ScheduledJobInstance.cs
+++ b/src/Foundatio.Extensions.Hosting/Jobs/ScheduledJobInstance.cs
@@ -191,12 +191,12 @@ internal class ScheduledJobInstance
             try
             {
                 // hold this lock for 1 hour to prevent duplicates
-                scheduledTimeLock = await _lockProvider.AcquireAsync(GetLockKey(scheduledTime), TimeSpan.FromHours(1), TimeSpan.Zero).AnyContext();
+                scheduledTimeLock = await _lockProvider.TryAcquireAsync(GetLockKey(scheduledTime), TimeSpan.FromHours(1), TimeSpan.Zero).AnyContext();
 
                 if (scheduledTimeLock is not null)
                 {
                     // hold this lock while the job is running to prevent multiple instances of the job running at the same time
-                    jobRunningLock = await _lockProvider.AcquireAsync(CacheKey, TimeSpan.FromMinutes(15), TimeSpan.Zero).AnyContext();
+                    jobRunningLock = await _lockProvider.TryAcquireAsync(CacheKey, TimeSpan.FromMinutes(15), TimeSpan.Zero).AnyContext();
 
                     if (jobRunningLock is null)
                         await scheduledTimeLock.ReleaseAsync().AnyContext();

--- a/src/Foundatio.TestHarness/Jobs/SampleQueueJob.cs
+++ b/src/Foundatio.TestHarness/Jobs/SampleQueueJob.cs
@@ -58,7 +58,7 @@ public class SampleQueueJobWithLocking : QueueJobBase<SampleQueueWorkItem>
     protected override Task<ILock?> GetQueueEntryLockAsync(IQueueEntry<SampleQueueWorkItem> queueEntry, CancellationToken cancellationToken = default(CancellationToken))
     {
         if (_lockProvider != null)
-            return _lockProvider.AcquireAsync("job", TimeSpan.FromMilliseconds(100), TimeSpan.Zero);
+            return _lockProvider.TryAcquireAsync("job", TimeSpan.FromMilliseconds(100), TimeSpan.Zero);
 
         return base.GetQueueEntryLockAsync(queueEntry, cancellationToken);
     }

--- a/src/Foundatio.TestHarness/Jobs/ThrottledJob.cs
+++ b/src/Foundatio.TestHarness/Jobs/ThrottledJob.cs
@@ -20,7 +20,7 @@ public class ThrottledJob : JobWithLockBase
 
     protected override Task<ILock?> GetLockAsync(CancellationToken cancellationToken = default)
     {
-        return _locker.AcquireAsync(nameof(ThrottledJob), acquireTimeout: TimeSpan.Zero);
+        return _locker.TryAcquireAsync(nameof(ThrottledJob), acquireTimeout: TimeSpan.Zero);
     }
 
     protected override Task<JobResult> RunInternalAsync(JobContext context)

--- a/src/Foundatio.TestHarness/Jobs/WithLockingJob.cs
+++ b/src/Foundatio.TestHarness/Jobs/WithLockingJob.cs
@@ -23,7 +23,7 @@ public class WithLockingJob : JobWithLockBase
 
     protected override Task<ILock?> GetLockAsync(CancellationToken cancellationToken = default(CancellationToken))
     {
-        return _locker.AcquireAsync(nameof(WithLockingJob), TimeSpan.FromSeconds(1), TimeSpan.Zero);
+        return _locker.TryAcquireAsync(nameof(WithLockingJob), TimeSpan.FromSeconds(1), TimeSpan.Zero);
     }
 
     protected override async Task<JobResult> RunInternalAsync(JobContext context)

--- a/src/Foundatio.TestHarness/Locks/LockTestBase.cs
+++ b/src/Foundatio.TestHarness/Locks/LockTestBase.cs
@@ -38,13 +38,13 @@ public abstract class LockTestBase : TestWithLoggingBase
             return;
 
         string lockName = Guid.NewGuid().ToString("N")[..10];
-        await using var lock1 = await locker.AcquireAsync(lockName, acquireTimeout: TimeSpan.FromMilliseconds(100), timeUntilExpires: TimeSpan.FromSeconds(1));
+        await using var lock1 = await locker.TryAcquireAsync(lockName, acquireTimeout: TimeSpan.FromMilliseconds(100), timeUntilExpires: TimeSpan.FromSeconds(1));
 
         try
         {
             Assert.NotNull(lock1);
             Assert.True(await locker.IsLockedAsync(lockName));
-            var lock2Task = locker.AcquireAsync(lockName, acquireTimeout: TimeSpan.FromMilliseconds(250));
+            var lock2Task = locker.TryAcquireAsync(lockName, acquireTimeout: TimeSpan.FromMilliseconds(250));
             await Task.Delay(TimeSpan.FromMilliseconds(250));
             Assert.Null(await lock2Task);
         }
@@ -78,12 +78,12 @@ public abstract class LockTestBase : TestWithLoggingBase
             return;
 
         string lockName = Guid.NewGuid().ToString("N")[..10];
-        var lock1 = await locker.AcquireAsync(lockName, acquireTimeout: TimeSpan.FromMilliseconds(100), timeUntilExpires: TimeSpan.FromSeconds(1));
+        var lock1 = await locker.TryAcquireAsync(lockName, acquireTimeout: TimeSpan.FromMilliseconds(100), timeUntilExpires: TimeSpan.FromSeconds(1));
         Assert.NotNull(lock1);
         await lock1.ReleaseAsync();
         Assert.False(await locker.IsLockedAsync(lockName));
 
-        await using var lock2 = await locker.AcquireAsync(lockName, acquireTimeout: TimeSpan.FromMilliseconds(100), timeUntilExpires: TimeSpan.FromSeconds(1));
+        await using var lock2 = await locker.TryAcquireAsync(lockName, acquireTimeout: TimeSpan.FromMilliseconds(100), timeUntilExpires: TimeSpan.FromSeconds(1));
 
         // has already been released, should not release other people's lock
         await lock1.ReleaseAsync();
@@ -111,7 +111,7 @@ public abstract class LockTestBase : TestWithLoggingBase
         string lockName = Guid.NewGuid().ToString("N")[..10];
 
         _logger.LogInformation("Acquiring lock attempt #1");
-        var testLock = await locker.AcquireAsync(lockName, timeUntilExpires: TimeSpan.FromMilliseconds(250));
+        var testLock = await locker.TryAcquireAsync(lockName, timeUntilExpires: TimeSpan.FromMilliseconds(250));
         if (testLock is not null)
             _logger.LogInformation("Acquired lock attempt #1");
         else
@@ -119,7 +119,7 @@ public abstract class LockTestBase : TestWithLoggingBase
         Assert.NotNull(testLock);
 
         _logger.LogInformation("Acquiring lock attempt #2");
-        testLock = await locker.AcquireAsync(lockName, acquireTimeout: TimeSpan.FromMilliseconds(50));
+        testLock = await locker.TryAcquireAsync(lockName, acquireTimeout: TimeSpan.FromMilliseconds(50));
         if (testLock is not null)
             _logger.LogError("Acquired lock attempt #2");
         else
@@ -127,7 +127,7 @@ public abstract class LockTestBase : TestWithLoggingBase
         Assert.Null(testLock);
 
         _logger.LogInformation("Acquiring lock attempt #3");
-        testLock = await locker.AcquireAsync(lockName, acquireTimeout: TimeSpan.FromSeconds(10));
+        testLock = await locker.TryAcquireAsync(lockName, acquireTimeout: TimeSpan.FromSeconds(10));
         if (testLock is not null)
             _logger.LogInformation("Acquired lock attempt #3");
         else
@@ -152,7 +152,7 @@ public abstract class LockTestBase : TestWithLoggingBase
         string lockName = Guid.NewGuid().ToString("N")[..10];
 
         _logger.LogInformation("Acquiring lock attempt #1");
-        var testLock = await locker.AcquireAsync(lockName, timeUntilExpires: TimeSpan.FromSeconds(1));
+        var testLock = await locker.TryAcquireAsync(lockName, timeUntilExpires: TimeSpan.FromSeconds(1));
         if (testLock is not null)
             _logger.LogInformation("Acquired lock attempt #1");
         else
@@ -160,7 +160,7 @@ public abstract class LockTestBase : TestWithLoggingBase
         Assert.NotNull(testLock);
 
         _logger.LogInformation("Acquiring lock attempt #2");
-        var testLock2 = await locker.AcquireAsync(lockName, acquireTimeout: TimeSpan.FromMilliseconds(500));
+        var testLock2 = await locker.TryAcquireAsync(lockName, acquireTimeout: TimeSpan.FromMilliseconds(500));
         if (testLock2 is not null)
             _logger.LogError("Acquired lock attempt #2");
         else
@@ -171,7 +171,7 @@ public abstract class LockTestBase : TestWithLoggingBase
         await testLock.RenewAsync(timeUntilExpires: TimeSpan.FromSeconds(1));
 
         _logger.LogInformation("Acquiring lock attempt #3");
-        testLock = await locker.AcquireAsync(lockName, acquireTimeout: TimeSpan.FromMilliseconds(500));
+        testLock = await locker.TryAcquireAsync(lockName, acquireTimeout: TimeSpan.FromMilliseconds(500));
         if (testLock is not null)
             _logger.LogError("Acquired lock attempt #3");
         else
@@ -180,7 +180,7 @@ public abstract class LockTestBase : TestWithLoggingBase
 
         var sw = Stopwatch.StartNew();
         _logger.LogInformation("Acquiring lock attempt #4");
-        testLock = await locker.AcquireAsync(lockName, acquireTimeout: TimeSpan.FromSeconds(5));
+        testLock = await locker.TryAcquireAsync(lockName, acquireTimeout: TimeSpan.FromSeconds(5));
         sw.Stop();
         if (testLock is not null)
             _logger.LogInformation("Acquired lock attempt #4");
@@ -204,7 +204,7 @@ public abstract class LockTestBase : TestWithLoggingBase
             return;
 
         var resources = new List<string> { "test1", "test2", "test3", "test4", "test5" };
-        await using var testLock = await locker.AcquireAsync(resources, timeUntilExpires: TimeSpan.FromMilliseconds(250));
+        await using var testLock = await locker.TryAcquireAsync(resources, timeUntilExpires: TimeSpan.FromMilliseconds(250));
         if (testLock is not null)
             _logger.LogInformation("Acquired lock attempt #1");
         else
@@ -212,7 +212,7 @@ public abstract class LockTestBase : TestWithLoggingBase
         Assert.NotNull(testLock);
 
         resources.Add("other");
-        await using var testLock2 = await locker.AcquireAsync(resources, timeUntilExpires: TimeSpan.FromMilliseconds(250), acquireTimeout: TimeSpan.FromMilliseconds(10));
+        await using var testLock2 = await locker.TryAcquireAsync(resources, timeUntilExpires: TimeSpan.FromMilliseconds(250), acquireTimeout: TimeSpan.FromMilliseconds(10));
         if (testLock2 is not null)
             _logger.LogError("Acquired lock attempt #2");
         else
@@ -222,7 +222,7 @@ public abstract class LockTestBase : TestWithLoggingBase
         await testLock.RenewAsync();
         await testLock.ReleaseAsync();
 
-        await using var testLock3 = await locker.AcquireAsync(resources, timeUntilExpires: TimeSpan.FromMilliseconds(250), acquireTimeout: TimeSpan.FromMilliseconds(10));
+        await using var testLock3 = await locker.TryAcquireAsync(resources, timeUntilExpires: TimeSpan.FromMilliseconds(250), acquireTimeout: TimeSpan.FromMilliseconds(10));
         if (testLock3 is not null)
             _logger.LogInformation("Acquired lock attempt #3");
         else
@@ -243,7 +243,7 @@ public abstract class LockTestBase : TestWithLoggingBase
         locker = new ScopedLockProvider(locker, "myscope");
 
         var resources = new List<string> { "test1", "test2", "test3", "test4", "test5" };
-        await using var testLock = await locker.AcquireAsync(resources, timeUntilExpires: TimeSpan.FromMilliseconds(250));
+        await using var testLock = await locker.TryAcquireAsync(resources, timeUntilExpires: TimeSpan.FromMilliseconds(250));
         if (testLock is not null)
             _logger.LogInformation("Acquired lock attempt #1");
         else
@@ -251,7 +251,7 @@ public abstract class LockTestBase : TestWithLoggingBase
         Assert.NotNull(testLock);
 
         resources.Add("other");
-        await using var testLock2 = await locker.AcquireAsync(resources, timeUntilExpires: TimeSpan.FromMilliseconds(250), acquireTimeout: TimeSpan.FromMilliseconds(10));
+        await using var testLock2 = await locker.TryAcquireAsync(resources, timeUntilExpires: TimeSpan.FromMilliseconds(250), acquireTimeout: TimeSpan.FromMilliseconds(10));
         if (testLock2 is not null)
             _logger.LogError("Acquired lock attempt #2");
         else
@@ -261,7 +261,7 @@ public abstract class LockTestBase : TestWithLoggingBase
         await testLock.RenewAsync();
         await testLock.ReleaseAsync();
 
-        await using var testLock3 = await locker.AcquireAsync(resources, timeUntilExpires: TimeSpan.FromMilliseconds(250), acquireTimeout: TimeSpan.FromMilliseconds(10));
+        await using var testLock3 = await locker.TryAcquireAsync(resources, timeUntilExpires: TimeSpan.FromMilliseconds(250), acquireTimeout: TimeSpan.FromMilliseconds(10));
         if (testLock3 is not null)
             _logger.LogInformation("Acquired lock attempt #3");
         else
@@ -285,7 +285,7 @@ public abstract class LockTestBase : TestWithLoggingBase
 
         await Parallel.ForEachAsync(Enumerable.Range(1, COUNT), async (_, ct) =>
         {
-            await using var myLock = await locker.AcquireAsync(lockName, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
+            await using var myLock = await locker.TryAcquireAsync(lockName, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
             Assert.NotNull(myLock);
 
             int currentConcurrency = Interlocked.Increment(ref concurrency);
@@ -322,7 +322,7 @@ public abstract class LockTestBase : TestWithLoggingBase
 
         await Parallel.ForEachAsync(Enumerable.Range(1, COUNT), async (_, ct) =>
         {
-            await using var myLock = await locker.AcquireAsync(lockName, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
+            await using var myLock = await locker.TryAcquireAsync(lockName, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
             Assert.NotNull(myLock);
 
             int currentConcurrency = Interlocked.Increment(ref concurrency);
@@ -357,7 +357,7 @@ public abstract class LockTestBase : TestWithLoggingBase
 
         await Parallel.ForEachAsync(Enumerable.Range(1, COUNT), async (_, ct) =>
         {
-            await using var myLock = await locker.AcquireAsync([lockName, $"{lockName}2"], TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
+            await using var myLock = await locker.TryAcquireAsync([lockName, $"{lockName}2"], TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
             Assert.NotNull(myLock);
 
             int currentConcurrency = Interlocked.Increment(ref concurrency);
@@ -456,7 +456,7 @@ public abstract class LockTestBase : TestWithLoggingBase
         for (int i = 1; i <= allowedLocks; i++)
         {
             _logger.LogInformation("Allowed Locks: {Id}", i);
-            var l = await locker.AcquireAsync(lockName);
+            var l = await locker.TryAcquireAsync(lockName);
             Assert.NotNull(l);
         }
         sw.Stop();
@@ -465,19 +465,69 @@ public abstract class LockTestBase : TestWithLoggingBase
         Assert.True(sw.Elapsed.TotalSeconds < 1);
 
         sw.Restart();
-        var result = await locker.AcquireAsync(lockName, cancellationToken: new CancellationToken(true));
+        var result = await locker.TryAcquireAsync(lockName, cancellationToken: new CancellationToken(true));
         sw.Stop();
         _logger.LogInformation("Total acquire time took to attempt to get throttled lock: {Elapsed:g}", sw.Elapsed);
         Assert.Null(result);
 
         sw.Restart();
-        result = await locker.AcquireAsync(lockName, acquireTimeout: TimeSpan.FromSeconds(2.5));
+        result = await locker.TryAcquireAsync(lockName, acquireTimeout: TimeSpan.FromSeconds(2.5));
         sw.Stop();
         _logger.LogInformation("Time to acquire lock: {Elapsed:g}", sw.Elapsed);
         Assert.NotNull(result);
 
         // Cleanup
         await result.DisposeAsync();
+    }
+
+    public virtual async Task AcquireAsync_ThrowsWhenLockNotAvailableAsync()
+    {
+        var locker = GetLockProvider();
+        if (locker is null)
+            return;
+
+        string lockName = Guid.NewGuid().ToString("N")[..10];
+        await using var firstLock = await locker.AcquireAsync(lockName, timeUntilExpires: TimeSpan.FromSeconds(5), acquireTimeout: TimeSpan.FromSeconds(1));
+
+        var ex = await Assert.ThrowsAsync<LockAcquisitionTimeoutException>(() =>
+            locker.AcquireAsync(lockName, timeUntilExpires: TimeSpan.FromSeconds(1), acquireTimeout: TimeSpan.FromMilliseconds(50)));
+
+        Assert.Equal(lockName, ex.Resource);
+    }
+
+    public virtual async Task AcquireAsync_ThrowsWhenCancellationTokenCancelledAsync()
+    {
+        var locker = GetLockProvider();
+        if (locker is null)
+            return;
+
+        string lockName = Guid.NewGuid().ToString("N")[..10];
+        await using var firstLock = await locker.AcquireAsync(lockName, timeUntilExpires: TimeSpan.FromSeconds(5), acquireTimeout: TimeSpan.FromSeconds(1));
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var ex = await Assert.ThrowsAsync<LockAcquisitionTimeoutException>(() =>
+            locker.AcquireAsync(lockName, timeUntilExpires: TimeSpan.FromSeconds(1), cancellationToken: cts.Token));
+
+        Assert.Equal(lockName, ex.Resource);
+    }
+
+    public virtual async Task AcquireAsync_MultiResource_ThrowsWhenAnyLockUnavailableAsync()
+    {
+        var locker = GetLockProvider();
+        if (locker is null)
+            return;
+
+        string contendedResource = Guid.NewGuid().ToString("N")[..10];
+        string freeResource = Guid.NewGuid().ToString("N")[..10];
+
+        await using var first = await locker.AcquireAsync(contendedResource, timeUntilExpires: TimeSpan.FromSeconds(5), acquireTimeout: TimeSpan.FromSeconds(1));
+
+        var ex = await Assert.ThrowsAsync<LockAcquisitionTimeoutException>(() =>
+            locker.AcquireAsync(new[] { freeResource, contendedResource }, timeUntilExpires: TimeSpan.FromSeconds(1), acquireTimeout: TimeSpan.FromMilliseconds(50)));
+
+        Assert.Contains(contendedResource, ex.Resource);
     }
 
     public virtual async Task AcquireAsync_AfterPeriodExhausted_RecoversWithinNextPeriodAsync()
@@ -500,13 +550,13 @@ public abstract class LockTestBase : TestWithLoggingBase
             _logger.LogInformation("--- Iteration {Iteration}/5: exhausting period then acquiring across boundary ---", iteration + 1);
 
             // Act: acquire the one allowed lock to exhaust this period's quota
-            var firstLock = await locker.AcquireAsync(lockName);
+            var firstLock = await locker.TryAcquireAsync(lockName);
             Assert.NotNull(firstLock);
             _logger.LogInformation("Iteration {Iteration}: first lock acquired, period quota exhausted", iteration + 1);
 
             // Act: attempt a second acquire — must wait for the next period
             var sw = Stopwatch.StartNew();
-            var secondLock = await locker.AcquireAsync(lockName, acquireTimeout: TimeSpan.FromSeconds(2));
+            var secondLock = await locker.TryAcquireAsync(lockName, acquireTimeout: TimeSpan.FromSeconds(2));
             sw.Stop();
 
             // Assert: lock acquired successfully within the period + small margin (< 2s)

--- a/src/Foundatio.TestHarness/Queue/QueueTestBase.cs
+++ b/src/Foundatio.TestHarness/Queue/QueueTestBase.cs
@@ -1512,8 +1512,7 @@ public abstract class QueueTestBase : TestWithLoggingBase, IAsyncDisposable
             await queue.StartWorkingAsync(async w =>
             {
                 _logger.LogInformation("Acquiring distributed lock in work item");
-                var l = await distributedLock.AcquireAsync("test");
-                Assert.NotNull(l);
+                var l = await distributedLock.AcquireAsync("test", cancellationToken: cancellationTokenSource.Token);
                 _logger.LogInformation("Acquired distributed lock");
                 await Task.Delay(TimeSpan.FromMilliseconds(250));
                 await l.ReleaseAsync();
@@ -1579,7 +1578,6 @@ public abstract class QueueTestBase : TestWithLoggingBase, IAsyncDisposable
                     {
                         _logger.LogInformation("[{Instance}] Acquiring distributed lock in work item: {QueueEntryId}", instanceCount, w.Id);
                         var l = await distributedLock.AcquireAsync("test", cancellationToken: cancellationTokenSource.Token);
-                        Assert.NotNull(l);
                         _logger.LogInformation("[{Instance}] Acquired distributed lock: {QueueEntryId}", instanceCount, w.Id);
                         await Task.Delay(TimeSpan.FromMilliseconds(50), cancellationTokenSource.Token);
                         await l.ReleaseAsync();

--- a/src/Foundatio/Lock/CacheLockProvider.cs
+++ b/src/Foundatio/Lock/CacheLockProvider.cs
@@ -97,7 +97,7 @@ public class CacheLockProvider : ILockProvider, IHaveLogger, IHaveLoggerFactory,
         return activity;
     }
 
-    public async Task<ILock?> AcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
+    public async Task<ILock?> TryAcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
     {
         bool shouldWait = !cancellationToken.IsCancellationRequested;
         string lockId = GenerateNewLockId();

--- a/src/Foundatio/Lock/CacheLockProvider.cs
+++ b/src/Foundatio/Lock/CacheLockProvider.cs
@@ -97,7 +97,21 @@ public class CacheLockProvider : ILockProvider, IHaveLogger, IHaveLoggerFactory,
         return activity;
     }
 
-    public async Task<ILock?> TryAcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
+    public Task<ILock?> TryAcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
+    {
+        return TryAcquireCoreAsync(resource, timeUntilExpires, releaseOnDispose, cancellationToken);
+    }
+
+    public async Task<ILock> AcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
+    {
+        var l = await TryAcquireCoreAsync(resource, timeUntilExpires, releaseOnDispose, cancellationToken).AnyContext();
+        if (l is null)
+            throw new LockAcquisitionTimeoutException(resource);
+
+        return l;
+    }
+
+    private async Task<ILock?> TryAcquireCoreAsync(string resource, TimeSpan? timeUntilExpires, bool releaseOnDispose, CancellationToken cancellationToken)
     {
         bool shouldWait = !cancellationToken.IsCancellationRequested;
         string lockId = GenerateNewLockId();

--- a/src/Foundatio/Lock/CacheLockProvider.cs
+++ b/src/Foundatio/Lock/CacheLockProvider.cs
@@ -99,19 +99,19 @@ public class CacheLockProvider : ILockProvider, IHaveLogger, IHaveLoggerFactory,
 
     public Task<ILock?> TryAcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
     {
-        return TryAcquireCoreAsync(resource, timeUntilExpires, releaseOnDispose, cancellationToken);
+        return TryAcquireImplAsync(resource, timeUntilExpires, releaseOnDispose, cancellationToken);
     }
 
     public async Task<ILock> AcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
     {
-        var l = await TryAcquireCoreAsync(resource, timeUntilExpires, releaseOnDispose, cancellationToken).AnyContext();
+        var l = await TryAcquireImplAsync(resource, timeUntilExpires, releaseOnDispose, cancellationToken).AnyContext();
         if (l is null)
             throw new LockAcquisitionTimeoutException(resource);
 
         return l;
     }
 
-    private async Task<ILock?> TryAcquireCoreAsync(string resource, TimeSpan? timeUntilExpires, bool releaseOnDispose, CancellationToken cancellationToken)
+    private async Task<ILock?> TryAcquireImplAsync(string resource, TimeSpan? timeUntilExpires, bool releaseOnDispose, CancellationToken cancellationToken)
     {
         bool shouldWait = !cancellationToken.IsCancellationRequested;
         string lockId = GenerateNewLockId();

--- a/src/Foundatio/Lock/ILockProvider.cs
+++ b/src/Foundatio/Lock/ILockProvider.cs
@@ -15,6 +15,30 @@ namespace Foundatio.Lock;
 public interface ILockProvider
 {
     /// <summary>
+    /// Acquires a lock on the specified resource. Throws <see cref="LockAcquisitionTimeoutException"/>
+    /// if the lock cannot be obtained before the supplied <paramref name="cancellationToken"/> is cancelled.
+    /// </summary>
+    /// <param name="resource">The resource identifier to lock. Use consistent naming across processes.</param>
+    /// <param name="timeUntilExpires">
+    /// How long the lock is held before automatic release. Defaults to 20 minutes.
+    /// For long-running operations, call <see cref="ILock.RenewAsync"/> periodically.
+    /// </param>
+    /// <param name="releaseOnDispose">If true, the lock is released when disposed.</param>
+    /// <param name="cancellationToken">
+    /// Token used to abort the acquisition attempt. Pass a token from a <see cref="CancellationTokenSource"/>
+    /// with a <c>CancelAfter</c> to apply a timeout. The method throws
+    /// <see cref="LockAcquisitionTimeoutException"/> when the token is cancelled before acquisition completes.
+    /// </param>
+    /// <returns>The acquired <see cref="ILock"/>.</returns>
+    /// <exception cref="LockAcquisitionTimeoutException">The lock could not be acquired before cancellation.</exception>
+    /// <remarks>
+    /// Use this when the work cannot run safely without the lock. For best-effort acquisition where
+    /// failure is a normal control-flow outcome, call <see cref="TryAcquireAsync(string, TimeSpan?, bool, CancellationToken)"/>
+    /// and check the result for <c>null</c>.
+    /// </remarks>
+    Task<ILock> AcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Attempts to acquire a lock on the specified resource. Returns <c>null</c> if the lock
     /// cannot be obtained before the supplied <paramref name="cancellationToken"/> is cancelled.
     /// </summary>
@@ -31,10 +55,9 @@ public interface ILockProvider
     /// </param>
     /// <returns>The acquired <see cref="ILock"/>, or <c>null</c> if the lock could not be obtained.</returns>
     /// <remarks>
-    /// This is the Try-pattern entry point: callers that treat lock unavailability as a normal
-    /// outcome should use this and check for <c>null</c>. Callers that require the lock should
-    /// use <see cref="LockProviderExtensions.AcquireAsync(ILockProvider, string, TimeSpan?, TimeSpan?)"/>,
-    /// which throws <see cref="LockAcquisitionTimeoutException"/> on failure.
+    /// Use this when lock unavailability is a normal control-flow outcome (best-effort dedupe,
+    /// opportunistic work). When the work cannot run without the lock, call
+    /// <see cref="AcquireAsync(string, TimeSpan?, bool, CancellationToken)"/> instead.
     /// </remarks>
     Task<ILock?> TryAcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default);
 
@@ -123,6 +146,34 @@ public static class LockProviderExtensions
     }
 
     // ------------------------------------------------------------------
+    // AcquireAsync — single resource. Throws LockAcquisitionTimeoutException
+    // on failure. Use this when failure to acquire is genuinely exceptional
+    // (e.g. a serialization lock guarding correctness).
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Acquires the lock or throws <see cref="LockAcquisitionTimeoutException"/> if the
+    /// supplied <paramref name="cancellationToken"/> is cancelled before the lock is acquired.
+    /// </summary>
+    /// <exception cref="LockAcquisitionTimeoutException">The lock could not be acquired before cancellation.</exception>
+    public static Task<ILock> AcquireAsync(this ILockProvider provider, string resource, TimeSpan? timeUntilExpires = null, CancellationToken cancellationToken = default)
+    {
+        return provider.AcquireAsync(resource, timeUntilExpires, true, cancellationToken);
+    }
+
+    /// <summary>
+    /// Acquires the lock, waiting up to <paramref name="acquireTimeout"/> before throwing
+    /// <see cref="LockAcquisitionTimeoutException"/>. A null <paramref name="acquireTimeout"/>
+    /// applies a 30-second default.
+    /// </summary>
+    /// <exception cref="LockAcquisitionTimeoutException">The lock could not be acquired before the timeout elapsed.</exception>
+    public static async Task<ILock> AcquireAsync(this ILockProvider provider, string resource, TimeSpan? timeUntilExpires = null, TimeSpan? acquireTimeout = null)
+    {
+        using var cancellationTokenSource = acquireTimeout.ToCancellationTokenSource(TimeSpan.FromSeconds(30));
+        return await provider.AcquireAsync(resource, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
+    }
+
+    // ------------------------------------------------------------------
     // TryAcquireAsync — single resource. Returns null on failure.
     // Use this when lock unavailability is a normal control-flow outcome.
     // ------------------------------------------------------------------
@@ -138,47 +189,13 @@ public static class LockProviderExtensions
 
     /// <summary>
     /// Tries to acquire the lock, waiting up to <paramref name="acquireTimeout"/> before giving up.
-    /// Returns <c>null</c> if the timeout elapses without acquiring the lock.
+    /// Returns <c>null</c> if the timeout elapses without acquiring the lock. A null
+    /// <paramref name="acquireTimeout"/> applies a 30-second default.
     /// </summary>
     public static async Task<ILock?> TryAcquireAsync(this ILockProvider provider, string resource, TimeSpan? timeUntilExpires = null, TimeSpan? acquireTimeout = null)
     {
         using var cancellationTokenSource = acquireTimeout.ToCancellationTokenSource(TimeSpan.FromSeconds(30));
         return await provider.TryAcquireAsync(resource, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
-    }
-
-    // ------------------------------------------------------------------
-    // AcquireAsync — single resource. Throws LockAcquisitionTimeoutException
-    // on failure. Use this when failure to acquire is genuinely exceptional
-    // (e.g. a serialization lock guarding correctness).
-    // ------------------------------------------------------------------
-
-    /// <summary>
-    /// Acquires the lock or throws <see cref="LockAcquisitionTimeoutException"/> if the
-    /// supplied <paramref name="cancellationToken"/> is cancelled before the lock is acquired.
-    /// </summary>
-    /// <exception cref="LockAcquisitionTimeoutException">The lock could not be acquired before cancellation.</exception>
-    public static async Task<ILock> AcquireAsync(this ILockProvider provider, string resource, TimeSpan? timeUntilExpires = null, CancellationToken cancellationToken = default)
-    {
-        var l = await provider.TryAcquireAsync(resource, timeUntilExpires, true, cancellationToken).AnyContext();
-        if (l is null)
-            throw new LockAcquisitionTimeoutException(resource);
-
-        return l;
-    }
-
-    /// <summary>
-    /// Acquires the lock, waiting up to <paramref name="acquireTimeout"/> before throwing
-    /// <see cref="LockAcquisitionTimeoutException"/>.
-    /// </summary>
-    /// <exception cref="LockAcquisitionTimeoutException">The lock could not be acquired before the timeout elapsed.</exception>
-    public static async Task<ILock> AcquireAsync(this ILockProvider provider, string resource, TimeSpan? timeUntilExpires = null, TimeSpan? acquireTimeout = null)
-    {
-        using var cancellationTokenSource = acquireTimeout.ToCancellationTokenSource(TimeSpan.FromSeconds(30));
-        var l = await provider.TryAcquireAsync(resource, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
-        if (l is null)
-            throw new LockAcquisitionTimeoutException(resource);
-
-        return l;
     }
 
     // ------------------------------------------------------------------
@@ -369,9 +386,15 @@ public static class LockProviderExtensions
     /// <exception cref="LockAcquisitionTimeoutException">One or more locks could not be acquired.</exception>
     public static async Task<ILock> AcquireAsync(this ILockProvider provider, IEnumerable<string> resources, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
     {
-        var l = await provider.TryAcquireAsync(resources, timeUntilExpires, releaseOnDispose, cancellationToken).AnyContext();
+        ArgumentNullException.ThrowIfNull(resources);
+
+        // Materialize once so the exception message reports exactly what we attempted to acquire,
+        // and so single-use enumerables don't get walked twice.
+        string[] resourceList = resources as string[] ?? resources.ToArray();
+
+        var l = await provider.TryAcquireAsync(resourceList, timeUntilExpires, releaseOnDispose, cancellationToken).AnyContext();
         if (l is null)
-            throw new LockAcquisitionTimeoutException(String.Join(",", resources));
+            throw new LockAcquisitionTimeoutException(String.Join(",", resourceList));
 
         return l;
     }
@@ -379,10 +402,14 @@ public static class LockProviderExtensions
     /// <exception cref="LockAcquisitionTimeoutException">One or more locks could not be acquired before the timeout elapsed.</exception>
     public static async Task<ILock> AcquireAsync(this ILockProvider provider, IEnumerable<string> resources, TimeSpan? timeUntilExpires, TimeSpan? acquireTimeout)
     {
+        ArgumentNullException.ThrowIfNull(resources);
+
+        string[] resourceList = resources as string[] ?? resources.ToArray();
+
         using var cancellationTokenSource = acquireTimeout.ToCancellationTokenSource(TimeSpan.FromSeconds(30));
-        var l = await provider.TryAcquireAsync(resources, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
+        var l = await provider.TryAcquireAsync(resourceList, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
         if (l is null)
-            throw new LockAcquisitionTimeoutException(String.Join(",", resources));
+            throw new LockAcquisitionTimeoutException(String.Join(",", resourceList));
 
         return l;
     }
@@ -390,10 +417,14 @@ public static class LockProviderExtensions
     /// <exception cref="LockAcquisitionTimeoutException">One or more locks could not be acquired before the timeout elapsed.</exception>
     public static async Task<ILock> AcquireAsync(this ILockProvider provider, IEnumerable<string> resources, TimeSpan? timeUntilExpires, TimeSpan? acquireTimeout, bool releaseOnDispose)
     {
+        ArgumentNullException.ThrowIfNull(resources);
+
+        string[] resourceList = resources as string[] ?? resources.ToArray();
+
         using var cancellationTokenSource = acquireTimeout.ToCancellationTokenSource(TimeSpan.FromSeconds(30));
-        var l = await provider.TryAcquireAsync(resources, timeUntilExpires, releaseOnDispose, cancellationTokenSource.Token).AnyContext();
+        var l = await provider.TryAcquireAsync(resourceList, timeUntilExpires, releaseOnDispose, cancellationTokenSource.Token).AnyContext();
         if (l is null)
-            throw new LockAcquisitionTimeoutException(String.Join(",", resources));
+            throw new LockAcquisitionTimeoutException(String.Join(",", resourceList));
 
         return l;
     }

--- a/src/Foundatio/Lock/ILockProvider.cs
+++ b/src/Foundatio/Lock/ILockProvider.cs
@@ -15,7 +15,8 @@ namespace Foundatio.Lock;
 public interface ILockProvider
 {
     /// <summary>
-    /// Acquires a lock on the specified resource, waiting until available or cancellation.
+    /// Attempts to acquire a lock on the specified resource. Returns <c>null</c> if the lock
+    /// cannot be obtained before the supplied <paramref name="cancellationToken"/> is cancelled.
     /// </summary>
     /// <param name="resource">The resource identifier to lock. Use consistent naming across processes.</param>
     /// <param name="timeUntilExpires">
@@ -23,15 +24,19 @@ public interface ILockProvider
     /// For long-running operations, call <see cref="ILock.RenewAsync"/> periodically.
     /// </param>
     /// <param name="releaseOnDispose">If true, the lock is released when disposed.</param>
-    /// <param name="cancellationToken">Token to cancel the acquisition attempt. When cancellation occurs
-    /// before the lock is acquired, the method returns <c>null</c>.</param>
-    /// <returns>
-    /// An <see cref="ILock"/> representing the acquired lock, or <c>null</c> if acquisition was cancelled
-    /// or the lock could not be obtained within the timeout. Callers should always check for <c>null</c>
-    /// before using the returned lock. For convenience wrappers that handle the null check, see
-    /// <see cref="LockProviderExtensions.TryUsingAsync(ILockProvider, string, Func{CancellationToken, Task}, TimeSpan?, CancellationToken)"/>.
-    /// </returns>
-    Task<ILock?> AcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default);
+    /// <param name="cancellationToken">
+    /// Token used to abort the acquisition attempt. Pass a token from a <see cref="CancellationTokenSource"/>
+    /// with a <c>CancelAfter</c> to apply a timeout. When acquisition cannot complete before
+    /// cancellation, the method returns <c>null</c> rather than throwing.
+    /// </param>
+    /// <returns>The acquired <see cref="ILock"/>, or <c>null</c> if the lock could not be obtained.</returns>
+    /// <remarks>
+    /// This is the Try-pattern entry point: callers that treat lock unavailability as a normal
+    /// outcome should use this and check for <c>null</c>. Callers that require the lock should
+    /// use <see cref="LockProviderExtensions.AcquireAsync(ILockProvider, string, TimeSpan?, TimeSpan?)"/>,
+    /// which throws <see cref="LockAcquisitionTimeoutException"/> on failure.
+    /// </remarks>
+    Task<ILock?> TryAcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Checks whether a resource is currently locked.
@@ -117,20 +122,73 @@ public static class LockProviderExtensions
         return provider.RenewAsync(@lock.Resource, @lock.LockId, timeUntilExpires);
     }
 
-    public static Task<ILock?> AcquireAsync(this ILockProvider provider, string resource, TimeSpan? timeUntilExpires = null, CancellationToken cancellationToken = default)
+    // ------------------------------------------------------------------
+    // TryAcquireAsync — single resource. Returns null on failure.
+    // Use this when lock unavailability is a normal control-flow outcome.
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Tries to acquire the lock without a timeout. Returns <c>null</c> if the supplied
+    /// <paramref name="cancellationToken"/> is cancelled before the lock is acquired.
+    /// </summary>
+    public static Task<ILock?> TryAcquireAsync(this ILockProvider provider, string resource, TimeSpan? timeUntilExpires = null, CancellationToken cancellationToken = default)
     {
-        return provider.AcquireAsync(resource, timeUntilExpires, true, cancellationToken);
+        return provider.TryAcquireAsync(resource, timeUntilExpires, true, cancellationToken);
     }
 
-    public static async Task<ILock?> AcquireAsync(this ILockProvider provider, string resource, TimeSpan? timeUntilExpires = null, TimeSpan? acquireTimeout = null)
+    /// <summary>
+    /// Tries to acquire the lock, waiting up to <paramref name="acquireTimeout"/> before giving up.
+    /// Returns <c>null</c> if the timeout elapses without acquiring the lock.
+    /// </summary>
+    public static async Task<ILock?> TryAcquireAsync(this ILockProvider provider, string resource, TimeSpan? timeUntilExpires = null, TimeSpan? acquireTimeout = null)
     {
         using var cancellationTokenSource = acquireTimeout.ToCancellationTokenSource(TimeSpan.FromSeconds(30));
-        return await provider.AcquireAsync(resource, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
+        return await provider.TryAcquireAsync(resource, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
     }
+
+    // ------------------------------------------------------------------
+    // AcquireAsync — single resource. Throws LockAcquisitionTimeoutException
+    // on failure. Use this when failure to acquire is genuinely exceptional
+    // (e.g. a serialization lock guarding correctness).
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Acquires the lock or throws <see cref="LockAcquisitionTimeoutException"/> if the
+    /// supplied <paramref name="cancellationToken"/> is cancelled before the lock is acquired.
+    /// </summary>
+    /// <exception cref="LockAcquisitionTimeoutException">The lock could not be acquired before cancellation.</exception>
+    public static async Task<ILock> AcquireAsync(this ILockProvider provider, string resource, TimeSpan? timeUntilExpires = null, CancellationToken cancellationToken = default)
+    {
+        var l = await provider.TryAcquireAsync(resource, timeUntilExpires, true, cancellationToken).AnyContext();
+        if (l is null)
+            throw new LockAcquisitionTimeoutException(resource);
+
+        return l;
+    }
+
+    /// <summary>
+    /// Acquires the lock, waiting up to <paramref name="acquireTimeout"/> before throwing
+    /// <see cref="LockAcquisitionTimeoutException"/>.
+    /// </summary>
+    /// <exception cref="LockAcquisitionTimeoutException">The lock could not be acquired before the timeout elapsed.</exception>
+    public static async Task<ILock> AcquireAsync(this ILockProvider provider, string resource, TimeSpan? timeUntilExpires = null, TimeSpan? acquireTimeout = null)
+    {
+        using var cancellationTokenSource = acquireTimeout.ToCancellationTokenSource(TimeSpan.FromSeconds(30));
+        var l = await provider.TryAcquireAsync(resource, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
+        if (l is null)
+            throw new LockAcquisitionTimeoutException(resource);
+
+        return l;
+    }
+
+    // ------------------------------------------------------------------
+    // TryUsingAsync — single resource. Best-effort: skips work if lock
+    // can't be obtained, returns whether the work ran.
+    // ------------------------------------------------------------------
 
     public static async Task<bool> TryUsingAsync(this ILockProvider locker, string resource, Func<CancellationToken, Task> work, TimeSpan? timeUntilExpires = null, CancellationToken cancellationToken = default)
     {
-        await using var l = await locker.AcquireAsync(resource, timeUntilExpires, true, cancellationToken).AnyContext();
+        await using var l = await locker.TryAcquireAsync(resource, timeUntilExpires, true, cancellationToken).AnyContext();
         if (l is null)
             return false;
 
@@ -148,7 +206,7 @@ public static class LockProviderExtensions
 
     public static async Task<bool> TryUsingAsync(this ILockProvider locker, string resource, Func<Task> work, TimeSpan? timeUntilExpires = null, CancellationToken cancellationToken = default)
     {
-        await using var l = await locker.AcquireAsync(resource, timeUntilExpires, true, cancellationToken).AnyContext();
+        await using var l = await locker.TryAcquireAsync(resource, timeUntilExpires, true, cancellationToken).AnyContext();
         if (l is null)
             return false;
 
@@ -167,7 +225,7 @@ public static class LockProviderExtensions
     public static async Task<bool> TryUsingAsync(this ILockProvider locker, string resource, Func<CancellationToken, Task> work, TimeSpan? timeUntilExpires = null, TimeSpan? acquireTimeout = null)
     {
         using var cancellationTokenSource = acquireTimeout.ToCancellationTokenSource();
-        await using var l = await locker.AcquireAsync(resource, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
+        await using var l = await locker.TryAcquireAsync(resource, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
         if (l is null)
             return false;
 
@@ -186,7 +244,7 @@ public static class LockProviderExtensions
     public static async Task<bool> TryUsingAsync(this ILockProvider locker, string resource, Func<Task> work, TimeSpan? timeUntilExpires = null, TimeSpan? acquireTimeout = null)
     {
         using var cancellationTokenSource = acquireTimeout.ToCancellationTokenSource();
-        await using var l = await locker.AcquireAsync(resource, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
+        await using var l = await locker.TryAcquireAsync(resource, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
         if (l is null)
             return false;
 
@@ -211,7 +269,11 @@ public static class LockProviderExtensions
         }, timeUntilExpires, acquireTimeout);
     }
 
-    public static async Task<ILock?> AcquireAsync(this ILockProvider provider, IEnumerable<string> resources, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
+    // ------------------------------------------------------------------
+    // TryAcquireAsync — multiple resources. Returns null on failure.
+    // ------------------------------------------------------------------
+
+    public static async Task<ILock?> TryAcquireAsync(this ILockProvider provider, IEnumerable<string> resources, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(resources);
 
@@ -232,7 +294,7 @@ public static class LockProviderExtensions
         var acquiredLocks = new List<(ILock Lock, DateTimeOffset LastRenewed)>(resourceList.Length);
         foreach (string resource in resourceList)
         {
-            var l = await provider.AcquireAsync(resource, timeUntilExpires, releaseOnDispose, cancellationToken).AnyContext();
+            var l = await provider.TryAcquireAsync(resource, timeUntilExpires, releaseOnDispose, cancellationToken).AnyContext();
             if (l is null)
             {
                 break;
@@ -288,21 +350,61 @@ public static class LockProviderExtensions
         return new DisposableLockCollection(locks, String.Join("+", locks.Select(l => l.LockId)), provider.GetTimeProvider().GetUtcNow().UtcDateTime, sw.Elapsed, logger);
     }
 
-    public static async Task<ILock?> AcquireAsync(this ILockProvider provider, IEnumerable<string> resources, TimeSpan? timeUntilExpires, TimeSpan? acquireTimeout)
+    public static async Task<ILock?> TryAcquireAsync(this ILockProvider provider, IEnumerable<string> resources, TimeSpan? timeUntilExpires, TimeSpan? acquireTimeout)
     {
         using var cancellationTokenSource = acquireTimeout.ToCancellationTokenSource(TimeSpan.FromSeconds(30));
-        return await provider.AcquireAsync(resources, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
+        return await provider.TryAcquireAsync(resources, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
     }
 
-    public static async Task<ILock?> AcquireAsync(this ILockProvider provider, IEnumerable<string> resources, TimeSpan? timeUntilExpires, TimeSpan? acquireTimeout, bool releaseOnDispose)
+    public static async Task<ILock?> TryAcquireAsync(this ILockProvider provider, IEnumerable<string> resources, TimeSpan? timeUntilExpires, TimeSpan? acquireTimeout, bool releaseOnDispose)
     {
         using var cancellationTokenSource = acquireTimeout.ToCancellationTokenSource(TimeSpan.FromSeconds(30));
-        return await provider.AcquireAsync(resources, timeUntilExpires, releaseOnDispose, cancellationTokenSource.Token).AnyContext();
+        return await provider.TryAcquireAsync(resources, timeUntilExpires, releaseOnDispose, cancellationTokenSource.Token).AnyContext();
     }
+
+    // ------------------------------------------------------------------
+    // AcquireAsync — multiple resources. Throws on failure.
+    // ------------------------------------------------------------------
+
+    /// <exception cref="LockAcquisitionTimeoutException">One or more locks could not be acquired.</exception>
+    public static async Task<ILock> AcquireAsync(this ILockProvider provider, IEnumerable<string> resources, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
+    {
+        var l = await provider.TryAcquireAsync(resources, timeUntilExpires, releaseOnDispose, cancellationToken).AnyContext();
+        if (l is null)
+            throw new LockAcquisitionTimeoutException(String.Join(",", resources));
+
+        return l;
+    }
+
+    /// <exception cref="LockAcquisitionTimeoutException">One or more locks could not be acquired before the timeout elapsed.</exception>
+    public static async Task<ILock> AcquireAsync(this ILockProvider provider, IEnumerable<string> resources, TimeSpan? timeUntilExpires, TimeSpan? acquireTimeout)
+    {
+        using var cancellationTokenSource = acquireTimeout.ToCancellationTokenSource(TimeSpan.FromSeconds(30));
+        var l = await provider.TryAcquireAsync(resources, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
+        if (l is null)
+            throw new LockAcquisitionTimeoutException(String.Join(",", resources));
+
+        return l;
+    }
+
+    /// <exception cref="LockAcquisitionTimeoutException">One or more locks could not be acquired before the timeout elapsed.</exception>
+    public static async Task<ILock> AcquireAsync(this ILockProvider provider, IEnumerable<string> resources, TimeSpan? timeUntilExpires, TimeSpan? acquireTimeout, bool releaseOnDispose)
+    {
+        using var cancellationTokenSource = acquireTimeout.ToCancellationTokenSource(TimeSpan.FromSeconds(30));
+        var l = await provider.TryAcquireAsync(resources, timeUntilExpires, releaseOnDispose, cancellationTokenSource.Token).AnyContext();
+        if (l is null)
+            throw new LockAcquisitionTimeoutException(String.Join(",", resources));
+
+        return l;
+    }
+
+    // ------------------------------------------------------------------
+    // TryUsingAsync — multiple resources.
+    // ------------------------------------------------------------------
 
     public static async Task<bool> TryUsingAsync(this ILockProvider locker, IEnumerable<string> resources, Func<CancellationToken, Task> work, TimeSpan? timeUntilExpires = null, CancellationToken cancellationToken = default)
     {
-        await using var l = await locker.AcquireAsync(resources, timeUntilExpires, true, cancellationToken).AnyContext();
+        await using var l = await locker.TryAcquireAsync(resources, timeUntilExpires, true, cancellationToken).AnyContext();
         if (l is null)
             return false;
 
@@ -320,7 +422,7 @@ public static class LockProviderExtensions
 
     public static async Task<bool> TryUsingAsync(this ILockProvider locker, IEnumerable<string> resources, Func<Task> work, TimeSpan? timeUntilExpires = null, CancellationToken cancellationToken = default)
     {
-        await using var l = await locker.AcquireAsync(resources, timeUntilExpires, true, cancellationToken).AnyContext();
+        await using var l = await locker.TryAcquireAsync(resources, timeUntilExpires, true, cancellationToken).AnyContext();
         if (l is null)
             return false;
 
@@ -339,7 +441,7 @@ public static class LockProviderExtensions
     public static async Task<bool> TryUsingAsync(this ILockProvider locker, IEnumerable<string> resources, Func<CancellationToken, Task> work, TimeSpan? timeUntilExpires, TimeSpan? acquireTimeout)
     {
         using var cancellationTokenSource = acquireTimeout.ToCancellationTokenSource();
-        await using var l = await locker.AcquireAsync(resources, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
+        await using var l = await locker.TryAcquireAsync(resources, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
         if (l is null)
             return false;
 
@@ -358,7 +460,7 @@ public static class LockProviderExtensions
     public static async Task<bool> TryUsingAsync(this ILockProvider locker, IEnumerable<string> resources, Func<Task> work, TimeSpan? timeUntilExpires, TimeSpan? acquireTimeout)
     {
         using var cancellationTokenSource = acquireTimeout.ToCancellationTokenSource();
-        await using var l = await locker.AcquireAsync(resources, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
+        await using var l = await locker.TryAcquireAsync(resources, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
         if (l is null)
             return false;
 

--- a/src/Foundatio/Lock/ILockProvider.cs
+++ b/src/Foundatio/Lock/ILockProvider.cs
@@ -145,12 +145,6 @@ public static class LockProviderExtensions
         return provider.RenewAsync(@lock.Resource, @lock.LockId, timeUntilExpires);
     }
 
-    // ------------------------------------------------------------------
-    // AcquireAsync — single resource. Throws LockAcquisitionTimeoutException
-    // on failure. Use this when failure to acquire is genuinely exceptional
-    // (e.g. a serialization lock guarding correctness).
-    // ------------------------------------------------------------------
-
     /// <summary>
     /// Acquires the lock or throws <see cref="LockAcquisitionTimeoutException"/> if the
     /// supplied <paramref name="cancellationToken"/> is cancelled before the lock is acquired.
@@ -173,11 +167,6 @@ public static class LockProviderExtensions
         return await provider.AcquireAsync(resource, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
     }
 
-    // ------------------------------------------------------------------
-    // TryAcquireAsync — single resource. Returns null on failure.
-    // Use this when lock unavailability is a normal control-flow outcome.
-    // ------------------------------------------------------------------
-
     /// <summary>
     /// Tries to acquire the lock without a timeout. Returns <c>null</c> if the supplied
     /// <paramref name="cancellationToken"/> is cancelled before the lock is acquired.
@@ -197,11 +186,6 @@ public static class LockProviderExtensions
         using var cancellationTokenSource = acquireTimeout.ToCancellationTokenSource(TimeSpan.FromSeconds(30));
         return await provider.TryAcquireAsync(resource, timeUntilExpires, true, cancellationTokenSource.Token).AnyContext();
     }
-
-    // ------------------------------------------------------------------
-    // TryUsingAsync — single resource. Best-effort: skips work if lock
-    // can't be obtained, returns whether the work ran.
-    // ------------------------------------------------------------------
 
     public static async Task<bool> TryUsingAsync(this ILockProvider locker, string resource, Func<CancellationToken, Task> work, TimeSpan? timeUntilExpires = null, CancellationToken cancellationToken = default)
     {
@@ -285,10 +269,6 @@ public static class LockProviderExtensions
             return Task.CompletedTask;
         }, timeUntilExpires, acquireTimeout);
     }
-
-    // ------------------------------------------------------------------
-    // TryAcquireAsync — multiple resources. Returns null on failure.
-    // ------------------------------------------------------------------
 
     public static async Task<ILock?> TryAcquireAsync(this ILockProvider provider, IEnumerable<string> resources, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
     {
@@ -379,10 +359,6 @@ public static class LockProviderExtensions
         return await provider.TryAcquireAsync(resources, timeUntilExpires, releaseOnDispose, cancellationTokenSource.Token).AnyContext();
     }
 
-    // ------------------------------------------------------------------
-    // AcquireAsync — multiple resources. Throws on failure.
-    // ------------------------------------------------------------------
-
     /// <exception cref="LockAcquisitionTimeoutException">One or more locks could not be acquired.</exception>
     public static async Task<ILock> AcquireAsync(this ILockProvider provider, IEnumerable<string> resources, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
     {
@@ -428,10 +404,6 @@ public static class LockProviderExtensions
 
         return l;
     }
-
-    // ------------------------------------------------------------------
-    // TryUsingAsync — multiple resources.
-    // ------------------------------------------------------------------
 
     public static async Task<bool> TryUsingAsync(this ILockProvider locker, IEnumerable<string> resources, Func<CancellationToken, Task> work, TimeSpan? timeUntilExpires = null, CancellationToken cancellationToken = default)
     {

--- a/src/Foundatio/Lock/ILockProvider.cs
+++ b/src/Foundatio/Lock/ILockProvider.cs
@@ -28,6 +28,8 @@ public interface ILockProvider
     /// Token used to abort the acquisition attempt. Pass a token from a <see cref="CancellationTokenSource"/>
     /// with a <c>CancelAfter</c> to apply a timeout. The method throws
     /// <see cref="LockAcquisitionTimeoutException"/> when the token is cancelled before acquisition completes.
+    /// An already-cancelled token is treated as an immediate-deadline attempt: a single acquire is tried
+    /// and <see cref="LockAcquisitionTimeoutException"/> is thrown if it fails.
     /// </param>
     /// <returns>The acquired <see cref="ILock"/>.</returns>
     /// <exception cref="LockAcquisitionTimeoutException">The lock could not be acquired before cancellation.</exception>
@@ -51,7 +53,9 @@ public interface ILockProvider
     /// <param name="cancellationToken">
     /// Token used to abort the acquisition attempt. Pass a token from a <see cref="CancellationTokenSource"/>
     /// with a <c>CancelAfter</c> to apply a timeout. When acquisition cannot complete before
-    /// cancellation, the method returns <c>null</c> rather than throwing.
+    /// cancellation, the method returns <c>null</c> rather than throwing. An already-cancelled token
+    /// is treated as an immediate-deadline attempt: a single acquire is tried and <c>null</c> is returned
+    /// if it fails.
     /// </param>
     /// <returns>The acquired <see cref="ILock"/>, or <c>null</c> if the lock could not be obtained.</returns>
     /// <remarks>

--- a/src/Foundatio/Lock/LockAcquisitionTimeoutException.cs
+++ b/src/Foundatio/Lock/LockAcquisitionTimeoutException.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace Foundatio.Lock;
+
+/// <summary>
+/// Thrown by <see cref="LockProviderExtensions.AcquireAsync(ILockProvider, string, TimeSpan?, TimeSpan?)"/>
+/// (and related overloads) when a lock cannot be acquired before the requested timeout
+/// elapses or the supplied <see cref="System.Threading.CancellationToken"/> is cancelled.
+/// </summary>
+/// <remarks>
+/// Callers that treat lock unavailability as a normal control-flow outcome (best-effort
+/// dedupe, opportunistic work) should call <c>TryAcquireAsync</c> instead and check the
+/// returned <see cref="ILock"/> for <c>null</c>.
+/// </remarks>
+public sealed class LockAcquisitionTimeoutException : Exception
+{
+    public LockAcquisitionTimeoutException(string resource)
+        : base($"Failed to acquire lock for resource '{resource}' before the timeout elapsed.")
+    {
+        Resource = resource;
+    }
+
+    public LockAcquisitionTimeoutException(string resource, string message)
+        : base(message)
+    {
+        Resource = resource;
+    }
+
+    public LockAcquisitionTimeoutException(string resource, string message, Exception innerException)
+        : base(message, innerException)
+    {
+        Resource = resource;
+    }
+
+    /// <summary>
+    /// The resource identifier that the caller attempted to lock.
+    /// </summary>
+    public string Resource { get; }
+}

--- a/src/Foundatio/Lock/LockAcquisitionTimeoutException.cs
+++ b/src/Foundatio/Lock/LockAcquisitionTimeoutException.cs
@@ -3,19 +3,19 @@ using System;
 namespace Foundatio.Lock;
 
 /// <summary>
-/// Thrown by <see cref="LockProviderExtensions.AcquireAsync(ILockProvider, string, TimeSpan?, TimeSpan?)"/>
-/// (and related overloads) when a lock cannot be acquired before the requested timeout
-/// elapses or the supplied <see cref="System.Threading.CancellationToken"/> is cancelled.
+/// Thrown by <see cref="ILockProvider.AcquireAsync(string, TimeSpan?, bool, System.Threading.CancellationToken)"/>
+/// (and the multi-resource extension overloads) when a lock cannot be acquired before the
+/// requested timeout elapses or the supplied <see cref="System.Threading.CancellationToken"/> is cancelled.
 /// </summary>
 /// <remarks>
 /// Callers that treat lock unavailability as a normal control-flow outcome (best-effort
-/// dedupe, opportunistic work) should call <c>TryAcquireAsync</c> instead and check the
-/// returned <see cref="ILock"/> for <c>null</c>.
+/// dedupe, opportunistic work) should call <see cref="ILockProvider.TryAcquireAsync"/> instead
+/// and check the returned <see cref="ILock"/> for <c>null</c>.
 /// </remarks>
 public sealed class LockAcquisitionTimeoutException : Exception
 {
     public LockAcquisitionTimeoutException(string resource)
-        : base($"Failed to acquire lock for resource '{resource}' before the timeout elapsed.")
+        : base($"Failed to acquire lock for resource '{resource}'.")
     {
         Resource = resource;
     }
@@ -33,7 +33,8 @@ public sealed class LockAcquisitionTimeoutException : Exception
     }
 
     /// <summary>
-    /// The resource identifier that the caller attempted to lock.
+    /// The resource identifier (or comma-separated list, for multi-resource acquisition)
+    /// that the caller attempted to lock.
     /// </summary>
     public string Resource { get; }
 }

--- a/src/Foundatio/Lock/LockAcquisitionTimeoutException.cs
+++ b/src/Foundatio/Lock/LockAcquisitionTimeoutException.cs
@@ -12,7 +12,7 @@ namespace Foundatio.Lock;
 /// dedupe, opportunistic work) should call <see cref="ILockProvider.TryAcquireAsync"/> instead
 /// and check the returned <see cref="ILock"/> for <c>null</c>.
 /// </remarks>
-public sealed class LockAcquisitionTimeoutException : Exception
+public sealed class LockAcquisitionTimeoutException : LockException
 {
     public LockAcquisitionTimeoutException(string resource)
         : base($"Failed to acquire lock for resource '{resource}'.")

--- a/src/Foundatio/Lock/LockException.cs
+++ b/src/Foundatio/Lock/LockException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Foundatio.Lock;
+
+public class LockException : Exception
+{
+    public LockException(string message) : base(message)
+    {
+    }
+
+    public LockException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/Foundatio/Lock/ScopedLockProvider.cs
+++ b/src/Foundatio/Lock/ScopedLockProvider.cs
@@ -53,6 +53,11 @@ public class ScopedLockProvider : ILockProvider, IHaveLogger, IHaveLoggerFactory
         return String.Concat(_keyPrefix, key);
     }
 
+    public Task<ILock> AcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
+    {
+        return UnscopedLockProvider.AcquireAsync(GetScopedLockProviderKey(resource), timeUntilExpires, releaseOnDispose, cancellationToken);
+    }
+
     public Task<ILock?> TryAcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
     {
         return UnscopedLockProvider.TryAcquireAsync(GetScopedLockProviderKey(resource), timeUntilExpires, releaseOnDispose, cancellationToken);

--- a/src/Foundatio/Lock/ScopedLockProvider.cs
+++ b/src/Foundatio/Lock/ScopedLockProvider.cs
@@ -53,9 +53,9 @@ public class ScopedLockProvider : ILockProvider, IHaveLogger, IHaveLoggerFactory
         return String.Concat(_keyPrefix, key);
     }
 
-    public Task<ILock?> AcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
+    public Task<ILock?> TryAcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
     {
-        return UnscopedLockProvider.AcquireAsync(GetScopedLockProviderKey(resource), timeUntilExpires, releaseOnDispose, cancellationToken);
+        return UnscopedLockProvider.TryAcquireAsync(GetScopedLockProviderKey(resource), timeUntilExpires, releaseOnDispose, cancellationToken);
     }
 
     public Task<bool> IsLockedAsync(string resource)

--- a/src/Foundatio/Lock/ThrottlingLockProvider.cs
+++ b/src/Foundatio/Lock/ThrottlingLockProvider.cs
@@ -43,7 +43,7 @@ public class ThrottlingLockProvider : ILockProvider, IHaveLogger, IHaveLoggerFac
     TimeProvider IHaveTimeProvider.TimeProvider => _timeProvider;
     IResiliencePolicyProvider IHaveResiliencePolicyProvider.ResiliencePolicyProvider => _resiliencePolicyProvider;
 
-    public async Task<ILock?> AcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
+    public async Task<ILock?> TryAcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
     {
         _logger.LogTrace("AcquireLockAsync: {Resource}", resource);
 

--- a/src/Foundatio/Lock/ThrottlingLockProvider.cs
+++ b/src/Foundatio/Lock/ThrottlingLockProvider.cs
@@ -43,9 +43,23 @@ public class ThrottlingLockProvider : ILockProvider, IHaveLogger, IHaveLoggerFac
     TimeProvider IHaveTimeProvider.TimeProvider => _timeProvider;
     IResiliencePolicyProvider IHaveResiliencePolicyProvider.ResiliencePolicyProvider => _resiliencePolicyProvider;
 
-    public async Task<ILock?> TryAcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
+    public Task<ILock?> TryAcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
     {
-        _logger.LogTrace("AcquireLockAsync: {Resource}", resource);
+        return TryAcquireCoreAsync(resource, timeUntilExpires, releaseOnDispose, cancellationToken);
+    }
+
+    public async Task<ILock> AcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
+    {
+        var l = await TryAcquireCoreAsync(resource, timeUntilExpires, releaseOnDispose, cancellationToken).AnyContext();
+        if (l is null)
+            throw new LockAcquisitionTimeoutException(resource);
+
+        return l;
+    }
+
+    private async Task<ILock?> TryAcquireCoreAsync(string resource, TimeSpan? timeUntilExpires, bool releaseOnDispose, CancellationToken cancellationToken)
+    {
+        _logger.LogTrace("TryAcquireAsync: {Resource}", resource);
 
         bool allowLock = false;
         byte errors = 0;

--- a/src/Foundatio/Lock/ThrottlingLockProvider.cs
+++ b/src/Foundatio/Lock/ThrottlingLockProvider.cs
@@ -45,19 +45,19 @@ public class ThrottlingLockProvider : ILockProvider, IHaveLogger, IHaveLoggerFac
 
     public Task<ILock?> TryAcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
     {
-        return TryAcquireCoreAsync(resource, timeUntilExpires, releaseOnDispose, cancellationToken);
+        return TryAcquireImplAsync(resource, timeUntilExpires, releaseOnDispose, cancellationToken);
     }
 
     public async Task<ILock> AcquireAsync(string resource, TimeSpan? timeUntilExpires = null, bool releaseOnDispose = true, CancellationToken cancellationToken = default)
     {
-        var l = await TryAcquireCoreAsync(resource, timeUntilExpires, releaseOnDispose, cancellationToken).AnyContext();
+        var l = await TryAcquireImplAsync(resource, timeUntilExpires, releaseOnDispose, cancellationToken).AnyContext();
         if (l is null)
             throw new LockAcquisitionTimeoutException(resource);
 
         return l;
     }
 
-    private async Task<ILock?> TryAcquireCoreAsync(string resource, TimeSpan? timeUntilExpires, bool releaseOnDispose, CancellationToken cancellationToken)
+    private async Task<ILock?> TryAcquireImplAsync(string resource, TimeSpan? timeUntilExpires, bool releaseOnDispose, CancellationToken cancellationToken)
     {
         _logger.LogTrace("TryAcquireAsync: {Resource}", resource);
 

--- a/tests/Foundatio.Tests/Locks/InMemoryLockTests.cs
+++ b/tests/Foundatio.Tests/Locks/InMemoryLockTests.cs
@@ -95,6 +95,24 @@ public class InMemoryLockTests : LockTestBase, IDisposable
     }
 
     [Fact]
+    public override Task AcquireAsync_ThrowsWhenLockNotAvailableAsync()
+    {
+        return base.AcquireAsync_ThrowsWhenLockNotAvailableAsync();
+    }
+
+    [Fact]
+    public override Task AcquireAsync_ThrowsWhenCancellationTokenCancelledAsync()
+    {
+        return base.AcquireAsync_ThrowsWhenCancellationTokenCancelledAsync();
+    }
+
+    [Fact]
+    public override Task AcquireAsync_MultiResource_ThrowsWhenAnyLockUnavailableAsync()
+    {
+        return base.AcquireAsync_MultiResource_ThrowsWhenAnyLockUnavailableAsync();
+    }
+
+    [Fact]
     public override Task CanReleaseLockMultipleTimes()
     {
         return base.CanReleaseLockMultipleTimes();

--- a/tests/Foundatio.Tests/Utility/ResiliencePolicyTests.cs
+++ b/tests/Foundatio.Tests/Utility/ResiliencePolicyTests.cs
@@ -460,7 +460,7 @@ public class ResiliencePolicyTests : TestWithLoggingBase
 
         var lockProvider = new CacheLockProvider(mockCacheClient.Object, new InMemoryMessageBus());
 
-        var l = await lockProvider.AcquireAsync("test", TimeSpan.FromSeconds(1), TimeSpan.Zero);
+        var l = await lockProvider.TryAcquireAsync("test", TimeSpan.FromSeconds(1), TimeSpan.Zero);
         Assert.NotNull(l);
         Assert.True(await lockProvider.IsLockedAsync("test"));
 


### PR DESCRIPTION
## Why

`ILockProvider.AcquireAsync` previously returned `Task<ILock?>` — `null` when the lock couldn't be obtained. Callers who forgot the null check silently ran their protected work **without holding the lock**, the exact scenario the lock was meant to prevent. We hit this in a downstream caller (an account-number generation lock) where a forgotten null check would have allowed duplicate numbers under contention.

The fix is to make the dangerous shape impossible to write by accident: failing to acquire should not produce a value of type `ILock`.

## What

`ILockProvider` now exposes two acquisition shapes as interface methods, sharing a private core in each implementation so neither path pays an exception-as-control-flow cost:

| API | Returns | Use when |
| --- | --- | --- |
| `AcquireAsync` | `Task<ILock>` — throws `LockAcquisitionTimeoutException` on failure | The work cannot run safely without the lock (the safer default). |
| `TryAcquireAsync` | `Task<ILock?>` — `null` on failure | Lock unavailability is normal control flow (best-effort dedupe, opportunistic work). |

`CacheLockProvider` and `ThrottlingLockProvider` route both public methods through a private `TryAcquireCoreAsync`. `ScopedLockProvider` forwards each shape to the corresponding method on the unscoped provider.

`LockAcquisitionTimeoutException` derives from a new `LockException` base (mirroring `CacheException` / `StorageException`) so consumers can `catch (LockException)` to handle all lock-related failures uniformly.

## Source / behavior compatibility

This is a breaking change for callers — both at the source level and at the behavior level. Three categories to be aware of:

**1. Code that *calls* `AcquireAsync` and assigns to `var` / `ILock` / `ILock?`** — recompiles fine. The only signature shift is the return type going from `Task<ILock?>` to `Task<ILock>`. Existing null checks become dead code (compiler warns "always non-null"); switch them to `try`/`catch (LockAcquisitionTimeoutException)` if you want to handle the failure, or move to `TryAcquireAsync` if null-on-failure is what you want.

**2. Code that *returns* `AcquireAsync`'s result from a method typed `Task<ILock?>`** — gets a compile error. `Task<T>` is a class and is **invariant** in `T`, so `Task<ILock>` is not assignable to `Task<ILock?>`. Concrete known case: `Foundatio.Repositories`'s `ReindexWorkItemHandler.GetWorkItemLockAsync`. Fix is either to retype the method as `Task<ILock>` (and let the throw propagate) or switch the call site to `TryAcquireAsync`.

**3. Code that handled the null return as graceful skip** — silently changes from "skip the work" to "throw `LockAcquisitionTimeoutException`". Known examples in `Foundatio.Repositories`: `ElasticConfiguration` and `MigrationManager` both have `if (lock is null) return …` paths. These need to switch to `TryAcquireAsync` to preserve the existing skip behavior.

The internal best-effort callers in this repo (`ScheduledJobInstance`, `WithLockingJob`, `ThrottledJob`, `SampleQueueJob`, `QueueTestBase`) have already been migrated to `TryAcquireAsync` as part of this PR.

External Foundatio repos that ship a *provider* (`Foundatio.Redis`, `Foundatio.AWS`, …) consume `CacheLockProvider` rather than implementing `ILockProvider` directly, so the new interface methods don't require changes there.

## Cancelled-token contract

Both `AcquireAsync` and `TryAcquireAsync` treat an already-cancelled `cancellationToken` as an immediate-deadline attempt: a single acquire is tried, and on failure `AcquireAsync` throws `LockAcquisitionTimeoutException` while `TryAcquireAsync` returns `null`. This preserves the existing `acquireTimeout: TimeSpan.Zero` try-once-no-wait pattern (used by `TryUsingAsync(..., TimeSpan.Zero)` in `LockTestBase.DoLockedWorkAsync`).

## Other changes

- New `LockException` base type (in `Foundatio.Lock`), and `LockAcquisitionTimeoutException` derived from it.
- The default exception message is neutral (`Failed to acquire lock for resource 'X'.`) so it covers cancellation and multi-resource cases as well as plain timeouts.
- Multi-resource throwing `AcquireAsync` overloads materialize `resources` once so single-use enumerables aren't walked twice and the exception message reflects the actual attempt.
- Convenience overloads' XML docs explicitly note that a null `acquireTimeout` applies a 30-second default (pre-existing behavior, now documented).
- Updated `docs/guide/locks.md` to document the dual API and recommend `AcquireAsync` as the safer default.
- New `LockTestBase` tests covering the throwing shape (single resource, cancelled token, multi-resource).

## Test plan

- [x] `dotnet build Foundatio.slnx` — clean
- [x] `dotnet test Foundatio.slnx` — 1861 passed, 13 skipped (pre-existing skips), 0 failed
- [ ] Verify CI passes
- [ ] Follow-up: migrate downstream `Foundatio.Repositories` callers (`ReindexWorkItemHandler`, `ElasticConfiguration`, `MigrationManager`, `CustomFieldDefinitionRepository`)