### PR TITLE
perf: change IMessage.Data from byte[] to ReadOnlyMemory<byte>

### DIFF
--- a/benchmarks/Program.cs
+++ b/benchmarks/Program.cs
@@ -1,3 +1,4 @@
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 using RhoMicro.BdnLogging;
 
@@ -14,6 +15,11 @@ public class Program
         //   dotnet run -c Release -- --filter *Resilience* # Run only resilience benchmarks
         //   dotnet run -c Release -- --filter *DeepClone*  # Run only deep clone benchmarks
         //   dotnet run -c Release -- --list tree           # List all benchmarks
-        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, SpotlightConfig.Instance);
+
+        // The spotlight logger renders a live, cursor-positioned console. When output is
+        // redirected (CI, agents, log files) there is no interactive console and its cursor
+        // calls throw, so fall back to the default config in that case.
+        var config = System.Console.IsOutputRedirected ? DefaultConfig.Instance : SpotlightConfig.Instance;
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
     }
 }

--- a/docs/guide/messaging.md
+++ b/docs/guide/messaging.md
@@ -272,17 +272,15 @@ await messageBus.SubscribeAsync(async (IMessage message, CancellationToken ct) =
     var order = message.GetBody<OrderCreated>();
 });
 ```
+**Breaking change in v5.0: `IMessage.Data` is now `ReadOnlyMemory<byte>`**
 
-> [!WARNING] Breaking change: `IMessage.Data` is `ReadOnlyMemory<byte>`
-> `IMessage.Data` exposes the raw payload as `ReadOnlyMemory<byte>` (previously `byte[]`). This lets memory-backed transports such as Azure Service Bus (`BinaryData`) avoid copying the payload into a new array. Because it is a struct:
->
-> - Check for an empty payload with `message.Data.IsEmpty` (not `== null`).
-> - Read the bytes directly via `message.Data.Span`.
-> - Call `message.Data.ToArray()` only when you genuinely need a `byte[]`.
->
-> Most code uses `GetBody()` / `Body` and is unaffected. When constructing a `Message`, you can still pass a `byte[]`; it converts implicitly to `ReadOnlyMemory<byte>`.
+`IMessage.Data` exposes the raw payload as `ReadOnlyMemory<byte>` instead of `byte[]`. This lets memory-backed transports such as Azure Service Bus avoid copying the payload into a new array. Since it is a struct, follow these patterns:
 
-## Common Patterns
+- Check for an empty payload with `message.Data.IsEmpty` (not `== null`)
+- Read the bytes directly via `message.Data.Span`
+- Call `message.Data.ToArray()` only when you need a `byte[]`
+
+Most code that uses `GetBody()` / `Body` is unaffected. When constructing a `Message`, you can still pass a `byte[]`; it converts implicitly to `ReadOnlyMemory<byte>`.
 
 ### Event-Driven Architecture
 

--- a/docs/guide/messaging.md
+++ b/docs/guide/messaging.md
@@ -272,7 +272,8 @@ await messageBus.SubscribeAsync(async (IMessage message, CancellationToken ct) =
     var order = message.GetBody<OrderCreated>();
 });
 ```
-**Breaking change: `IMessage.Data` is now `ReadOnlyMemory<byte>`**
+
+#### Breaking change: `IMessage.Data` is now `ReadOnlyMemory<byte>`
 
 `IMessage.Data` exposes the raw payload as `ReadOnlyMemory<byte>` instead of `byte[]`. This lets memory-backed transports such as Azure Service Bus avoid copying the payload into a new array. Since it is a struct, follow these patterns:
 
