### PR TITLE
fix: abandon queue entry when GetQueueEntryLockAsync throws

### DIFF
--- a/.agents/skills/foundatio/SKILL.md
+++ b/.agents/skills/foundatio/SKILL.md
@@ -298,12 +298,13 @@ public class OrderServiceTests : TestLoggerBase
 
 ## Gotchas
 
-- **Lock returns null**: `AcquireAsync` returns `null` when the lock cannot be acquired -- always guard with `is not null` before doing work.
+- **Lock returns null**: `TryAcquireAsync` returns `null` when the lock cannot be acquired -- always guard with `is not null` before doing work. `AcquireAsync` throws `LockAcquisitionTimeoutException` instead of returning null.
 - **Dispose streams and locks**: `ILock` is `IAsyncDisposable` -- use `await using`. Streams from `GetFileStreamAsync` are `IDisposable` -- use `using var`.
 - **Cache TTL floor**: Expiration values below 5ms are treated as already-expired and the key is silently removed. If you compute TTL dynamically (e.g., `expiresAt - now`), guard against near-zero values.
 - **Cache `GetAsync` returns `CacheValue<T>`**: Check `result.HasValue` before accessing `result.Value`. A missing key returns `HasValue = false`, not an exception.
 - **Cache stampede (thundering herd)**: The cache-aside pattern (`Get` -> miss -> load -> `Set`) is vulnerable to stampedes when a popular key expires and many callers regenerate simultaneously. Use `CacheLockProvider` to serialize regeneration: acquire a lock keyed on the cache key, double-check the cache after acquiring, and only then call the backing store. See the [Cache Stampede Protection](https://foundatio.readthedocs.io/guide/caching.html#cache-stampede-protection) docs for the full pattern.
 - **Queue auto-complete**: `QueueJobBase<T>` auto-completes entries based on `JobResult` by default. Set `AutoComplete = false` only when you need manual `CompleteAsync()`/`AbandonAsync()` control. Manual `DequeueAsync` does NOT auto-complete.
+- **GetQueueEntryLockAsync error handling**: If `GetQueueEntryLockAsync` returns `null`, the queue entry is abandoned. If it throws, the entry is also abandoned and a `JobResult.FromException` is returned. Use `TryAcquireAsync` (not `AcquireAsync`) in your override since the return type is `Task<ILock?>`.
 - **JobWithLockBase vs manual locking**: Use `JobWithLockBase` when the entire run must be single-instance (leader election). Use manual `ILockProvider.AcquireAsync` inside `JobBase` for finer-grained locking within a job.
 - **JobContext.RenewLockAsync**: Call in long-running jobs (both `JobBase` and `QueueJobBase`) to prevent lock expiration mid-processing.
 - **Register as singletons**: All infrastructure services (`ICacheClient`, `IMessageBus`, `IQueue<T>`, `IFileStorage`, `ILockProvider`) maintain internal state and connections -- always register as singletons.

--- a/docs/guide/jobs.md
+++ b/docs/guide/jobs.md
@@ -269,7 +269,7 @@ protected override Task<JobResult> RunInternalAsync(JobContext context)
 **Key behaviors:**
 
 - **AutoComplete (default: `true`)** — entries are completed when `ProcessQueueEntryAsync` returns success, or abandoned on failure/exception. Set `AutoComplete = false` when you need to call `CompleteAsync()` / `AbandonAsync()` yourself.
-- **Entry-level locking** — override `GetQueueEntryLockAsync` to acquire a distributed lock per queue entry before processing. The default returns an empty (no-op) lock.
+- **Entry-level locking** — override `GetQueueEntryLockAsync` to acquire a distributed lock per queue entry before processing. The default returns an empty (no-op) lock. If `GetQueueEntryLockAsync` returns `null`, the entry is abandoned. If it throws, the entry is abandoned and a failure `JobResult` is returned.
 - **Poison message safety** — entries with `null` values (deserialization failures) are automatically abandoned without calling your code.
 
 ```csharp

--- a/docs/guide/queues.md
+++ b/docs/guide/queues.md
@@ -305,7 +305,7 @@ public class OrderProcessorJob : QueueJobBase<OrderWorkItem>
         // Lock on the business key (order ID) to prevent concurrent processing
         // of the same order across all queue entries
         string lockKey = $"order:{queueEntry.Value.OrderId}";
-        return _lockProvider.AcquireAsync(lockKey, TimeSpan.FromMinutes(5), cancellationToken);
+        return _lockProvider.TryAcquireAsync(lockKey, TimeSpan.FromMinutes(5), cancellationToken);
     }
 
     protected override async Task<JobResult> ProcessQueueEntryAsync(
@@ -325,8 +325,9 @@ public class OrderProcessorJob : QueueJobBase<OrderWorkItem>
 
 1. When `QueueJobBase` dequeues an entry, it calls `GetQueueEntryLockAsync` before processing
 2. If the lock cannot be acquired (returns `null`), the entry is abandoned and returned to the queue
-3. If the lock is acquired, processing continues and the lock is automatically released after completion
-4. The lock is also used for manual renewal within `ProcessQueueEntryAsync` via `await context.QueueEntry.RenewLockAsync()`
+3. If the lock acquisition throws an exception (e.g., network failure), the entry is abandoned and a `JobResult.FromException` is returned
+4. If the lock is acquired, processing continues and the lock is automatically released after completion
+5. The lock is also used for manual renewal within `ProcessQueueEntryAsync` via `await context.QueueEntry.RenewLockAsync()`
 
 ::: tip Lock Provider Selection
 Use a distributed lock provider (e.g., `CacheLockProvider` with Redis) in production to coordinate across multiple instances. For single-instance scenarios, `CacheLockProvider` with `InMemoryCacheClient` is sufficient.

--- a/src/Foundatio.TestHarness/Jobs/JobQueueTestsBase.cs
+++ b/src/Foundatio.TestHarness/Jobs/JobQueueTestsBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -185,5 +185,34 @@ public abstract class JobQueueTestsBase : TestWithLoggingBase
                 q.Dispose();
             }
         }
+    }
+
+    public virtual async Task GetQueueEntryLockAsync_WhenLockThrows_AbandonsQueueEntry()
+    {
+        // Arrange
+        using var queue = GetSampleWorkItemQueue(retries: 0, retryDelay: TimeSpan.Zero);
+        await queue.DeleteQueueAsync();
+
+        await queue.EnqueueAsync(new SampleQueueWorkItem
+        {
+            Created = DateTime.UtcNow,
+            Path = "somepath"
+        });
+
+        var job = new SampleQueueJobWithThrowingLock(queue, loggerFactory: Log);
+
+        // Act
+        var result = await job.RunAsync();
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.NotNull(result.Error);
+        Assert.IsType<InvalidOperationException>(result.Error);
+
+        var stats = await queue.GetQueueStatsAsync();
+        Assert.Equal(0, stats.Queued);
+        Assert.Equal(1, stats.Enqueued);
+        Assert.Equal(1, stats.Abandoned);
+        Assert.Equal(0, stats.Completed);
     }
 }

--- a/src/Foundatio.TestHarness/Jobs/SampleQueueJob.cs
+++ b/src/Foundatio.TestHarness/Jobs/SampleQueueJob.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable 612, 618
+#pragma warning disable 612, 618
 
 using System;
 using System.Threading;
@@ -57,10 +57,24 @@ public class SampleQueueJobWithLocking : QueueJobBase<SampleQueueWorkItem>
 
     protected override Task<ILock?> GetQueueEntryLockAsync(IQueueEntry<SampleQueueWorkItem> queueEntry, CancellationToken cancellationToken = default(CancellationToken))
     {
-        if (_lockProvider != null)
-            return _lockProvider.TryAcquireAsync("job", TimeSpan.FromMilliseconds(100), TimeSpan.Zero);
+        return _lockProvider.TryAcquireAsync("job", TimeSpan.FromMilliseconds(100), TimeSpan.Zero);
+    }
 
-        return base.GetQueueEntryLockAsync(queueEntry, cancellationToken);
+    protected override Task<JobResult> ProcessQueueEntryAsync(QueueEntryContext<SampleQueueWorkItem> context)
+    {
+        return Task.FromResult(JobResult.Success);
+    }
+}
+
+public class SampleQueueJobWithThrowingLock : QueueJobBase<SampleQueueWorkItem>
+{
+    public SampleQueueJobWithThrowingLock(IQueue<SampleQueueWorkItem> queue, TimeProvider? timeProvider = null, IResiliencePolicyProvider? resiliencePolicyProvider = null, ILoggerFactory? loggerFactory = null) : base(queue, timeProvider, resiliencePolicyProvider, loggerFactory)
+    {
+    }
+
+    protected override Task<ILock?> GetQueueEntryLockAsync(IQueueEntry<SampleQueueWorkItem> queueEntry, CancellationToken cancellationToken = default)
+    {
+        throw new InvalidOperationException("Lock provider is unavailable");
     }
 
     protected override Task<JobResult> ProcessQueueEntryAsync(QueueEntryContext<SampleQueueWorkItem> context)

--- a/src/Foundatio/Jobs/QueueJobBase.cs
+++ b/src/Foundatio/Jobs/QueueJobBase.cs
@@ -107,7 +107,18 @@ public abstract class QueueJobBase<T> : IQueueJob<T>, IHaveLogger, IHaveLoggerFa
             return JobResult.SuccessWithMessage($"Abandoned poison message in {_queueName}: {queueEntry.Id}");
         }
 
-        var lockValue = await GetQueueEntryLockAsync(queueEntry, cancellationToken).AnyContext();
+        ILock? lockValue;
+        try
+        {
+            lockValue = await GetQueueEntryLockAsync(queueEntry, cancellationToken).AnyContext();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error acquiring lock for {QueueName} queue entry {QueueEntryId}: {Message}", _queueName, queueEntry.Id, ex.Message);
+            await queueEntry.AbandonAsync().AnyContext();
+            return JobResult.FromException(ex, $"Error acquiring lock for {_queueName} queue entry {queueEntry.Id}: {ex.Message}");
+        }
+
         if (lockValue is null)
         {
             await queueEntry.AbandonAsync().AnyContext();

--- a/tests/Foundatio.Tests/Jobs/InMemoryJobQueueTests.cs
+++ b/tests/Foundatio.Tests/Jobs/InMemoryJobQueueTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Foundatio.Queues;
 
@@ -16,15 +16,15 @@ public class InMemoryJobQueueTests : JobQueueTestsBase
     }
 
     [Fact]
-    public override Task CanRunMultipleQueueJobsAsync()
+    public override Task ActivityWillFlowThroughQueueJobAsync()
     {
-        return base.CanRunMultipleQueueJobsAsync();
+        return base.ActivityWillFlowThroughQueueJobAsync();
     }
 
     [Fact]
-    public override Task CanRunQueueJobWithLockFailAsync()
+    public override Task CanRunMultipleQueueJobsAsync()
     {
-        return base.CanRunQueueJobWithLockFailAsync();
+        return base.CanRunMultipleQueueJobsAsync();
     }
 
     [Fact]
@@ -34,8 +34,14 @@ public class InMemoryJobQueueTests : JobQueueTestsBase
     }
 
     [Fact]
-    public override Task ActivityWillFlowThroughQueueJobAsync()
+    public override Task CanRunQueueJobWithLockFailAsync()
     {
-        return base.ActivityWillFlowThroughQueueJobAsync();
+        return base.CanRunQueueJobWithLockFailAsync();
+    }
+
+    [Fact]
+    public override Task GetQueueEntryLockAsync_WhenLockThrows_AbandonsQueueEntry()
+    {
+        return base.GetQueueEntryLockAsync_WhenLockThrows_AbandonsQueueEntry();
     }
 }


### PR DESCRIPTION
## Summary

- Wraps \GetQueueEntryLockAsync\ in a try-catch in \QueueJobBase.ProcessAsync\ so that if the lock acquisition throws (e.g., network failure in a distributed lock provider), the queue entry is properly abandoned rather than left in-flight until visibility timeout expires
- Updates the \GetQueueEntryLockAsync\ example in docs to use \TryAcquireAsync\ (matching the \Task<ILock?>\ return type) instead of \AcquireAsync\
- Documents the error handling behavior in jobs guide, queues guide, and the Foundatio agent skill

## Test plan

- [x] Added \GetQueueEntryLockAsync_WhenLockThrows_AbandonsQueueEntry\ test to \JobQueueTestsBase\ and wired it into \InMemoryJobQueueTests\ and \RedisJobQueueTests\
- [x] All existing \InMemoryJobQueueTests\ pass (5/5)
- [x] Full workspace build (\Foundatio.All.slnx\) succeeds with 0 warnings