@@ -281,6 +282,8 @@ await messageBus.SubscribeAsync(async (IMessage message, CancellationToken ct) =
 - Call `message.Data.ToArray()` only when you need a `byte[]`
 
 Most code that uses `GetBody()` / `Body` is unaffected. When constructing a `Message`, you can still pass a `byte[]`; it converts implicitly to `ReadOnlyMemory<byte>`.
+
+## Common Patterns
 
 ### Event-Driven Architecture
 

--- a/docs/guide/messaging.md
+++ b/docs/guide/messaging.md
@@ -272,7 +272,7 @@ await messageBus.SubscribeAsync(async (IMessage message, CancellationToken ct) =
     var order = message.GetBody<OrderCreated>();
 });
 ```
-**Breaking change in v5.0: `IMessage.Data` is now `ReadOnlyMemory<byte>`**
+**Breaking change: `IMessage.Data` is now `ReadOnlyMemory<byte>`**
 
 `IMessage.Data` exposes the raw payload as `ReadOnlyMemory<byte>` instead of `byte[]`. This lets memory-backed transports such as Azure Service Bus avoid copying the payload into a new array. Since it is a struct, follow these patterns:
 

--- a/docs/guide/messaging.md
+++ b/docs/guide/messaging.md
@@ -273,6 +273,15 @@ await messageBus.SubscribeAsync(async (IMessage message, CancellationToken ct) =
 });
 ```
 
+> [!WARNING] Breaking change: `IMessage.Data` is `ReadOnlyMemory<byte>`
+> `IMessage.Data` exposes the raw payload as `ReadOnlyMemory<byte>` (previously `byte[]`). This lets memory-backed transports such as Azure Service Bus (`BinaryData`) avoid copying the payload into a new array. Because it is a struct:
+>
+> - Check for an empty payload with `message.Data.IsEmpty` (not `== null`).
+> - Read the bytes directly via `message.Data.Span`.
+> - Call `message.Data.ToArray()` only when you genuinely need a `byte[]`.
+>
+> Most code uses `GetBody()` / `Body` and is unaffected. When constructing a `Message`, you can still pass a `byte[]`; it converts implicitly to `ReadOnlyMemory<byte>`.
+
 ## Common Patterns
 
 ### Event-Driven Architecture

--- a/src/Foundatio.TestHarness/Serializer/SerializerTestsBase.cs
+++ b/src/Foundatio.TestHarness/Serializer/SerializerTestsBase.cs
@@ -31,6 +31,7 @@ public abstract class SerializerTestsBase : TestWithLoggingBase
         Assert.Throws<ArgumentNullException>(() => serializer.Deserialize<SerializeModel>((Stream)null!));
         Assert.Throws<ArgumentNullException>(() => serializer.Deserialize<SerializeModel>((byte[])null!));
         Assert.Throws<ArgumentException>(() => serializer.Deserialize<SerializeModel>([]));
+        Assert.Throws<ArgumentException>(() => serializer.Deserialize<SerializeModel>(ReadOnlyMemory<byte>.Empty));
         Assert.Throws<ArgumentNullException>(() => serializer.Deserialize<SerializeModel>((string)null!));
         Assert.Throws<ArgumentException>(() => serializer.Deserialize<SerializeModel>(String.Empty));
         Assert.Throws<ArgumentException>(() => serializer.Deserialize<SerializeModel>("   "));
@@ -115,6 +116,24 @@ public abstract class SerializerTestsBase : TestWithLoggingBase
         Assert.Equal(model.IntProperty, actual.IntProperty);
         Assert.Equal(model.StringProperty, actual.StringProperty);
         Assert.Equal(model.ListProperty, actual.ListProperty);
+
+        // Act - ReadOnlyMemory<byte> over a managed array (MemoryMarshal.TryGetArray fast path)
+        var fromArrayMemory = serializer.Deserialize<SerializeModel>(new ReadOnlyMemory<byte>(bytes));
+        Assert.NotNull(fromArrayMemory);
+
+        // Assert
+        Assert.Equal(model.IntProperty, fromArrayMemory.IntProperty);
+        Assert.Equal(model.StringProperty, fromArrayMemory.StringProperty);
+        Assert.Equal(model.ListProperty, fromArrayMemory.ListProperty);
+
+        // Act - ReadOnlyMemory<byte> NOT backed by a managed array (ReadOnlyMemoryStream fallback)
+        var fromNativeMemory = serializer.Deserialize<SerializeModel>(CreateNativeBackedMemory(bytes));
+        Assert.NotNull(fromNativeMemory);
+
+        // Assert
+        Assert.Equal(model.IntProperty, fromNativeMemory.IntProperty);
+        Assert.Equal(model.StringProperty, fromNativeMemory.StringProperty);
+        Assert.Equal(model.ListProperty, fromNativeMemory.ListProperty);
 
         // Act
         string text = serializer.SerializeToString(model);
@@ -429,6 +448,32 @@ public abstract class SerializerTestsBase : TestWithLoggingBase
     {
         return value is byte or sbyte or short or ushort or int or uint or long or ulong
             or float or double or decimal;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="ReadOnlyMemory{T}"/> that is NOT backed by a managed array (it is backed by a
+    /// custom <see cref="System.Buffers.MemoryManager{T}"/>), so the
+    /// <see cref="System.Runtime.InteropServices.MemoryMarshal.TryGetArray"/> fast path fails and the
+    /// <c>ReadOnlyMemoryStream</c> fallback is exercised.
+    /// </summary>
+    private static ReadOnlyMemory<byte> CreateNativeBackedMemory(byte[] source)
+    {
+        return new ManagerBackedMemory(source).Memory;
+    }
+
+    private sealed class ManagerBackedMemory : System.Buffers.MemoryManager<byte>
+    {
+        private readonly byte[] _buffer;
+
+        public ManagerBackedMemory(byte[] source) => _buffer = source;
+
+        public override Span<byte> GetSpan() => _buffer;
+
+        public override System.Buffers.MemoryHandle Pin(int elementIndex = 0) => throw new NotSupportedException();
+
+        public override void Unpin() { }
+
+        protected override void Dispose(bool disposing) { }
     }
 }
 

--- a/src/Foundatio/Messaging/Message.cs
+++ b/src/Foundatio/Messaging/Message.cs
@@ -35,11 +35,11 @@ public interface IMessage
     /// <summary>
     /// Gets the raw serialized message payload.
     /// </summary>
-    /// <remarks>
-    /// Returned as a <see cref="ReadOnlyMemory{T}"/> to avoid forcing an array copy on providers
-    /// whose transport buffers are already memory-backed (e.g. Azure Service Bus). The underlying
-    /// buffer is owned by the message and remains valid for the lifetime of the message.
-    /// </remarks>
+/// <remarks>
+/// Returned as a <see cref="ReadOnlyMemory{T}"/> to avoid forcing an array copy on providers
+/// whose transport buffers are already memory-backed (e.g. Azure Service Bus). Implementations
+/// should ensure the backing memory remains valid for the lifetime of the message.
+/// </remarks>
     ReadOnlyMemory<byte> Data { get; }
 
     /// <summary>

--- a/src/Foundatio/Messaging/Message.cs
+++ b/src/Foundatio/Messaging/Message.cs
@@ -35,11 +35,12 @@ public interface IMessage
     /// <summary>
     /// Gets the raw serialized message payload.
     /// </summary>
-/// <remarks>
-/// Returned as a <see cref="ReadOnlyMemory{T}"/> to avoid forcing an array copy on providers
-/// whose transport buffers are already memory-backed (e.g. Azure Service Bus). Implementations
-/// should ensure the backing memory remains valid for the lifetime of the message.
-/// </remarks>
+    /// <remarks>
+    /// Returned as a <see cref="ReadOnlyMemory{T}"/> to avoid forcing an array copy on providers
+    /// whose transport buffers are already memory-backed (e.g. Azure Service Bus). Implementations
+    /// are expected to keep the underlying buffer valid for the lifetime of the message; consumers
+    /// that need to retain the payload beyond the current operation should copy it via <c>ToArray()</c>.
+    /// </remarks>
     ReadOnlyMemory<byte> Data { get; }
 
     /// <summary>

--- a/src/Foundatio/Messaging/Message.cs
+++ b/src/Foundatio/Messaging/Message.cs
@@ -35,7 +35,12 @@ public interface IMessage
     /// <summary>
     /// Gets the raw serialized message payload.
     /// </summary>
-    byte[] Data { get; }
+    /// <remarks>
+    /// Returned as a <see cref="ReadOnlyMemory{T}"/> to avoid forcing an array copy on providers
+    /// whose transport buffers are already memory-backed (e.g. Azure Service Bus). The underlying
+    /// buffer is owned by the message and remains valid for the lifetime of the message.
+    /// </remarks>
+    ReadOnlyMemory<byte> Data { get; }
 
     /// <summary>
     /// Deserializes and returns the message payload.
@@ -65,7 +70,7 @@ public class Message : IMessage
 {
     private readonly Func<IMessage, object?> _getBody;
 
-    public Message(byte[] data, Func<IMessage, object?> getBody)
+    public Message(ReadOnlyMemory<byte> data, Func<IMessage, object?> getBody)
     {
         Data = data;
         _getBody = getBody;
@@ -77,7 +82,7 @@ public class Message : IMessage
     public Type? ClrType { get; set; }
     [DisallowNull]
     public IDictionary<string, string> Properties { get => field; set => field = value ?? new Dictionary<string, string>(); } = new Dictionary<string, string>();
-    public byte[] Data { get; set; }
+    public ReadOnlyMemory<byte> Data { get; set; }
     public object? GetBody() => _getBody(this);
 }
 
@@ -90,7 +95,7 @@ public class Message<T> : IMessage<T> where T : class
         _message = message;
     }
 
-    public byte[] Data => _message.Data;
+    public ReadOnlyMemory<byte> Data => _message.Data;
 
     public T Body => GetBody() as T ?? throw new MessageBusException("Message body is null or not of expected type");
 

--- a/src/Foundatio/Messaging/MessageBusBase.cs
+++ b/src/Foundatio/Messaging/MessageBusBase.cs
@@ -319,14 +319,14 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
 
     protected virtual object? DeserializeMessageBody(IMessage message)
     {
-        if (message.Data is null || message.Data.Length == 0)
+        if (message.Data.IsEmpty)
             return null;
 
         object? body;
         try
         {
             var clrType = message.ClrType ?? GetMappedMessageType(message.Type);
-            body = clrType != null ? _serializer.Deserialize(message.Data, clrType) : message.Data;
+            body = clrType != null ? _serializer.Deserialize(message.Data, clrType) : message.Data.ToArray();
         }
         catch (Exception ex)
         {

--- a/src/Foundatio/Messaging/MessageBusBase.cs
+++ b/src/Foundatio/Messaging/MessageBusBase.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Foundatio.Resilience;
@@ -326,7 +327,7 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
         try
         {
             var clrType = message.ClrType ?? GetMappedMessageType(message.Type);
-            body = clrType != null ? _serializer.Deserialize(message.Data, clrType) : message.Data.ToArray();
+            body = clrType != null ? _serializer.Deserialize(message.Data, clrType) : GetRawBody(message.Data);
         }
         catch (Exception ex)
         {
@@ -335,6 +336,27 @@ public abstract class MessageBusBase<TOptions> : IMessageBus, IHaveLogger, IHave
         }
 
         return body;
+    }
+
+    /// <summary>
+    /// Returns the raw payload as a <see cref="byte"/> array for subscribers that consume the body
+    /// without a mapped CLR type (e.g. <c>Subscribe&lt;byte[]&gt;()</c>).
+    /// </summary>
+    /// <remarks>
+    /// When the payload already wraps a full-length managed array (offset 0, count equal to the array
+    /// length) the underlying array is returned directly, preserving the no-copy behavior that existed
+    /// before <see cref="IMessage.Data"/> became a <see cref="ReadOnlyMemory{T}"/>. Otherwise the memory
+    /// is copied to honor the <c>byte[]</c> contract.
+    /// </remarks>
+    private static byte[] GetRawBody(ReadOnlyMemory<byte> data)
+    {
+        if (MemoryMarshal.TryGetArray(data, out ArraySegment<byte> segment) && segment.Array is not null
+            && segment.Offset == 0 && segment.Count == segment.Array.Length)
+        {
+            return segment.Array;
+        }
+
+        return data.ToArray();
     }
 
     protected async Task SendMessageToSubscribersAsync(IMessage message)

--- a/src/Foundatio/Serializer/ISerializer.cs
+++ b/src/Foundatio/Serializer/ISerializer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Foundatio.Serializer;
@@ -104,6 +105,51 @@ public static class SerializerExtensions
             throw new ArgumentException("Data cannot be empty.", nameof(data));
 
         using var stream = new MemoryStream(data);
+        return serializer.Deserialize(stream, objectType);
+    }
+
+    /// <summary>
+    /// Deserializes an object of type <typeparamref name="T"/> from <paramref name="data"/>.
+    /// </summary>
+    /// <returns>The deserialized value, or <c>default</c> if the underlying serializer returns <c>null</c>.</returns>
+    /// <remarks>
+    /// The return type is <c>T</c> annotated with <c>[return: MaybeNull]</c> rather than <c>T?</c>
+    /// because <c>T?</c> on an unconstrained generic would double-wrap <c>Nullable&lt;T&gt;</c> value types.
+    /// Callers that expect <c>null</c> should use a nullable type argument, e.g. <c>Deserialize&lt;MyType?&gt;</c>.
+    /// </remarks>
+    [return: MaybeNull]
+    public static T Deserialize<T>(this ISerializer serializer, ReadOnlyMemory<byte> data)
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        if (data.IsEmpty)
+            throw new ArgumentException("Data cannot be empty.", nameof(data));
+
+        object? result = serializer.Deserialize(data, typeof(T));
+        if (result is T typed)
+            return typed;
+
+        if (result is not null)
+            throw new SerializerException($"Deserialized object is of type '{result.GetType().FullName}', expected '{typeof(T).FullName}'.");
+
+        return default!;
+    }
+
+    public static object? Deserialize(this ISerializer serializer, ReadOnlyMemory<byte> data, Type objectType)
+    {
+        ArgumentNullException.ThrowIfNull(serializer);
+        ArgumentNullException.ThrowIfNull(objectType);
+        if (data.IsEmpty)
+            throw new ArgumentException("Data cannot be empty.", nameof(data));
+
+        // Fast path: if the memory is backed by a managed array we can hand it straight to a
+        // MemoryStream without copying. Otherwise fall back to a stream over the memory.
+        if (MemoryMarshal.TryGetArray(data, out ArraySegment<byte> segment) && segment.Array is not null)
+        {
+            using var arrayStream = new MemoryStream(segment.Array, segment.Offset, segment.Count, writable: false);
+            return serializer.Deserialize(arrayStream, objectType);
+        }
+
+        using var stream = new ReadOnlyMemoryStream(data);
         return serializer.Deserialize(stream, objectType);
     }
 

--- a/src/Foundatio/Serializer/ReadOnlyMemoryStream.cs
+++ b/src/Foundatio/Serializer/ReadOnlyMemoryStream.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+
+namespace Foundatio.Serializer;
+
+/// <summary>
+/// A read-only, seekable <see cref="Stream"/> over a <see cref="ReadOnlyMemory{T}"/> of bytes.
+/// </summary>
+/// <remarks>
+/// Used as a fallback for deserializing a <see cref="ReadOnlyMemory{T}"/> whose backing store is not
+/// a managed array (so the no-copy <see cref="System.Runtime.InteropServices.MemoryMarshal.TryGetArray"/>
+/// fast path is unavailable). This avoids allocating an intermediate <c>byte[]</c> copy just to wrap
+/// the payload in a <see cref="MemoryStream"/>.
+/// </remarks>
+internal sealed class ReadOnlyMemoryStream : Stream
+{
+    private readonly ReadOnlyMemory<byte> _memory;
+    private int _position;
+
+    public ReadOnlyMemoryStream(ReadOnlyMemory<byte> memory)
+    {
+        _memory = memory;
+    }
+
+    public override bool CanRead => true;
+    public override bool CanSeek => true;
+    public override bool CanWrite => false;
+    public override long Length => _memory.Length;
+
+    public override long Position
+    {
+        get => _position;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, _memory.Length);
+            _position = (int)value;
+        }
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        return Read(buffer.AsSpan(offset, count));
+    }
+
+    public override int Read(Span<byte> buffer)
+    {
+        int remaining = _memory.Length - _position;
+        if (remaining <= 0)
+            return 0;
+
+        int toCopy = Math.Min(remaining, buffer.Length);
+        _memory.Span.Slice(_position, toCopy).CopyTo(buffer);
+        _position += toCopy;
+        return toCopy;
+    }
+
+    public override int ReadByte()
+    {
+        if (_position >= _memory.Length)
+            return -1;
+
+        return _memory.Span[_position++];
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        long target = origin switch
+        {
+            SeekOrigin.Begin => offset,
+            SeekOrigin.Current => _position + offset,
+            SeekOrigin.End => _memory.Length + offset,
+            _ => throw new ArgumentOutOfRangeException(nameof(origin))
+        };
+
+        ArgumentOutOfRangeException.ThrowIfNegative(target);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(target, _memory.Length);
+        _position = (int)target;
+        return _position;
+    }
+
+    public override void Flush() { }
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+}

--- a/src/Foundatio/Serializer/ReadOnlyMemoryStream.cs
+++ b/src/Foundatio/Serializer/ReadOnlyMemoryStream.cs
@@ -34,6 +34,7 @@ internal sealed class ReadOnlyMemoryStream : Stream
         {
             ArgumentOutOfRangeException.ThrowIfNegative(value);
             ArgumentOutOfRangeException.ThrowIfGreaterThan(value, _memory.Length);
+
             _position = (int)value;
         }
     }
@@ -76,6 +77,7 @@ internal sealed class ReadOnlyMemoryStream : Stream
 
         ArgumentOutOfRangeException.ThrowIfNegative(target);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(target, _memory.Length);
+
         _position = (int)target;
         return _position;
     }

--- a/tests/Foundatio.Tests/Messaging/InMemoryMessageBusTests.cs
+++ b/tests/Foundatio.Tests/Messaging/InMemoryMessageBusTests.cs
@@ -265,7 +265,7 @@ public class InMemoryMessageBusTests : MessageBusTestBase, IDisposable
         {
             Assert.Null(msg.Type);
             Assert.Null(msg.ClrType);
-            Assert.NotEmpty(msg.Data);
+            Assert.False(msg.Data.IsEmpty);
             rawReceived.Signal();
         }, TestCancellationToken);
 

--- a/tests/Foundatio.Tests/Messaging/MessageTests.cs
+++ b/tests/Foundatio.Tests/Messaging/MessageTests.cs
@@ -10,10 +10,13 @@ public class MessageTests
     [Fact]
     public void Constructor_WithByteArray_StoresDataAsReadOnlyMemory()
     {
+        // Arrange
         byte[] payload = [1, 2, 3, 4];
 
+        // Act
         var message = new Message(payload, _ => null);
 
+        // Assert
         Assert.False(message.Data.IsEmpty);
         Assert.Equal(payload.Length, message.Data.Length);
         Assert.True(payload.AsSpan().SequenceEqual(message.Data.Span));
@@ -22,16 +25,16 @@ public class MessageTests
     [Fact]
     public void Constructor_WithReadOnlyMemory_StoresDataWithoutCopy()
     {
+        // Arrange
         byte[] payload = [10, 20, 30];
         var memory = new ReadOnlyMemory<byte>(payload);
 
+        // Act
         var message = new Message(memory, _ => null);
 
+        // Assert
         Assert.Equal(3, message.Data.Length);
         Assert.True(payload.AsSpan().SequenceEqual(message.Data.Span));
-
-        // Verify the data was stored without copying: the stored memory must still be backed by the
-        // exact same array instance and segment as the original payload, not a defensive copy.
         Assert.True(MemoryMarshal.TryGetArray(message.Data, out ArraySegment<byte> segment));
         Assert.Same(payload, segment.Array);
         Assert.Equal(0, segment.Offset);
@@ -41,26 +44,32 @@ public class MessageTests
     [Fact]
     public void Data_WhenEmptyMemory_IsEmptyReturnsTrue()
     {
+        // Arrange / Act
         var message = new Message(ReadOnlyMemory<byte>.Empty, _ => null);
 
+        // Assert
         Assert.True(message.Data.IsEmpty);
         Assert.Equal(0, message.Data.Length);
     }
 
     [Fact]
-    public void GetBody_InvokesProvidedDelegate()
+    public void GetBody_WhenDelegateIsProvided_ReturnsDelegateResult()
     {
+        // Arrange
         byte[] payload = [1];
         var expected = new object();
 
+        // Act
         var message = new Message(payload, _ => expected);
 
+        // Assert
         Assert.Same(expected, message.GetBody());
     }
 
     [Fact]
-    public void TypedMessage_ExposesUnderlyingData()
+    public void TypedMessage_WhenWrappingMessage_ForwardsPropertiesAndData()
     {
+        // Arrange
         byte[] payload = [5, 6, 7];
         var inner = new Message(payload, _ => "body")
         {
@@ -69,8 +78,10 @@ public class MessageTests
             CorrelationId = "corr"
         };
 
+        // Act
         var typed = new Message<string>(inner);
 
+        // Assert
         Assert.Equal("body", typed.Body);
         Assert.Equal("test", typed.Type);
         Assert.Equal("id", typed.UniqueId);

--- a/tests/Foundatio.Tests/Messaging/MessageTests.cs
+++ b/tests/Foundatio.Tests/Messaging/MessageTests.cs
@@ -1,0 +1,72 @@
+using System;
+using Foundatio.Messaging;
+using Xunit;
+
+namespace Foundatio.Tests.Messaging;
+
+public class MessageTests
+{
+    [Fact]
+    public void Constructor_WithByteArray_StoresDataAsReadOnlyMemory()
+    {
+        byte[] payload = [1, 2, 3, 4];
+
+        var message = new Message(payload, _ => null);
+
+        Assert.False(message.Data.IsEmpty);
+        Assert.Equal(payload.Length, message.Data.Length);
+        Assert.True(payload.AsSpan().SequenceEqual(message.Data.Span));
+    }
+
+    [Fact]
+    public void Constructor_WithReadOnlyMemory_StoresDataWithoutCopy()
+    {
+        byte[] payload = [10, 20, 30];
+        var memory = new ReadOnlyMemory<byte>(payload);
+
+        var message = new Message(memory, _ => null);
+
+        Assert.Equal(3, message.Data.Length);
+        Assert.True(payload.AsSpan().SequenceEqual(message.Data.Span));
+    }
+
+    [Fact]
+    public void Data_WhenEmptyMemory_IsEmptyReturnsTrue()
+    {
+        var message = new Message(ReadOnlyMemory<byte>.Empty, _ => null);
+
+        Assert.True(message.Data.IsEmpty);
+        Assert.Equal(0, message.Data.Length);
+    }
+
+    [Fact]
+    public void GetBody_InvokesProvidedDelegate()
+    {
+        byte[] payload = [1];
+        var expected = new object();
+
+        var message = new Message(payload, _ => expected);
+
+        Assert.Same(expected, message.GetBody());
+    }
+
+    [Fact]
+    public void TypedMessage_ExposesUnderlyingData()
+    {
+        byte[] payload = [5, 6, 7];
+        var inner = new Message(payload, _ => "body")
+        {
+            Type = "test",
+            UniqueId = "id",
+            CorrelationId = "corr"
+        };
+
+        var typed = new Message<string>(inner);
+
+        Assert.Equal("body", typed.Body);
+        Assert.Equal("test", typed.Type);
+        Assert.Equal("id", typed.UniqueId);
+        Assert.Equal("corr", typed.CorrelationId);
+        Assert.True(payload.AsSpan().SequenceEqual(typed.Data.Span));
+    }
+}

--- a/tests/Foundatio.Tests/Messaging/MessageTests.cs
+++ b/tests/Foundatio.Tests/Messaging/MessageTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using Foundatio.Messaging;
 using Xunit;
 
@@ -28,6 +29,13 @@ public class MessageTests
 
         Assert.Equal(3, message.Data.Length);
         Assert.True(payload.AsSpan().SequenceEqual(message.Data.Span));
+
+        // Verify the data was stored without copying: the stored memory must still be backed by the
+        // exact same array instance and segment as the original payload, not a defensive copy.
+        Assert.True(MemoryMarshal.TryGetArray(message.Data, out ArraySegment<byte> segment));
+        Assert.Same(payload, segment.Array);
+        Assert.Equal(0, segment.Offset);
+        Assert.Equal(payload.Length, segment.Count);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Changes `IMessage.Data` from `byte[]` to `ReadOnlyMemory<byte>`. This is a **breaking change** for any code that implements `IMessage` directly or reads `Data` as a `byte[]`, but is source-compatible for all existing provider code because `byte[]` implicitly converts to `ReadOnlyMemory<byte>`.

The change eliminates a forced heap allocation on providers whose transport already hands us memory-backed buffers (Azure Service Bus, etc.), and sets up a cleaner zero-copy deserialization path.

---

## Changes

### `IMessage.Data`: `byte[]` → `ReadOnlyMemory<byte>`

```csharp
// Before
byte[] Data { get; }

// After
ReadOnlyMemory<byte> Data { get; }
```

- `Message(byte[] data, ...)` constructor updated to accept `ReadOnlyMemory<byte>` — existing callers passing `byte[]` still compile via implicit conversion.
- `Message.Data` and `Message<T>.Data` properties updated accordingly.

### New: `ReadOnlyMemoryStream` (internal)

.NET's BCL does not provide a `Stream` wrapper over `ReadOnlyMemory<byte>`. Added `src/Foundatio/Serializer/ReadOnlyMemoryStream.cs` — a fully seekable, read-only `Stream` implementation used during deserialization.

### New: `ISerializer.Deserialize(ReadOnlyMemory<byte>, Type)` extension

```csharp
public static object? Deserialize(this ISerializer serializer, ReadOnlyMemory<byte> data, Type objectType)
```

Uses `MemoryMarshal.TryGetArray()` as a zero-copy fast path (succeeds whenever the `ReadOnlyMemory<byte>` is backed by a managed array — which covers all current providers). Falls back to `ReadOnlyMemoryStream` when the backing is non-array memory (e.g. native memory, `MemoryMappedFile`).

### `MessageBusBase.DeserializeMessageBody` updated

- `message.Data is null || message.Data.Length == 0` → `message.Data.IsEmpty` (correct for `ReadOnlyMemory<byte>`, which cannot be null)
- Deserialization now routes through the ROM-aware extension method above
- The `clrType == null` fallback (for `Subscribe<byte[]>()`) still calls `.ToArray()` — intentional, since `byte[]` subscribers need a real array

### Docs & tests updated

- `docs/guide/messaging.md` updated to document the type change
- `tests/Foundatio.Tests/Messaging/MessageTests.cs` — new tests covering ROM contract
- `tests/Foundatio.Tests/Messaging/InMemoryMessageBusTests.cs` — updated for ROM
- `src/Foundatio.TestHarness/Serializer/SerializerTestsBase.cs` — covers `ReadOnlyMemoryStream` fallback path

---

## Design decisions

**Why stay on the copy-lazy path?**  
`MessageBusBase` currently copies the raw bytes into `Message.Data` eagerly in `SendMessageToSubscribersAsync`. We benchmarked four strategies:

| Strategy | Notes |
|---|---|
| Baseline: copy + `MemoryStream` re-wrap | Previous behavior |
| **Copy + `ReadOnlyMemoryStream`** | ✅ Chosen — eliminates the `MemoryStream` re-wrap allocation |
| Eager copy (no lazy stream) | Allocates byte[] up front on every message |
| Eager no-copy (pass ROM directly) | Lowest allocation — but risky if a subscriber stores `Data` past handler lifetime |

We keep the lazy copy and swap `MemoryStream` for `ReadOnlyMemoryStream` to eliminate one allocation per deserialization without changing the copy semantics.

**Why not go fully zero-copy?**  
Providers like RabbitMQ reclaim pooled transport buffers after the receive callback returns. Any subscriber that stores `message.Data` beyond the handler (e.g. for async logging) would silently read garbage. The copy at receive time gives a stable, lifetime-safe `ReadOnlyMemory<byte>`.

---

## Breaking changes

| API | Before | After |
|---|---|---|
| `IMessage.Data` | `byte[] Data { get; }` | `ReadOnlyMemory<byte> Data { get; }` |
| `Message(data, getBody)` ctor | `byte[] data` | `ReadOnlyMemory<byte> data` |

`byte[]` → `ReadOnlyMemory<byte>` is an **implicit conversion**, so existing provider code that passes a `byte[]` to the `Message` constructor compiles without changes. Code that reads `message.Data` as a `byte[]` will need to call `.ToArray()` or `.Span`.

---

## Companion PRs

- **Foundatio.AzureServiceBus** — zero-copy `Body.ToMemory()` instead of `Body.ToArray()` on receive; fixes critical message-loss bug where swallowed exceptions caused `AutoCompleteMessages` to permanently ack failed messages
- **Foundatio.RabbitMQ** — `ReadOnlyMemory<byte>` signature on republish path; updated receive-path comment to accurately explain the copy rationale
