### PR TITLE
Messaging and jobs redesign in-memory slice

### DIFF
--- a/src/Foundatio.TestHarness/Messaging/MessageTransportConformanceTests.cs
+++ b/src/Foundatio.TestHarness/Messaging/MessageTransportConformanceTests.cs
@@ -1,0 +1,333 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Foundatio.Messaging;
+using Foundatio.Queues;
+using Foundatio.Xunit;
+using Xunit;
+
+namespace Foundatio.Tests.Messaging;
+
+public abstract class MessageTransportConformanceTests : TestWithLoggingBase
+{
+    protected MessageTransportConformanceTests(ITestOutputHelper output) : base(output) { }
+
+    protected virtual IMessageTransport? CreateTransport()
+    {
+        return null;
+    }
+
+    protected virtual ValueTask CleanupTransportAsync(IMessageTransport transport)
+    {
+        return transport.DisposeAsync();
+    }
+
+    public virtual async Task CanSendAndReceiveBatchAsync()
+    {
+        var transport = CreateTransport();
+        if (transport is not ISupportsPull pull)
+            return;
+
+        try
+        {
+            await EnsureAsync(transport, new DestinationDeclaration { Name = "orders", Role = DestinationRole.Queue });
+
+            var result = await transport.SendAsync("orders", [
+                CreateMessage("one", ("tenant", "acme")),
+                CreateMessage("two", ("tenant", "acme"))
+            ], new TransportSendOptions(), TestCancellationToken);
+
+            Assert.True(result.AllSucceeded);
+            Assert.Equal(2, result.Items.Count);
+            Assert.All(result.Items, item => Assert.True(item.Success));
+
+            var entries = await pull.ReceiveAsync("orders", new ReceiveRequest
+            {
+                MaxMessages = 2,
+                MaxWaitTime = TimeSpan.FromSeconds(1)
+            }, TestCancellationToken);
+
+            Assert.Equal(2, entries.Count);
+            Assert.Equal("one", ReadBody(entries[0]));
+            Assert.Equal("two", ReadBody(entries[1]));
+            Assert.Equal("acme", entries[0].Headers["tenant"]);
+            Assert.Equal(1, entries[0].DeliveryCount);
+
+            await transport.CompleteAsync(entries[0], TestCancellationToken);
+            await transport.CompleteAsync(entries[1], TestCancellationToken);
+
+            if (transport is ISupportsStats stats)
+            {
+                QueueStats queueStats = await stats.GetStatsAsync("orders", TestCancellationToken);
+                Assert.Equal(0, queueStats.Queued);
+                Assert.Equal(0, queueStats.Working);
+                Assert.Equal(2, queueStats.Completed);
+            }
+        }
+        finally
+        {
+            await CleanupTransportIfNotNullAsync(transport);
+        }
+    }
+
+    public virtual async Task AbandonAsync_RedeliversWithIncrementedDeliveryCountAsync()
+    {
+        var transport = CreateTransport();
+        if (transport is not ISupportsPull pull)
+            return;
+
+        try
+        {
+            await EnsureAsync(transport, new DestinationDeclaration { Name = "retry", Role = DestinationRole.Queue });
+            await transport.SendAsync("retry", [CreateMessage("retry-me")], new TransportSendOptions(), TestCancellationToken);
+
+            var first = Assert.Single(await pull.ReceiveAsync("retry", new ReceiveRequest { MaxWaitTime = TimeSpan.FromSeconds(1) }, TestCancellationToken));
+            Assert.Equal(1, first.DeliveryCount);
+
+            await transport.AbandonAsync(first, TestCancellationToken);
+
+            var second = Assert.Single(await pull.ReceiveAsync("retry", new ReceiveRequest { MaxWaitTime = TimeSpan.FromSeconds(1) }, TestCancellationToken));
+            Assert.Equal(first.Id, second.Id);
+            Assert.Equal(2, second.DeliveryCount);
+            Assert.Equal("retry-me", ReadBody(second));
+
+            await transport.CompleteAsync(second, TestCancellationToken);
+        }
+        finally
+        {
+            await CleanupTransportIfNotNullAsync(transport);
+        }
+    }
+
+    public virtual async Task CompleteAsync_WithExpiredReceipt_ThrowsReceiptExpiredExceptionAsync()
+    {
+        var transport = CreateTransport();
+        if (transport is not ISupportsPull pull)
+            return;
+
+        try
+        {
+            await EnsureAsync(transport, new DestinationDeclaration { Name = "receipts", Role = DestinationRole.Queue });
+            await transport.SendAsync("receipts", [CreateMessage("done")], new TransportSendOptions(), TestCancellationToken);
+
+            var entry = Assert.Single(await pull.ReceiveAsync("receipts", new ReceiveRequest { MaxWaitTime = TimeSpan.FromSeconds(1) }, TestCancellationToken));
+            await transport.CompleteAsync(entry, TestCancellationToken);
+
+            await Assert.ThrowsAsync<ReceiptExpiredException>(async () =>
+                await transport.CompleteAsync(entry, TestCancellationToken));
+        }
+        finally
+        {
+            await CleanupTransportIfNotNullAsync(transport);
+        }
+    }
+
+    public virtual async Task SubscribeAsync_DeliversPushMessagesAsync()
+    {
+        var transport = CreateTransport();
+        if (transport is not ISupportsPush push)
+            return;
+
+        try
+        {
+            await EnsureAsync(transport, new DestinationDeclaration { Name = "push", Role = DestinationRole.Queue });
+
+            var received = new TaskCompletionSource<TransportEntry>(TaskCreationOptions.RunContinuationsAsynchronously);
+            await using var subscription = await push.SubscribeAsync("push", async (entry, ct) =>
+            {
+                await transport.CompleteAsync(entry, ct);
+                received.TrySetResult(entry);
+            }, new PushOptions(), TestCancellationToken);
+
+            await transport.SendAsync("push", [CreateMessage("pushed")], new TransportSendOptions(), TestCancellationToken);
+
+            var completed = await Task.WhenAny(received.Task, Task.Delay(TimeSpan.FromSeconds(3), TestCancellationToken));
+            Assert.Equal(received.Task, completed);
+            Assert.Equal("pushed", ReadBody(await received.Task));
+            Assert.Equal("push", subscription.Source);
+        }
+        finally
+        {
+            await CleanupTransportIfNotNullAsync(transport);
+        }
+    }
+
+    public virtual async Task SendAsync_ToTopic_FansOutToSubscriptionsAsync()
+    {
+        var transport = CreateTransport();
+        if (transport is not ISupportsPull pull || transport is not ISupportsProvisioning)
+            return;
+
+        try
+        {
+            await EnsureAsync(transport,
+                new DestinationDeclaration { Name = "orders-topic", Role = DestinationRole.Topic },
+                new DestinationDeclaration { Name = "orders-subscription-a", Role = DestinationRole.Subscription, Source = "orders-topic" },
+                new DestinationDeclaration { Name = "orders-subscription-b", Role = DestinationRole.Subscription, Source = "orders-topic" });
+
+            await transport.SendAsync("orders-topic", [CreateMessage("fanout")], new TransportSendOptions(), TestCancellationToken);
+
+            var first = Assert.Single(await pull.ReceiveAsync("orders-subscription-a", new ReceiveRequest { MaxWaitTime = TimeSpan.FromSeconds(1) }, TestCancellationToken));
+            var second = Assert.Single(await pull.ReceiveAsync("orders-subscription-b", new ReceiveRequest { MaxWaitTime = TimeSpan.FromSeconds(1) }, TestCancellationToken));
+
+            Assert.Equal("fanout", ReadBody(first));
+            Assert.Equal("fanout", ReadBody(second));
+
+            await transport.CompleteAsync(first, TestCancellationToken);
+            await transport.CompleteAsync(second, TestCancellationToken);
+        }
+        finally
+        {
+            await CleanupTransportIfNotNullAsync(transport);
+        }
+    }
+
+    public virtual async Task ReceiveAsync_RespectsPriorityAsync()
+    {
+        var transport = CreateTransport();
+        if (transport is not ISupportsPull pull || transport is not ISupportsPriority)
+            return;
+
+        try
+        {
+            await EnsureAsync(transport, new DestinationDeclaration { Name = "priority", Role = DestinationRole.Queue });
+            await transport.SendAsync("priority", [CreateMessage("low")], new TransportSendOptions { Priority = MessagePriority.Low }, TestCancellationToken);
+            await transport.SendAsync("priority", [CreateMessage("high")], new TransportSendOptions { Priority = MessagePriority.High }, TestCancellationToken);
+            await transport.SendAsync("priority", [CreateMessage("normal")], new TransportSendOptions { Priority = MessagePriority.Normal }, TestCancellationToken);
+
+            var entries = await pull.ReceiveAsync("priority", new ReceiveRequest
+            {
+                MaxMessages = 3,
+                MaxWaitTime = TimeSpan.FromSeconds(1)
+            }, TestCancellationToken);
+
+            Assert.Equal(3, entries.Count);
+            Assert.Equal("high", ReadBody(entries[0]));
+            Assert.Equal("normal", ReadBody(entries[1]));
+            Assert.Equal("low", ReadBody(entries[2]));
+
+            foreach (var entry in entries)
+                await transport.CompleteAsync(entry, TestCancellationToken);
+        }
+        finally
+        {
+            await CleanupTransportIfNotNullAsync(transport);
+        }
+    }
+
+    public virtual async Task SendAsync_WithDeliverAt_DelaysVisibilityAsync()
+    {
+        var transport = CreateTransport();
+        if (transport is not ISupportsPull pull || transport is not ISupportsDelayedDelivery)
+            return;
+
+        try
+        {
+            await EnsureAsync(transport, new DestinationDeclaration { Name = "delayed", Role = DestinationRole.Queue });
+            await transport.SendAsync("delayed", [CreateMessage("later")], new TransportSendOptions
+            {
+                DeliverAt = DateTimeOffset.UtcNow.AddMilliseconds(250)
+            }, TestCancellationToken);
+
+            var immediate = await pull.ReceiveAsync("delayed", new ReceiveRequest { MaxWaitTime = TimeSpan.FromMilliseconds(50) }, TestCancellationToken);
+            Assert.Empty(immediate);
+
+            var delayed = Assert.Single(await pull.ReceiveAsync("delayed", new ReceiveRequest { MaxWaitTime = TimeSpan.FromSeconds(2) }, TestCancellationToken));
+            Assert.Equal("later", ReadBody(delayed));
+            await transport.CompleteAsync(delayed, TestCancellationToken);
+        }
+        finally
+        {
+            await CleanupTransportIfNotNullAsync(transport);
+        }
+    }
+
+    public virtual async Task DeadLetterAsync_MovesEntryToDeadletterStatsAsync()
+    {
+        var transport = CreateTransport();
+        if (transport is not ISupportsPull pull || transport is not ISupportsDeadLetter || transport is not ISupportsStats stats)
+            return;
+
+        try
+        {
+            await EnsureAsync(transport, new DestinationDeclaration { Name = "deadletter", Role = DestinationRole.Queue });
+            await transport.SendAsync("deadletter", [CreateMessage("poison")], new TransportSendOptions(), TestCancellationToken);
+
+            var entry = Assert.Single(await pull.ReceiveAsync("deadletter", new ReceiveRequest { MaxWaitTime = TimeSpan.FromSeconds(1) }, TestCancellationToken));
+            await ((ISupportsDeadLetter)transport).DeadLetterAsync(entry, "bad-payload", TestCancellationToken);
+
+            QueueStats queueStats = await stats.GetStatsAsync("deadletter", TestCancellationToken);
+            Assert.Equal(0, queueStats.Working);
+            Assert.Equal(1, queueStats.Deadletter);
+        }
+        finally
+        {
+            await CleanupTransportIfNotNullAsync(transport);
+        }
+    }
+
+    public virtual async Task ReceiveAsync_WithExpiredMessage_DeadlettersAndSkipsAsync()
+    {
+        var transport = CreateTransport();
+        if (transport is not ISupportsPull pull || transport is not ISupportsExpiration || transport is not ISupportsStats stats)
+            return;
+
+        try
+        {
+            await EnsureAsync(transport, new DestinationDeclaration { Name = "expiration", Role = DestinationRole.Queue });
+            var expired = new TransportMessage
+            {
+                Body = Encoding.UTF8.GetBytes("expired"),
+                Headers = MessageHeaders.Create([
+                    new KeyValuePair<string, string>(KnownHeaders.Expiration, DateTimeOffset.UtcNow.AddMinutes(-1).ToString("O"))
+                ])
+            };
+
+            await transport.SendAsync("expiration", [expired], new TransportSendOptions(), TestCancellationToken);
+
+            var entries = await pull.ReceiveAsync("expiration", new ReceiveRequest { MaxWaitTime = TimeSpan.FromMilliseconds(50) }, TestCancellationToken);
+            Assert.Empty(entries);
+
+            QueueStats queueStats = await stats.GetStatsAsync("expiration", TestCancellationToken);
+            Assert.Equal(0, queueStats.Queued);
+            Assert.Equal(1, queueStats.Deadletter);
+        }
+        finally
+        {
+            await CleanupTransportIfNotNullAsync(transport);
+        }
+    }
+    private async ValueTask CleanupTransportIfNotNullAsync(IMessageTransport? transport)
+    {
+        if (transport is not null)
+            await CleanupTransportAsync(transport);
+    }
+
+    private static async Task EnsureAsync(IMessageTransport transport, params DestinationDeclaration[] declarations)
+    {
+        if (transport is ISupportsProvisioning provisioning)
+            await provisioning.EnsureAsync(declarations, CancellationToken.None);
+    }
+
+    private static TransportMessage CreateMessage(string body, params (string Key, string Value)[] headers)
+    {
+        return new TransportMessage
+        {
+            Body = Encoding.UTF8.GetBytes(body),
+            Headers = MessageHeaders.Create(ToKeyValuePairs(headers))
+        };
+    }
+
+    private static IEnumerable<KeyValuePair<string, string>> ToKeyValuePairs((string Key, string Value)[] headers)
+    {
+        foreach (var header in headers)
+            yield return new KeyValuePair<string, string>(header.Key, header.Value);
+    }
+
+    private static string ReadBody(TransportEntry entry)
+    {
+        return Encoding.UTF8.GetString(entry.Body.Span);
+    }
+}

--- a/src/Foundatio/Jobs/JobRuntime.cs
+++ b/src/Foundatio/Jobs/JobRuntime.cs
@@ -1,0 +1,517 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Foundatio.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Foundatio.Jobs;
+
+public enum JobStatus
+{
+    Queued,
+    Scheduled,
+    Processing,
+    Completed,
+    Failed,
+    Cancelled,
+    DeadLettered
+}
+
+public enum ScheduledDispatchKind
+{
+    QueueMessage,
+    PubSubMessage,
+    JobOccurrence
+}
+
+public sealed record JobState
+{
+    public required string JobId { get; init; }
+    public required string Name { get; init; }
+    public JobStatus Status { get; init; } = JobStatus.Queued;
+    public int? Progress { get; init; }
+    public string? ProgressMessage { get; init; }
+    public int Attempt { get; init; }
+    public string? NodeId { get; init; }
+    public DateTimeOffset CreatedUtc { get; init; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset LastUpdatedUtc { get; init; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset? StartedUtc { get; init; }
+    public DateTimeOffset? CompletedUtc { get; init; }
+    public DateTimeOffset? LeaseExpiresUtc { get; init; }
+    public string? Error { get; init; }
+    public bool CancellationRequested { get; init; }
+    public DateTimeOffset? ScheduledForUtc { get; init; }
+}
+
+public sealed record JobStatePatch
+{
+    public JobStatus? Status { get; init; }
+    public int? Progress { get; init; }
+    public string? ProgressMessage { get; init; }
+    public string? Error { get; init; }
+    public int AttemptDelta { get; init; }
+    public string? NodeId { get; init; }
+    public DateTimeOffset? LeaseExpiresUtc { get; init; }
+    public DateTimeOffset? LastUpdatedUtc { get; init; }
+    public DateTimeOffset? StartedUtc { get; init; }
+    public DateTimeOffset? CompletedUtc { get; init; }
+    public bool? CancellationRequested { get; init; }
+}
+
+public sealed record JobQuery
+{
+    public string? Name { get; init; }
+    public JobStatus? Status { get; init; }
+    public int Limit { get; init; } = 100;
+}
+
+public sealed record ScheduledDispatchState
+{
+    public required string DispatchId { get; init; }
+    public ScheduledDispatchKind Kind { get; init; }
+    public required string Destination { get; init; }
+    public required ReadOnlyMemory<byte> Body { get; init; }
+    public MessageHeaders Headers { get; init; } = MessageHeaders.Empty;
+    public TransportSendOptions Options { get; init; } = new();
+    public DateTimeOffset DueUtc { get; init; }
+    public string? ClaimOwner { get; init; }
+    public DateTimeOffset? ClaimExpiresUtc { get; init; }
+    public int Attempts { get; init; }
+    public string? JobId { get; init; }
+}
+
+public sealed record RunJobOptions
+{
+    public string? JobId { get; init; }
+    public string? Name { get; init; }
+    public string? NodeId { get; init; }
+}
+
+public interface IJobMonitor
+{
+    Task<JobState?> GetAsync(string jobId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<JobState>> QueryAsync(JobQuery query, CancellationToken cancellationToken = default);
+}
+
+public interface IJobClient : IJobMonitor
+{
+    Task<string> RunAsync<TJob>(RunJobOptions? options = null, CancellationToken cancellationToken = default) where TJob : IJob;
+    Task<bool> RequestCancellationAsync(string jobId, CancellationToken cancellationToken = default);
+}
+
+public interface IJobRuntimeStore : IJobMonitor
+{
+    Task CreateIfAbsentAsync(JobState initial, CancellationToken cancellationToken = default);
+    Task<bool> TryTransitionAsync(string jobId, JobStatus expectedStatus, JobStatus newStatus, JobStatePatch? patch = null, CancellationToken cancellationToken = default);
+    Task<bool> TryClaimAsync(string jobId, string nodeId, TimeSpan lease, CancellationToken cancellationToken = default);
+    Task<bool> RenewClaimAsync(string jobId, string nodeId, TimeSpan lease, CancellationToken cancellationToken = default);
+    Task<bool> ReleaseClaimAsync(string jobId, string nodeId, CancellationToken cancellationToken = default);
+    Task SetProgressAsync(string jobId, int? percent = null, string? message = null, CancellationToken cancellationToken = default);
+    Task IncrementAttemptAsync(string jobId, CancellationToken cancellationToken = default);
+    Task<bool> RequestCancellationAsync(string jobId, CancellationToken cancellationToken = default);
+    Task<bool> IsCancellationRequestedAsync(string jobId, CancellationToken cancellationToken = default);
+    Task ScheduleDispatchAsync(ScheduledDispatchState dispatch, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<ScheduledDispatchState>> ClaimDueDispatchesAsync(DateTimeOffset now, int limit, string nodeId, TimeSpan lease, CancellationToken cancellationToken = default);
+    Task CompleteDispatchAsync(string dispatchId, string nodeId, CancellationToken cancellationToken = default);
+    Task ReleaseDispatchAsync(string dispatchId, string nodeId, DateTimeOffset nextDueUtc, CancellationToken cancellationToken = default);
+}
+
+public sealed class InMemoryJobRuntimeStore : IJobRuntimeStore
+{
+    private readonly ConcurrentDictionary<string, JobState> _jobs = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, ScheduledDispatchState> _dispatches = new(StringComparer.Ordinal);
+    private readonly TimeProvider _timeProvider;
+    private readonly object _lock = new();
+
+    public InMemoryJobRuntimeStore(TimeProvider? timeProvider = null)
+    {
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public Task CreateIfAbsentAsync(JobState initial, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(initial);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var now = _timeProvider.GetUtcNow();
+        _jobs.TryAdd(initial.JobId, initial with
+        {
+            CreatedUtc = initial.CreatedUtc == default ? now : initial.CreatedUtc,
+            LastUpdatedUtc = initial.LastUpdatedUtc == default ? now : initial.LastUpdatedUtc
+        });
+
+        return Task.CompletedTask;
+    }
+
+    public Task<JobState?> GetAsync(string jobId, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        _jobs.TryGetValue(jobId, out var state);
+        return Task.FromResult(state);
+    }
+
+    public Task<IReadOnlyList<JobState>> QueryAsync(JobQuery query, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        IEnumerable<JobState> results = _jobs.Values;
+        if (!String.IsNullOrEmpty(query.Name))
+            results = results.Where(s => String.Equals(s.Name, query.Name, StringComparison.Ordinal));
+
+        if (query.Status is { } status)
+            results = results.Where(s => s.Status == status);
+
+        return Task.FromResult<IReadOnlyList<JobState>>(results
+            .OrderByDescending(s => s.LastUpdatedUtc)
+            .Take(Math.Max(1, query.Limit))
+            .ToArray());
+    }
+
+    public Task<bool> TryTransitionAsync(string jobId, JobStatus expectedStatus, JobStatus newStatus, JobStatePatch? patch = null, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_lock)
+        {
+            if (!_jobs.TryGetValue(jobId, out var current) || current.Status != expectedStatus)
+                return Task.FromResult(false);
+
+            _jobs[jobId] = ApplyPatch(current, patch) with
+            {
+                Status = newStatus,
+                LastUpdatedUtc = patch?.LastUpdatedUtc ?? _timeProvider.GetUtcNow()
+            };
+            return Task.FromResult(true);
+        }
+    }
+
+    public Task<bool> TryClaimAsync(string jobId, string nodeId, TimeSpan lease, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentException.ThrowIfNullOrEmpty(nodeId);
+
+        lock (_lock)
+        {
+            if (!_jobs.TryGetValue(jobId, out var current))
+                return Task.FromResult(false);
+
+            var now = _timeProvider.GetUtcNow();
+            if (!String.IsNullOrEmpty(current.NodeId) && current.LeaseExpiresUtc is { } leaseExpires && leaseExpires > now && current.NodeId != nodeId)
+                return Task.FromResult(false);
+
+            _jobs[jobId] = current with
+            {
+                NodeId = nodeId,
+                LeaseExpiresUtc = now.Add(lease),
+                LastUpdatedUtc = now
+            };
+            return Task.FromResult(true);
+        }
+    }
+
+    public Task<bool> RenewClaimAsync(string jobId, string nodeId, TimeSpan lease, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_lock)
+        {
+            if (!_jobs.TryGetValue(jobId, out var current) || current.NodeId != nodeId)
+                return Task.FromResult(false);
+
+            var now = _timeProvider.GetUtcNow();
+            _jobs[jobId] = current with
+            {
+                LeaseExpiresUtc = now.Add(lease),
+                LastUpdatedUtc = now
+            };
+            return Task.FromResult(true);
+        }
+    }
+
+    public Task<bool> ReleaseClaimAsync(string jobId, string nodeId, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_lock)
+        {
+            if (!_jobs.TryGetValue(jobId, out var current) || current.NodeId != nodeId)
+                return Task.FromResult(false);
+
+            _jobs[jobId] = current with
+            {
+                NodeId = null,
+                LeaseExpiresUtc = null,
+                LastUpdatedUtc = _timeProvider.GetUtcNow()
+            };
+            return Task.FromResult(true);
+        }
+    }
+
+    public Task SetProgressAsync(string jobId, int? percent = null, string? message = null, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        UpdateJob(jobId, state => state with
+        {
+            Progress = percent ?? state.Progress,
+            ProgressMessage = message ?? state.ProgressMessage,
+            LastUpdatedUtc = _timeProvider.GetUtcNow()
+        });
+
+        return Task.CompletedTask;
+    }
+
+    public Task IncrementAttemptAsync(string jobId, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        UpdateJob(jobId, state => state with { Attempt = state.Attempt + 1, LastUpdatedUtc = _timeProvider.GetUtcNow() });
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> RequestCancellationAsync(string jobId, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(UpdateJob(jobId, state => state with
+        {
+            CancellationRequested = true,
+            LastUpdatedUtc = _timeProvider.GetUtcNow()
+        }));
+    }
+
+    public Task<bool> IsCancellationRequestedAsync(string jobId, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(_jobs.TryGetValue(jobId, out var state) && state.CancellationRequested);
+    }
+
+    public Task ScheduleDispatchAsync(ScheduledDispatchState dispatch, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(dispatch);
+        cancellationToken.ThrowIfCancellationRequested();
+        _dispatches.TryAdd(dispatch.DispatchId, dispatch);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<ScheduledDispatchState>> ClaimDueDispatchesAsync(DateTimeOffset now, int limit, string nodeId, TimeSpan lease, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentException.ThrowIfNullOrEmpty(nodeId);
+
+        lock (_lock)
+        {
+            var due = _dispatches.Values
+                .Where(d => d.DueUtc <= now && (String.IsNullOrEmpty(d.ClaimOwner) || d.ClaimExpiresUtc <= now))
+                .OrderBy(d => d.DueUtc)
+                .Take(Math.Max(1, limit))
+                .ToArray();
+
+            for (int index = 0; index < due.Length; index++)
+            {
+                var claimed = due[index] with
+                {
+                    ClaimOwner = nodeId,
+                    ClaimExpiresUtc = now.Add(lease),
+                    Attempts = due[index].Attempts + 1
+                };
+                _dispatches[claimed.DispatchId] = claimed;
+                due[index] = claimed;
+            }
+
+            return Task.FromResult<IReadOnlyList<ScheduledDispatchState>>(due);
+        }
+    }
+
+    public Task CompleteDispatchAsync(string dispatchId, string nodeId, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_lock)
+        {
+            if (_dispatches.TryGetValue(dispatchId, out var dispatch) && dispatch.ClaimOwner == nodeId)
+                _dispatches.TryRemove(dispatchId, out _);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task ReleaseDispatchAsync(string dispatchId, string nodeId, DateTimeOffset nextDueUtc, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_lock)
+        {
+            if (_dispatches.TryGetValue(dispatchId, out var dispatch) && dispatch.ClaimOwner == nodeId)
+            {
+                _dispatches[dispatchId] = dispatch with
+                {
+                    DueUtc = nextDueUtc,
+                    ClaimOwner = null,
+                    ClaimExpiresUtc = null
+                };
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private bool UpdateJob(string jobId, Func<JobState, JobState> update)
+    {
+        lock (_lock)
+        {
+            if (!_jobs.TryGetValue(jobId, out var current))
+                return false;
+
+            _jobs[jobId] = update(current);
+            return true;
+        }
+    }
+
+    private JobState ApplyPatch(JobState state, JobStatePatch? patch)
+    {
+        if (patch is null)
+            return state;
+
+        return state with
+        {
+            Status = patch.Status ?? state.Status,
+            Progress = patch.Progress ?? state.Progress,
+            ProgressMessage = patch.ProgressMessage ?? state.ProgressMessage,
+            Error = patch.Error ?? state.Error,
+            Attempt = state.Attempt + patch.AttemptDelta,
+            NodeId = patch.NodeId ?? state.NodeId,
+            LeaseExpiresUtc = patch.LeaseExpiresUtc ?? state.LeaseExpiresUtc,
+            LastUpdatedUtc = patch.LastUpdatedUtc ?? state.LastUpdatedUtc,
+            StartedUtc = patch.StartedUtc ?? state.StartedUtc,
+            CompletedUtc = patch.CompletedUtc ?? state.CompletedUtc,
+            CancellationRequested = patch.CancellationRequested ?? state.CancellationRequested
+        };
+    }
+}
+
+public sealed class JobClient : IJobClient
+{
+    private readonly IJobRuntimeStore _store;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly TimeProvider _timeProvider;
+    private readonly string _nodeId;
+
+    public JobClient(IJobRuntimeStore store, IServiceProvider serviceProvider, TimeProvider? timeProvider = null, string? nodeId = null)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _nodeId = !String.IsNullOrEmpty(nodeId)
+            ? nodeId
+            : Environment.GetEnvironmentVariable("FOUNDATIO_NODE_ID") ?? Environment.MachineName;
+    }
+
+    public Task<JobState?> GetAsync(string jobId, CancellationToken cancellationToken = default)
+    {
+        return _store.GetAsync(jobId, cancellationToken);
+    }
+
+    public Task<IReadOnlyList<JobState>> QueryAsync(JobQuery query, CancellationToken cancellationToken = default)
+    {
+        return _store.QueryAsync(query, cancellationToken);
+    }
+
+    public async Task<string> RunAsync<TJob>(RunJobOptions? options = null, CancellationToken cancellationToken = default) where TJob : IJob
+    {
+        options ??= new RunJobOptions();
+        string jobId = options.JobId ?? Guid.NewGuid().ToString("N");
+        string name = options.Name ?? typeof(TJob).Name;
+        string nodeId = options.NodeId ?? _nodeId;
+        var now = _timeProvider.GetUtcNow();
+
+        await _store.CreateIfAbsentAsync(new JobState
+        {
+            JobId = jobId,
+            Name = name,
+            Status = JobStatus.Queued,
+            CreatedUtc = now,
+            LastUpdatedUtc = now
+        }, cancellationToken).ConfigureAwait(false);
+
+        if (!await _store.TryTransitionAsync(jobId, JobStatus.Queued, JobStatus.Processing, new JobStatePatch
+        {
+            NodeId = nodeId,
+            StartedUtc = now,
+            LeaseExpiresUtc = now.AddMinutes(5),
+            AttemptDelta = 1
+        }, cancellationToken).ConfigureAwait(false))
+        {
+            return jobId;
+        }
+
+        using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        using var cancellationWatcher = WatchCancellation(jobId, linkedCancellationTokenSource);
+        var job = ActivatorUtilities.GetServiceOrCreateInstance<TJob>(_serviceProvider);
+
+        try
+        {
+            var result = await job.TryRunAsync(linkedCancellationTokenSource.Token).ConfigureAwait(false);
+            var completedAt = _timeProvider.GetUtcNow();
+            if (result.IsCancelled)
+            {
+                await _store.TryTransitionAsync(jobId, JobStatus.Processing, JobStatus.Cancelled, new JobStatePatch
+                {
+                    Error = result.Message,
+                    CompletedUtc = completedAt,
+                    LeaseExpiresUtc = null
+                }, CancellationToken.None).ConfigureAwait(false);
+            }
+            else if (result.IsSuccess)
+            {
+                await _store.TryTransitionAsync(jobId, JobStatus.Processing, JobStatus.Completed, new JobStatePatch
+                {
+                    CompletedUtc = completedAt,
+                    LeaseExpiresUtc = null,
+                    Progress = 100
+                }, CancellationToken.None).ConfigureAwait(false);
+            }
+            else
+            {
+                await _store.TryTransitionAsync(jobId, JobStatus.Processing, JobStatus.Failed, new JobStatePatch
+                {
+                    Error = result.Message,
+                    CompletedUtc = completedAt,
+                    LeaseExpiresUtc = null
+                }, CancellationToken.None).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            await _store.ReleaseClaimAsync(jobId, nodeId, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        return jobId;
+    }
+
+    public Task<bool> RequestCancellationAsync(string jobId, CancellationToken cancellationToken = default)
+    {
+        return _store.RequestCancellationAsync(jobId, cancellationToken);
+    }
+
+    private IDisposable WatchCancellation(string jobId, CancellationTokenSource cancellationTokenSource)
+    {
+        return new Timer(_ => _ = PollCancellationAsync(jobId, cancellationTokenSource), null, TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(50));
+    }
+
+    private async Task PollCancellationAsync(string jobId, CancellationTokenSource cancellationTokenSource)
+    {
+        if (cancellationTokenSource.IsCancellationRequested)
+            return;
+
+        try
+        {
+            if (await _store.IsCancellationRequestedAsync(jobId, CancellationToken.None).ConfigureAwait(false))
+                await cancellationTokenSource.CancelAsync().ConfigureAwait(false);
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+    }
+}

--- a/src/Foundatio/Jobs/JobRuntime.cs
+++ b/src/Foundatio/Jobs/JobRuntime.cs
@@ -99,6 +99,7 @@ public interface IJobMonitor
 public interface IJobClient : IJobMonitor
 {
     Task<string> RunAsync<TJob>(RunJobOptions? options = null, CancellationToken cancellationToken = default) where TJob : IJob;
+    Task<string> RunAsync(Type jobType, RunJobOptions? options = null, CancellationToken cancellationToken = default);
     Task<bool> RequestCancellationAsync(string jobId, CancellationToken cancellationToken = default);
 }
 
@@ -418,11 +419,20 @@ public sealed class JobClient : IJobClient
         return _store.QueryAsync(query, cancellationToken);
     }
 
-    public async Task<string> RunAsync<TJob>(RunJobOptions? options = null, CancellationToken cancellationToken = default) where TJob : IJob
+    public Task<string> RunAsync<TJob>(RunJobOptions? options = null, CancellationToken cancellationToken = default) where TJob : IJob
     {
+        return RunAsync(typeof(TJob), options, cancellationToken);
+    }
+
+    public async Task<string> RunAsync(Type jobType, RunJobOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(jobType);
+        if (!typeof(IJob).IsAssignableFrom(jobType))
+            throw new ArgumentException("Job type must implement IJob.", nameof(jobType));
+
         options ??= new RunJobOptions();
         string jobId = options.JobId ?? Guid.NewGuid().ToString("N");
-        string name = options.Name ?? typeof(TJob).Name;
+        string name = options.Name ?? jobType.Name;
         string nodeId = options.NodeId ?? _nodeId;
         var now = _timeProvider.GetUtcNow();
 
@@ -448,7 +458,7 @@ public sealed class JobClient : IJobClient
 
         using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         using var cancellationWatcher = WatchCancellation(jobId, linkedCancellationTokenSource);
-        var job = ActivatorUtilities.GetServiceOrCreateInstance<TJob>(_serviceProvider);
+        var job = (IJob)ActivatorUtilities.GetServiceOrCreateInstance(_serviceProvider, jobType);
 
         try
         {

--- a/src/Foundatio/Jobs/JobScheduler.cs
+++ b/src/Foundatio/Jobs/JobScheduler.cs
@@ -1,0 +1,427 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Foundatio.Messaging;
+
+namespace Foundatio.Jobs;
+
+public enum ScheduledJobScope
+{
+    Global,
+    PerNode
+}
+
+public enum OverlapPolicy
+{
+    SkipIfRunning,
+    AllowConcurrent
+}
+
+public sealed record ScheduledJobDefinition
+{
+    public required string Name { get; init; }
+    public required string Cron { get; init; }
+    public Type? JobType { get; init; }
+    public TimeZoneInfo? TimeZone { get; init; }
+    public ScheduledJobScope Scope { get; init; } = ScheduledJobScope.Global;
+    public OverlapPolicy Overlap { get; init; } = OverlapPolicy.SkipIfRunning;
+    public TimeSpan? MisfireWindow { get; init; }
+    public int MaxRetries { get; init; } = 3;
+    public bool Enabled { get; init; } = true;
+}
+
+public interface IJobScheduler
+{
+    Task ScheduleAsync(ScheduledJobDefinition definition, CancellationToken cancellationToken = default);
+    Task UnscheduleAsync(string name, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<ScheduledJobDefinition>> GetSchedulesAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed class InMemoryJobScheduler : IJobScheduler
+{
+    private readonly ConcurrentDictionary<string, ScheduledJobDefinition> _definitions = new(StringComparer.Ordinal);
+
+    public Task ScheduleAsync(ScheduledJobDefinition definition, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentException.ThrowIfNullOrEmpty(definition.Name);
+        ArgumentException.ThrowIfNullOrEmpty(definition.Cron);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (definition.MaxRetries < 0)
+            throw new ArgumentOutOfRangeException(nameof(definition), definition.MaxRetries, "MaxRetries must be greater than or equal to zero.");
+
+        if (definition.JobType is not null && !typeof(IJob).IsAssignableFrom(definition.JobType))
+            throw new ArgumentException("JobType must implement IJob.", nameof(definition));
+
+        JobScheduleProcessor.ValidateCron(definition.Cron);
+        _definitions[definition.Name] = definition;
+        return Task.CompletedTask;
+    }
+
+    public Task UnscheduleAsync(string name, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        cancellationToken.ThrowIfCancellationRequested();
+        _definitions.TryRemove(name, out _);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<ScheduledJobDefinition>> GetSchedulesAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult<IReadOnlyList<ScheduledJobDefinition>>(_definitions.Values.OrderBy(d => d.Name, StringComparer.Ordinal).ToArray());
+    }
+}
+
+public sealed class JobScheduleProcessor
+{
+    private static readonly TimeSpan DefaultLease = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan DefaultMisfireWindow = TimeSpan.FromMinutes(1);
+
+    private readonly IJobScheduler _scheduler;
+    private readonly IJobRuntimeStore _store;
+    private readonly IJobClient _jobClient;
+    private readonly TimeProvider _timeProvider;
+    private readonly string _nodeId;
+
+    public JobScheduleProcessor(IJobScheduler scheduler, IJobRuntimeStore store, IJobClient jobClient, TimeProvider? timeProvider = null, string? nodeId = null)
+    {
+        _scheduler = scheduler ?? throw new ArgumentNullException(nameof(scheduler));
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _jobClient = jobClient ?? throw new ArgumentNullException(nameof(jobClient));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _nodeId = !String.IsNullOrEmpty(nodeId)
+            ? nodeId
+            : Environment.GetEnvironmentVariable("FOUNDATIO_NODE_ID") ?? Environment.MachineName;
+    }
+
+    public Task<IReadOnlyList<ScheduledDispatchState>> EnqueueDueOccurrencesAsync(CancellationToken cancellationToken = default)
+    {
+        return EnqueueDueOccurrencesAsync(_timeProvider.GetUtcNow(), cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<ScheduledDispatchState>> EnqueueDueOccurrencesAsync(DateTimeOffset utcNow, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var scheduled = new List<ScheduledDispatchState>();
+        var definitions = await _scheduler.GetSchedulesAsync(cancellationToken).ConfigureAwait(false);
+
+        foreach (var definition in definitions)
+        {
+            if (!definition.Enabled)
+                continue;
+
+            var cron = CronSchedule.Parse(definition.Cron);
+            var scheduledForUtc = cron.GetLastOccurrence(utcNow, definition.TimeZone ?? TimeZoneInfo.Utc, definition.MisfireWindow ?? DefaultMisfireWindow);
+            if (scheduledForUtc is null)
+                continue;
+
+            string scopeKey = GetScopeKey(definition);
+            string jobId = CreateOccurrenceId(definition.Name, scheduledForUtc.Value, scopeKey);
+
+            if (await _store.GetAsync(jobId, cancellationToken).ConfigureAwait(false) is not null)
+                continue;
+
+            if (definition.Overlap == OverlapPolicy.SkipIfRunning && await HasActiveOccurrenceAsync(definition.Name, scopeKey, cancellationToken).ConfigureAwait(false))
+                continue;
+
+            await _store.CreateIfAbsentAsync(new JobState
+            {
+                JobId = jobId,
+                Name = definition.Name,
+                Status = JobStatus.Scheduled,
+                CreatedUtc = utcNow,
+                LastUpdatedUtc = utcNow,
+                ScheduledForUtc = scheduledForUtc
+            }, cancellationToken).ConfigureAwait(false);
+
+            var dispatch = new ScheduledDispatchState
+            {
+                DispatchId = jobId,
+                Kind = ScheduledDispatchKind.JobOccurrence,
+                Destination = definition.Name,
+                Body = Array.Empty<byte>(),
+                Headers = CreateOccurrenceHeaders(definition, scheduledForUtc.Value, scopeKey),
+                DueUtc = utcNow,
+                JobId = jobId
+            };
+
+            await _store.ScheduleDispatchAsync(dispatch, cancellationToken).ConfigureAwait(false);
+            scheduled.Add(dispatch);
+        }
+
+        return scheduled;
+    }
+
+    public Task<int> RunDueOccurrencesAsync(CancellationToken cancellationToken = default)
+    {
+        return RunDueOccurrencesAsync(_timeProvider.GetUtcNow(), 100, null, cancellationToken);
+    }
+
+    public async Task<int> RunDueOccurrencesAsync(DateTimeOffset utcNow, int limit = 100, TimeSpan? lease = null, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var definitions = (await _scheduler.GetSchedulesAsync(cancellationToken).ConfigureAwait(false))
+            .ToDictionary(d => d.Name, StringComparer.Ordinal);
+
+        var dispatches = await _store.ClaimDueDispatchesAsync(utcNow, limit, _nodeId, lease ?? DefaultLease, cancellationToken).ConfigureAwait(false);
+        int completed = 0;
+
+        foreach (var dispatch in dispatches)
+        {
+            if (dispatch.Kind != ScheduledDispatchKind.JobOccurrence)
+            {
+                await _store.ReleaseDispatchAsync(dispatch.DispatchId, _nodeId, dispatch.DueUtc, cancellationToken).ConfigureAwait(false);
+                continue;
+            }
+
+            if (!definitions.TryGetValue(dispatch.Destination, out var definition) || !definition.Enabled || definition.JobType is null)
+            {
+                await _store.ReleaseDispatchAsync(dispatch.DispatchId, _nodeId, utcNow.AddMinutes(1), cancellationToken).ConfigureAwait(false);
+                continue;
+            }
+
+            string jobId = dispatch.JobId ?? dispatch.DispatchId;
+
+            try
+            {
+                await _store.TryTransitionAsync(jobId, JobStatus.Scheduled, JobStatus.Queued, new JobStatePatch { LastUpdatedUtc = utcNow }, cancellationToken).ConfigureAwait(false);
+                await _jobClient.RunAsync(definition.JobType, new RunJobOptions
+                {
+                    JobId = jobId,
+                    Name = definition.Name,
+                    NodeId = _nodeId
+                }, cancellationToken).ConfigureAwait(false);
+
+                await _store.CompleteDispatchAsync(dispatch.DispatchId, _nodeId, cancellationToken).ConfigureAwait(false);
+                completed++;
+            }
+            catch
+            {
+                await _store.ReleaseDispatchAsync(dispatch.DispatchId, _nodeId, utcNow.AddMinutes(1), CancellationToken.None).ConfigureAwait(false);
+                throw;
+            }
+        }
+
+        return completed;
+    }
+
+    private async Task<bool> HasActiveOccurrenceAsync(string name, string scopeKey, CancellationToken cancellationToken)
+    {
+        var states = await _store.QueryAsync(new JobQuery { Name = name, Limit = 1000 }, cancellationToken).ConfigureAwait(false);
+        return states.Any(s => s.JobId.EndsWith($":{scopeKey}", StringComparison.Ordinal) && s.Status is JobStatus.Queued or JobStatus.Scheduled or JobStatus.Processing);
+    }
+
+    private string GetScopeKey(ScheduledJobDefinition definition)
+    {
+        return definition.Scope == ScheduledJobScope.PerNode ? _nodeId : "global";
+    }
+
+    private static string CreateOccurrenceId(string name, DateTimeOffset scheduledForUtc, string scopeKey)
+    {
+        return $"{name}:{scheduledForUtc.UtcDateTime:yyyyMMddHHmmss}:{scopeKey}";
+    }
+
+    private static MessageHeaders CreateOccurrenceHeaders(ScheduledJobDefinition definition, DateTimeOffset scheduledForUtc, string scopeKey)
+    {
+        return MessageHeaders.Create([
+            new KeyValuePair<string, string>("job.name", definition.Name),
+            new KeyValuePair<string, string>("job.scheduled_for", scheduledForUtc.UtcDateTime.ToString("O")),
+            new KeyValuePair<string, string>("job.scope", scopeKey)
+        ]);
+    }
+
+    internal static void ValidateCron(string expression)
+    {
+        CronSchedule.Parse(expression);
+    }
+
+    private sealed class CronSchedule
+    {
+        private readonly CronFieldSet _second;
+        private readonly CronFieldSet _minute;
+        private readonly CronFieldSet _hour;
+        private readonly CronFieldSet _dayOfMonth;
+        private readonly CronFieldSet _month;
+        private readonly CronFieldSet _dayOfWeek;
+
+        private CronSchedule(CronFieldSet second, CronFieldSet minute, CronFieldSet hour, CronFieldSet dayOfMonth, CronFieldSet month, CronFieldSet dayOfWeek)
+        {
+            _second = second;
+            _minute = minute;
+            _hour = hour;
+            _dayOfMonth = dayOfMonth;
+            _month = month;
+            _dayOfWeek = dayOfWeek;
+        }
+
+        public static CronSchedule Parse(string expression)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(expression);
+
+            var parts = expression.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length != 5 && parts.Length != 6)
+                throw new FormatException("Cron expressions must contain five fields, or six fields when seconds are included.");
+
+            int offset = parts.Length == 6 ? 0 : -1;
+            return new CronSchedule(
+                offset == 0 ? CronFieldSet.Parse(parts[0], 0, 59) : CronFieldSet.Single(0, 0, 59),
+                CronFieldSet.Parse(parts[1 + offset], 0, 59),
+                CronFieldSet.Parse(parts[2 + offset], 0, 23),
+                CronFieldSet.Parse(parts[3 + offset], 1, 31, allowQuestion: true),
+                CronFieldSet.Parse(parts[4 + offset], 1, 12),
+                CronFieldSet.Parse(parts[5 + offset], 0, 6, allowQuestion: true, normalizeDayOfWeek: true));
+        }
+
+        public DateTimeOffset? GetLastOccurrence(DateTimeOffset utcNow, TimeZoneInfo timeZone, TimeSpan misfireWindow)
+        {
+            if (misfireWindow < TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(misfireWindow), misfireWindow, "MisfireWindow must be greater than or equal to zero.");
+
+            var localNow = TimeZoneInfo.ConvertTime(utcNow, timeZone);
+            var candidate = new DateTimeOffset(localNow.Year, localNow.Month, localNow.Day, localNow.Hour, localNow.Minute, localNow.Second, localNow.Offset);
+            int secondsToSearch = Math.Max(1, (int)Math.Ceiling(misfireWindow.TotalSeconds)) + 1;
+
+            for (int i = 0; i <= secondsToSearch; i++)
+            {
+                if (Matches(candidate.DateTime))
+                    return TimeZoneInfo.ConvertTime(candidate, TimeZoneInfo.Utc);
+
+                candidate = candidate.AddSeconds(-1);
+            }
+
+            return null;
+        }
+
+        private bool Matches(DateTime local)
+        {
+            if (!_second.Contains(local.Second) || !_minute.Contains(local.Minute) || !_hour.Contains(local.Hour) || !_month.Contains(local.Month))
+                return false;
+
+            bool dayOfMonthMatches = _dayOfMonth.Contains(local.Day);
+            bool dayOfWeekMatches = _dayOfWeek.Contains((int)local.DayOfWeek);
+            return _dayOfMonth.IsAny || _dayOfWeek.IsAny
+                ? dayOfMonthMatches && dayOfWeekMatches
+                : dayOfMonthMatches || dayOfWeekMatches;
+        }
+    }
+
+    private sealed class CronFieldSet
+    {
+        private readonly bool[] _values;
+        private readonly int _min;
+
+        private CronFieldSet(bool[] values, int min, bool isAny)
+        {
+            _values = values;
+            _min = min;
+            IsAny = isAny;
+        }
+
+        public bool IsAny { get; }
+
+        public static CronFieldSet Single(int value, int min, int max)
+        {
+            var values = new bool[max - min + 1];
+            values[value - min] = true;
+            return new CronFieldSet(values, min, false);
+        }
+
+        public static CronFieldSet Parse(string expression, int min, int max, bool allowQuestion = false, bool normalizeDayOfWeek = false)
+        {
+            if (expression == "*" || (allowQuestion && expression == "?"))
+                return Any(min, max);
+
+            var values = new bool[max - min + 1];
+            foreach (string segment in expression.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                AddSegment(values, segment, min, max, allowQuestion, normalizeDayOfWeek);
+
+            return new CronFieldSet(values, min, false);
+        }
+
+        public bool Contains(int value)
+        {
+            int index = value - _min;
+            return index >= 0 && index < _values.Length && _values[index];
+        }
+
+        private static CronFieldSet Any(int min, int max)
+        {
+            var values = new bool[max - min + 1];
+            Array.Fill(values, true);
+            return new CronFieldSet(values, min, true);
+        }
+
+        private static void AddSegment(bool[] values, string segment, int min, int max, bool allowQuestion, bool normalizeDayOfWeek)
+        {
+            string[] stepParts = segment.Split('/', StringSplitOptions.TrimEntries);
+            if (stepParts.Length > 2)
+                throw new FormatException($"Invalid cron field segment '{segment}'.");
+
+            int step = stepParts.Length == 2 ? ParseNumber(stepParts[1], 1, max) : 1;
+            string range = stepParts[0];
+
+            if (range == "*" || (allowQuestion && range == "?"))
+            {
+                AddRange(values, min, max, step, min, normalizeDayOfWeek);
+                return;
+            }
+
+            string[] rangeParts = range.Split('-', StringSplitOptions.TrimEntries);
+            if (rangeParts.Length == 1)
+            {
+                int value = Normalize(ParseNumber(rangeParts[0], min, normalizeDayOfWeek ? max + 1 : max), normalizeDayOfWeek);
+                EnsureInRange(value, min, max);
+                values[value - min] = true;
+                return;
+            }
+
+            if (rangeParts.Length != 2)
+                throw new FormatException($"Invalid cron field segment '{segment}'.");
+
+            int start = Normalize(ParseNumber(rangeParts[0], min, normalizeDayOfWeek ? max + 1 : max), normalizeDayOfWeek);
+            int end = Normalize(ParseNumber(rangeParts[1], min, normalizeDayOfWeek ? max + 1 : max), normalizeDayOfWeek);
+            EnsureInRange(start, min, max);
+            EnsureInRange(end, min, max);
+
+            if (end < start)
+                throw new FormatException($"Invalid cron range '{segment}'.");
+
+            AddRange(values, start, end, step, min, normalizeDayOfWeek);
+        }
+
+        private static void AddRange(bool[] values, int start, int end, int step, int min, bool normalizeDayOfWeek)
+        {
+            for (int value = start; value <= end; value += step)
+            {
+                int normalized = Normalize(value, normalizeDayOfWeek);
+                values[normalized - min] = true;
+            }
+        }
+
+        private static int ParseNumber(string value, int min, int max)
+        {
+            if (!Int32.TryParse(value, out int result) || result < min || result > max)
+                throw new FormatException($"Cron value '{value}' must be between {min} and {max}.");
+
+            return result;
+        }
+
+        private static int Normalize(int value, bool normalizeDayOfWeek)
+        {
+            return normalizeDayOfWeek && value == 7 ? 0 : value;
+        }
+
+        private static void EnsureInRange(int value, int min, int max)
+        {
+            if (value < min || value > max)
+                throw new FormatException($"Cron value '{value}' must be between {min} and {max}.");
+        }
+    }
+}

--- a/src/Foundatio/Messaging/InMemoryMessageTransport.cs
+++ b/src/Foundatio/Messaging/InMemoryMessageTransport.cs
@@ -1,0 +1,606 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Foundatio.AsyncEx;
+using Foundatio.Queues;
+using Foundatio.Utility;
+
+namespace Foundatio.Messaging;
+
+public sealed class InMemoryMessageTransport : IMessageTransport, ISupportsPull, ISupportsPush, ISupportsRedeliveryDelay, ISupportsDeadLetter, ISupportsStats, ISupportsPriority, ISupportsDelayedDelivery, ISupportsExpiration, ISupportsProvisioning, ITransportInfo
+{
+    private static readonly IReadOnlySet<DestinationRole> _supportedRoles = new HashSet<DestinationRole>
+    {
+        DestinationRole.Queue,
+        DestinationRole.Topic,
+        DestinationRole.Subscription,
+        DestinationRole.Binding
+    };
+
+    private readonly ConcurrentDictionary<string, DestinationState> _destinations = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, DestinationRole> _roles = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, byte>> _topicSubscriptions = new(StringComparer.OrdinalIgnoreCase);
+    private readonly TimeProvider _timeProvider;
+    private readonly CancellationTokenSource _disposeCancellationTokenSource = new();
+    private int _isDisposed;
+
+    public InMemoryMessageTransport(TimeProvider? timeProvider = null)
+    {
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public DeliveryGuarantee DeliveryGuarantee => DeliveryGuarantee.AtLeastOnce;
+    public OrderingGuarantee Ordering => OrderingGuarantee.Fifo;
+    public IReadOnlySet<DestinationRole> SupportedRoles => _supportedRoles;
+    public int? MaxBatchSize => null;
+    public long? MaxMessageBytes => null;
+
+    public Task<SendResult> SendAsync(string destination, IReadOnlyList<TransportMessage> messages, TransportSendOptions options, CancellationToken ct = default)
+    {
+        ThrowIfDisposed();
+        ct.ThrowIfCancellationRequested();
+        ArgumentException.ThrowIfNullOrEmpty(destination);
+        ArgumentNullException.ThrowIfNull(messages);
+
+        var results = new SendItemResult[messages.Count];
+        for (int index = 0; index < messages.Count; index++)
+        {
+            var message = messages[index];
+            string messageId = message.MessageId ?? options.DeduplicationId ?? Guid.NewGuid().ToString("N");
+            var stored = CreateStoredMessage(destination, messageId, message, options);
+            EnqueueOrSchedule(destination, stored, options);
+
+            results[index] = new SendItemResult
+            {
+                MessageId = messageId,
+                Success = true
+            };
+        }
+
+        return Task.FromResult(new SendResult { Items = results });
+    }
+
+    public Task<IReadOnlyList<TransportEntry>> ReceiveAsync(string source, ReceiveRequest request, CancellationToken ct)
+    {
+        return ReceiveAsync(source, request, visibility: null, ct);
+    }
+
+    public async Task<IReadOnlyList<TransportEntry>> ReceiveAsync(string source, ReceiveRequest request, TimeSpan visibility, CancellationToken ct)
+    {
+        return await ReceiveAsync(source, request, (TimeSpan?)visibility, ct).AnyContext();
+    }
+
+    private async Task<IReadOnlyList<TransportEntry>> ReceiveAsync(string source, ReceiveRequest request, TimeSpan? visibility, CancellationToken ct)
+    {
+        ThrowIfDisposed();
+        ct.ThrowIfCancellationRequested();
+        ArgumentException.ThrowIfNullOrEmpty(source);
+
+        int maxMessages = request.MaxMessages <= 0 ? 1 : request.MaxMessages;
+        var state = GetOrAddDestination(source, DestinationRole.Queue);
+        var entries = new List<TransportEntry>(maxMessages);
+        DateTimeOffset? waitUntil = request.MaxWaitTime is { } waitTime && waitTime > TimeSpan.Zero
+            ? _timeProvider.GetUtcNow().Add(waitTime)
+            : null;
+
+        while (entries.Count < maxMessages)
+        {
+            if (TryReceive(source, state, out var entry))
+            {
+                entries.Add(entry);
+                continue;
+            }
+
+            if (entries.Count > 0 || waitUntil is null)
+                break;
+
+            TimeSpan remaining = waitUntil.Value - _timeProvider.GetUtcNow();
+            if (remaining <= TimeSpan.Zero)
+                break;
+
+            using var waitCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(ct, _disposeCancellationTokenSource.Token);
+            waitCancellationTokenSource.CancelAfter(remaining);
+
+            try
+            {
+                await state.AvailableSignal.WaitAsync(waitCancellationTokenSource.Token).AnyContext();
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested && !_disposeCancellationTokenSource.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+
+        return entries;
+    }
+
+    public Task CompleteAsync(TransportEntry entry, CancellationToken ct = default)
+    {
+        ThrowIfDisposed();
+        ct.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(entry);
+
+        var receipt = GetReceipt(entry);
+        var state = GetExistingDestination(receipt.Destination);
+
+        if (!state.InFlight.TryRemove(receipt.LockToken, out var inFlight) || !String.Equals(inFlight.Message.Id, entry.Id, StringComparison.Ordinal))
+            throw new ReceiptExpiredException();
+
+        Interlocked.Increment(ref state.Completed);
+        return Task.CompletedTask;
+    }
+
+    public Task AbandonAsync(TransportEntry entry, CancellationToken ct = default)
+    {
+        return AbandonAsync(entry, TimeSpan.Zero, ct);
+    }
+
+    public Task AbandonAsync(TransportEntry entry, TimeSpan redeliveryDelay, CancellationToken ct)
+    {
+        ThrowIfDisposed();
+        ct.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(entry);
+
+        var receipt = GetReceipt(entry);
+        var state = GetExistingDestination(receipt.Destination);
+
+        if (!state.InFlight.TryRemove(receipt.LockToken, out var inFlight) || !String.Equals(inFlight.Message.Id, entry.Id, StringComparison.Ordinal))
+            throw new ReceiptExpiredException();
+
+        Interlocked.Increment(ref state.Abandoned);
+        var redelivered = inFlight.Message with { DeliveryCount = entry.DeliveryCount + 1 };
+
+        if (redeliveryDelay > TimeSpan.Zero)
+            _ = Run.DelayedAsync(redeliveryDelay, () => EnqueueStoredMessageAsync(receipt.Destination, redelivered), _timeProvider, _disposeCancellationTokenSource.Token);
+        else
+            EnqueueStoredMessage(receipt.Destination, redelivered);
+
+        return Task.CompletedTask;
+    }
+
+    public Task DeadLetterAsync(TransportEntry entry, string? reason, CancellationToken ct)
+    {
+        ThrowIfDisposed();
+        ct.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(entry);
+
+        var receipt = GetReceipt(entry);
+        var state = GetExistingDestination(receipt.Destination);
+
+        if (!state.InFlight.TryRemove(receipt.LockToken, out var inFlight) || !String.Equals(inFlight.Message.Id, entry.Id, StringComparison.Ordinal))
+            throw new ReceiptExpiredException();
+
+        DeadLetter(state, inFlight.Message, reason);
+        return Task.CompletedTask;
+    }
+
+    public Task<IPushSubscription> SubscribeAsync(string source, Func<TransportEntry, CancellationToken, Task> onMessage, PushOptions options, CancellationToken ct)
+    {
+        ThrowIfDisposed();
+        ct.ThrowIfCancellationRequested();
+        ArgumentException.ThrowIfNullOrEmpty(source);
+        ArgumentNullException.ThrowIfNull(onMessage);
+        ArgumentNullException.ThrowIfNull(options);
+
+        var subscription = new PushSubscription(source);
+        subscription.Start(RunPushSubscriptionAsync(source, onMessage, options, subscription.CancellationToken));
+        return Task.FromResult<IPushSubscription>(subscription);
+    }
+
+    public Task<QueueStats> GetStatsAsync(string destination, CancellationToken ct)
+    {
+        ThrowIfDisposed();
+        ct.ThrowIfCancellationRequested();
+        ArgumentException.ThrowIfNullOrEmpty(destination);
+
+        if (!_destinations.TryGetValue(destination, out var state))
+            return Task.FromResult(new QueueStats());
+
+        return Task.FromResult(new QueueStats
+        {
+            Queued = state.QueuedCount,
+            Working = state.InFlight.Count,
+            Deadletter = state.DeadletterCount,
+            Enqueued = Volatile.Read(ref state.Enqueued),
+            Dequeued = Volatile.Read(ref state.Dequeued),
+            Completed = Volatile.Read(ref state.Completed),
+            Abandoned = Volatile.Read(ref state.Abandoned)
+        });
+    }
+
+    public Task EnsureAsync(IReadOnlyList<DestinationDeclaration> declarations, CancellationToken ct)
+    {
+        ThrowIfDisposed();
+        ct.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(declarations);
+
+        foreach (var declaration in declarations)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(declaration.Name);
+
+            switch (declaration.Role)
+            {
+                case DestinationRole.Queue:
+                    GetOrAddDestination(declaration.Name, DestinationRole.Queue);
+                    break;
+                case DestinationRole.Topic:
+                    SetRole(declaration.Name, DestinationRole.Topic);
+                    _topicSubscriptions.GetOrAdd(declaration.Name, static _ => new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase));
+                    break;
+                case DestinationRole.Subscription:
+                    GetOrAddDestination(declaration.Name, DestinationRole.Subscription);
+                    if (!String.IsNullOrEmpty(declaration.Source))
+                        AddTopicSubscription(declaration.Source, declaration.Name);
+                    break;
+                case DestinationRole.Binding:
+                    if (String.IsNullOrEmpty(declaration.Source))
+                        throw new ArgumentException("A binding declaration must specify a source topic.", nameof(declarations));
+
+                    GetOrAddDestination(declaration.Name, DestinationRole.Subscription);
+                    AddTopicSubscription(declaration.Source, declaration.Name);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(declarations), declaration.Role, "Unsupported destination role.");
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(string name, CancellationToken ct)
+    {
+        ThrowIfDisposed();
+        ct.ThrowIfCancellationRequested();
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        _roles.TryRemove(name, out _);
+        _destinations.TryRemove(name, out _);
+        _topicSubscriptions.TryRemove(name, out _);
+
+        foreach (var subscriptions in _topicSubscriptions.Values)
+            subscriptions.TryRemove(name, out _);
+
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> ExistsAsync(string name, CancellationToken ct)
+    {
+        ThrowIfDisposed();
+        ct.ThrowIfCancellationRequested();
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        return Task.FromResult(_roles.ContainsKey(name));
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _isDisposed, 1) == 1)
+            return ValueTask.CompletedTask;
+
+        _disposeCancellationTokenSource.Cancel();
+        _disposeCancellationTokenSource.Dispose();
+        _destinations.Clear();
+        _roles.Clear();
+        _topicSubscriptions.Clear();
+        return ValueTask.CompletedTask;
+    }
+
+    private async Task RunPushSubscriptionAsync(string source, Func<TransportEntry, CancellationToken, Task> onMessage, PushOptions options, CancellationToken subscriptionCancellationToken)
+    {
+        using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(subscriptionCancellationToken, _disposeCancellationTokenSource.Token);
+        var token = linkedCancellationTokenSource.Token;
+        int maxMessages = Math.Max(1, options.MaxConcurrentMessages);
+
+        while (!token.IsCancellationRequested)
+        {
+            IReadOnlyList<TransportEntry> entries;
+            try
+            {
+                entries = await ReceiveAsync(source, new ReceiveRequest
+                {
+                    MaxMessages = maxMessages,
+                    MaxWaitTime = options.PollInterval
+                }, token).AnyContext();
+            }
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
+            {
+                break;
+            }
+
+            foreach (var entry in entries)
+            {
+                try
+                {
+                    await onMessage(entry, token).AnyContext();
+                }
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch
+                {
+                    await AbandonAsync(entry, token).AnyContext();
+                }
+            }
+        }
+    }
+
+    private void EnqueueOrSchedule(string destination, StoredMessage message, TransportSendOptions options)
+    {
+        if (options.DeliverAt is { } deliverAt)
+        {
+            TimeSpan delay = deliverAt - _timeProvider.GetUtcNow();
+            if (delay > TimeSpan.Zero)
+            {
+                _ = Run.DelayedAsync(delay, () => EnqueueForDestinationAsync(destination, message), _timeProvider, _disposeCancellationTokenSource.Token);
+                return;
+            }
+        }
+
+        EnqueueForDestination(destination, message);
+    }
+
+    private Task EnqueueForDestinationAsync(string destination, StoredMessage message)
+    {
+        EnqueueForDestination(destination, message);
+        return Task.CompletedTask;
+    }
+
+    private void EnqueueForDestination(string destination, StoredMessage message)
+    {
+        var role = _roles.GetOrAdd(destination, DestinationRole.Queue);
+        if (role == DestinationRole.Topic)
+        {
+            if (!_topicSubscriptions.TryGetValue(destination, out var subscriptions))
+                return;
+
+            foreach (string subscription in subscriptions.Keys)
+                EnqueueStoredMessage(subscription, message with { Destination = subscription });
+
+            return;
+        }
+
+        if (role is DestinationRole.Binding)
+            throw new InvalidOperationException($"Cannot send directly to binding destination \"{destination}\".");
+
+        EnqueueStoredMessage(destination, message);
+    }
+
+    private Task EnqueueStoredMessageAsync(string destination, StoredMessage message)
+    {
+        EnqueueStoredMessage(destination, message);
+        return Task.CompletedTask;
+    }
+
+    private void EnqueueStoredMessage(string destination, StoredMessage message)
+    {
+        var role = _roles.GetOrAdd(destination, DestinationRole.Queue);
+        var state = GetOrAddDestination(destination, role == DestinationRole.Topic ? DestinationRole.Queue : role);
+        state.Enqueue(message with { Destination = destination });
+    }
+
+    private bool TryReceive(string source, DestinationState state, out TransportEntry entry)
+    {
+        while (state.TryDequeue(out var message))
+        {
+            if (IsExpired(message))
+            {
+                DeadLetter(state, message, "expired");
+                continue;
+            }
+
+            var receipt = new InMemoryReceipt(source, Guid.NewGuid().ToString("N"));
+            state.InFlight[receipt.LockToken] = new InFlightMessage(message, receipt);
+            Interlocked.Increment(ref state.Dequeued);
+
+            entry = new TransportEntry
+            {
+                Id = message.Id,
+                Destination = source,
+                Body = message.Body,
+                Headers = message.Headers,
+                DeliveryCount = message.DeliveryCount,
+                EnqueuedUtc = message.EnqueuedUtc,
+                Receipt = new Receipt { TransportState = receipt }
+            };
+            return true;
+        }
+
+        entry = null!;
+        return false;
+    }
+
+    private bool IsExpired(StoredMessage message)
+    {
+        string? expiration = message.Headers.GetValueOrDefault(KnownHeaders.Expiration);
+        if (expiration is null)
+            return false;
+
+        return DateTimeOffset.TryParse(expiration, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var expiresAt)
+            && expiresAt <= _timeProvider.GetUtcNow();
+    }
+
+    private void DeadLetter(DestinationState state, StoredMessage message, string? reason)
+    {
+        if (!String.IsNullOrEmpty(reason))
+            message = message with { Headers = message.Headers.ToBuilder().Set(KnownHeaders.DeadLetterReason, reason).Build() };
+
+        state.Deadletter(message);
+    }
+
+    private StoredMessage CreateStoredMessage(string destination, string messageId, TransportMessage message, TransportSendOptions options)
+    {
+        var headers = message.Headers.ToBuilder()
+            .SetIfMissing(KnownHeaders.Priority, options.Priority.ToString())
+            .Build();
+
+        return new StoredMessage(
+            messageId,
+            destination,
+            message.Body.ToArray(),
+            headers,
+            NormalizePriority(options.Priority),
+            DeliveryCount: 1,
+            EnqueuedUtc: _timeProvider.GetUtcNow());
+    }
+
+    private DestinationState GetOrAddDestination(string name, DestinationRole role)
+    {
+        SetRole(name, role);
+        return _destinations.GetOrAdd(name, static _ => new DestinationState());
+    }
+
+    private DestinationState GetExistingDestination(string name)
+    {
+        if (_destinations.TryGetValue(name, out var destination))
+            return destination;
+
+        throw new ReceiptExpiredException($"The destination \"{name}\" no longer exists.");
+    }
+
+    private void SetRole(string name, DestinationRole role)
+    {
+        _roles.AddOrUpdate(name, role, (_, existing) =>
+        {
+            if (existing == role)
+                return existing;
+
+            if (existing == DestinationRole.Queue && role == DestinationRole.Subscription)
+                return role;
+
+            if (existing == DestinationRole.Subscription && role == DestinationRole.Queue)
+                return existing;
+
+            throw new InvalidOperationException($"Destination \"{name}\" is already declared as {existing}.");
+        });
+    }
+
+    private void AddTopicSubscription(string topic, string subscription)
+    {
+        SetRole(topic, DestinationRole.Topic);
+        GetOrAddDestination(subscription, DestinationRole.Subscription);
+        var subscriptions = _topicSubscriptions.GetOrAdd(topic, static _ => new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase));
+        subscriptions[subscription] = 0;
+    }
+
+    private static MessagePriority NormalizePriority(MessagePriority priority)
+    {
+        return priority switch
+        {
+            MessagePriority.Low => MessagePriority.Low,
+            MessagePriority.Normal => MessagePriority.Normal,
+            MessagePriority.High => MessagePriority.High,
+            _ => MessagePriority.Normal
+        };
+    }
+
+    private static InMemoryReceipt GetReceipt(TransportEntry entry)
+    {
+        return entry.Receipt.TransportState as InMemoryReceipt ?? throw new ReceiptExpiredException();
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _isDisposed) == 1, this);
+    }
+
+    private sealed record StoredMessage(
+        string Id,
+        string Destination,
+        ReadOnlyMemory<byte> Body,
+        MessageHeaders Headers,
+        MessagePriority Priority,
+        int DeliveryCount,
+        DateTimeOffset EnqueuedUtc);
+
+    private sealed record InFlightMessage(StoredMessage Message, InMemoryReceipt Receipt);
+
+    private sealed record InMemoryReceipt(string Destination, string LockToken);
+
+    private sealed class DestinationState
+    {
+        private readonly ConcurrentQueue<StoredMessage>[] _queues =
+        [
+            new ConcurrentQueue<StoredMessage>(),
+            new ConcurrentQueue<StoredMessage>(),
+            new ConcurrentQueue<StoredMessage>()
+        ];
+
+        private readonly ConcurrentQueue<StoredMessage> _deadletterQueue = new();
+
+        public ConcurrentDictionary<string, InFlightMessage> InFlight { get; } = new(StringComparer.Ordinal);
+        public AsyncAutoResetEvent AvailableSignal { get; } = new();
+        public long Enqueued;
+        public long Dequeued;
+        public long Completed;
+        public long Abandoned;
+        public long Deadlettered;
+
+        public long QueuedCount => _queues.Sum(q => q.Count);
+        public long DeadletterCount => _deadletterQueue.Count;
+
+        public void Enqueue(StoredMessage message)
+        {
+            _queues[(int)message.Priority].Enqueue(message);
+            Interlocked.Increment(ref Enqueued);
+            AvailableSignal.Set();
+        }
+
+        public bool TryDequeue(out StoredMessage message)
+        {
+            for (int index = (int)MessagePriority.High; index >= (int)MessagePriority.Low; index--)
+            {
+                if (_queues[index].TryDequeue(out message!))
+                    return true;
+            }
+
+            message = null!;
+            return false;
+        }
+
+        public void Deadletter(StoredMessage message)
+        {
+            _deadletterQueue.Enqueue(message);
+            Interlocked.Increment(ref Deadlettered);
+        }
+    }
+
+    private sealed class PushSubscription : IPushSubscription
+    {
+        private readonly CancellationTokenSource _cancellationTokenSource = new();
+        private Task? _worker;
+
+        public PushSubscription(string source)
+        {
+            Source = source;
+        }
+
+        public string Source { get; }
+        public CancellationToken CancellationToken => _cancellationTokenSource.Token;
+
+        public void Start(Task worker)
+        {
+            _worker = worker;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _cancellationTokenSource.CancelAsync().AnyContext();
+
+            if (_worker is not null)
+            {
+                try
+                {
+                    await _worker.AnyContext();
+                }
+                catch (OperationCanceledException) { }
+            }
+
+            _cancellationTokenSource.Dispose();
+        }
+    }
+}

--- a/src/Foundatio/Messaging/InMemoryMessageTransport.cs
+++ b/src/Foundatio/Messaging/InMemoryMessageTransport.cs
@@ -2,9 +2,9 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Threading.Channels;
 using Foundatio.AsyncEx;
 using Foundatio.Queues;
 using Foundatio.Utility;
@@ -107,7 +107,8 @@ public sealed class InMemoryMessageTransport : IMessageTransport, ISupportsPull,
 
             try
             {
-                await state.AvailableSignal.WaitAsync(waitCancellationTokenSource.Token).AnyContext();
+                if (!await state.WaitToReadAsync(waitCancellationTokenSource.Token).ConfigureAwait(false))
+                    break;
             }
             catch (OperationCanceledException) when (!ct.IsCancellationRequested && !_disposeCancellationTokenSource.IsCancellationRequested)
             {
@@ -258,7 +259,8 @@ public sealed class InMemoryMessageTransport : IMessageTransport, ISupportsPull,
         ArgumentException.ThrowIfNullOrEmpty(name);
 
         _roles.TryRemove(name, out _);
-        _destinations.TryRemove(name, out _);
+        if (_destinations.TryRemove(name, out var removed))
+            removed.Complete();
         _topicSubscriptions.TryRemove(name, out _);
 
         foreach (var subscriptions in _topicSubscriptions.Values)
@@ -523,49 +525,92 @@ public sealed class InMemoryMessageTransport : IMessageTransport, ISupportsPull,
 
     private sealed class DestinationState
     {
-        private readonly ConcurrentQueue<StoredMessage>[] _queues =
+        private readonly Channel<StoredMessage>[] _channels =
         [
-            new ConcurrentQueue<StoredMessage>(),
-            new ConcurrentQueue<StoredMessage>(),
-            new ConcurrentQueue<StoredMessage>()
+            Channel.CreateUnbounded<StoredMessage>(CreateChannelOptions()),
+            Channel.CreateUnbounded<StoredMessage>(CreateChannelOptions()),
+            Channel.CreateUnbounded<StoredMessage>(CreateChannelOptions())
         ];
 
-        private readonly ConcurrentQueue<StoredMessage> _deadletterQueue = new();
+        private readonly Channel<StoredMessage> _deadletterChannel = Channel.CreateUnbounded<StoredMessage>(CreateChannelOptions());
+        private readonly SemaphoreSlim _availableMessages = new(0);
+        private long _queuedCount;
+        private long _deadletterCount;
+        private int _isCompleted;
 
         public ConcurrentDictionary<string, InFlightMessage> InFlight { get; } = new(StringComparer.Ordinal);
-        public AsyncAutoResetEvent AvailableSignal { get; } = new();
         public long Enqueued;
         public long Dequeued;
         public long Completed;
         public long Abandoned;
         public long Deadlettered;
 
-        public long QueuedCount => _queues.Sum(q => q.Count);
-        public long DeadletterCount => _deadletterQueue.Count;
+        public long QueuedCount => Volatile.Read(ref _queuedCount);
+        public long DeadletterCount => Volatile.Read(ref _deadletterCount);
 
         public void Enqueue(StoredMessage message)
         {
-            _queues[(int)message.Priority].Enqueue(message);
+            if (!_channels[(int)message.Priority].Writer.TryWrite(message))
+                throw new InvalidOperationException("The destination is no longer accepting messages.");
+
+            Interlocked.Increment(ref _queuedCount);
             Interlocked.Increment(ref Enqueued);
-            AvailableSignal.Set();
+            _availableMessages.Release();
         }
 
         public bool TryDequeue(out StoredMessage message)
         {
             for (int index = (int)MessagePriority.High; index >= (int)MessagePriority.Low; index--)
             {
-                if (_queues[index].TryDequeue(out message!))
+                if (_channels[index].Reader.TryRead(out message!))
+                {
+                    _availableMessages.Wait(0);
+                    Interlocked.Decrement(ref _queuedCount);
                     return true;
+                }
             }
 
             message = null!;
             return false;
         }
 
+        public async ValueTask<bool> WaitToReadAsync(CancellationToken cancellationToken)
+        {
+            if (QueuedCount > 0)
+                return true;
+
+            await _availableMessages.WaitAsync(cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+
         public void Deadletter(StoredMessage message)
         {
-            _deadletterQueue.Enqueue(message);
+            if (!_deadletterChannel.Writer.TryWrite(message))
+                throw new InvalidOperationException("The destination is no longer accepting dead-letter messages.");
+
+            Interlocked.Increment(ref _deadletterCount);
             Interlocked.Increment(ref Deadlettered);
+        }
+
+        public void Complete()
+        {
+            if (Interlocked.Exchange(ref _isCompleted, 1) == 1)
+                return;
+
+            foreach (var channel in _channels)
+                channel.Writer.TryComplete();
+
+            _deadletterChannel.Writer.TryComplete();
+        }
+
+        private static UnboundedChannelOptions CreateChannelOptions()
+        {
+            return new UnboundedChannelOptions
+            {
+                AllowSynchronousContinuations = false,
+                SingleReader = false,
+                SingleWriter = false
+            };
         }
     }
 

--- a/src/Foundatio/Messaging/KnownHeaders.cs
+++ b/src/Foundatio/Messaging/KnownHeaders.cs
@@ -1,0 +1,14 @@
+namespace Foundatio.Messaging;
+
+public static class KnownHeaders
+{
+    public const string MessageType = "message.type";
+    public const string ContentType = "message.content_type";
+    public const string CorrelationId = "message.correlation_id";
+    public const string TraceParent = "traceparent";
+    public const string TraceState = "tracestate";
+    public const string Priority = "message.priority";
+    public const string Expiration = "message.expiration";
+    public const string Attempts = "message.attempts";
+    public const string DeadLetterReason = "message.dead_letter.reason";
+}

--- a/src/Foundatio/Messaging/MessageHeaders.cs
+++ b/src/Foundatio/Messaging/MessageHeaders.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+
+namespace Foundatio.Messaging;
+
+public sealed class MessageHeaders : IReadOnlyDictionary<string, string>
+{
+    public static MessageHeaders Empty { get; } = new(FrozenDictionary<string, string>.Empty);
+
+    private readonly FrozenDictionary<string, string> _headers;
+
+    private MessageHeaders(FrozenDictionary<string, string> headers)
+    {
+        _headers = headers;
+    }
+
+    public string this[string key] => _headers[key];
+    public IEnumerable<string> Keys => _headers.Keys;
+    public IEnumerable<string> Values => _headers.Values;
+    public int Count => _headers.Count;
+
+    public static MessageHeaders Create(IEnumerable<KeyValuePair<string, string>> headers)
+    {
+        ArgumentNullException.ThrowIfNull(headers);
+
+        if (headers is MessageHeaders messageHeaders)
+            return messageHeaders;
+
+        var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var header in headers)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(header.Key);
+            ArgumentNullException.ThrowIfNull(header.Value);
+            values[header.Key] = header.Value;
+        }
+
+        return values.Count == 0
+            ? Empty
+            : new MessageHeaders(values.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase));
+    }
+
+    public bool ContainsKey(string key)
+    {
+        return _headers.ContainsKey(key);
+    }
+
+    public bool TryGetValue(string key, out string value)
+    {
+        return _headers.TryGetValue(key, out value!);
+    }
+
+    public string? GetValueOrDefault(string key)
+    {
+        return _headers.GetValueOrDefault(key);
+    }
+
+    public Builder ToBuilder()
+    {
+        return new Builder(_headers);
+    }
+
+    public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+    {
+        return _headers.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    public sealed class Builder
+    {
+        private readonly Dictionary<string, string> _headers;
+
+        internal Builder(IEnumerable<KeyValuePair<string, string>> headers)
+        {
+            _headers = new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public Builder Add(string key, string value)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(key);
+            ArgumentNullException.ThrowIfNull(value);
+            _headers.Add(key, value);
+            return this;
+        }
+
+        public Builder Set(string key, string value)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(key);
+            ArgumentNullException.ThrowIfNull(value);
+            _headers[key] = value;
+            return this;
+        }
+
+        public Builder SetIfMissing(string key, string value)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(key);
+            ArgumentNullException.ThrowIfNull(value);
+            _headers.TryAdd(key, value);
+            return this;
+        }
+
+        public bool Remove(string key)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(key);
+            return _headers.Remove(key);
+        }
+
+        public MessageHeaders Build()
+        {
+            return Create(_headers);
+        }
+    }
+}

--- a/src/Foundatio/Messaging/MessageTransport.cs
+++ b/src/Foundatio/Messaging/MessageTransport.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Foundatio.Queues;
+
+namespace Foundatio.Messaging;
+
+public enum MessagePriority
+{
+    Low = 0,
+    Normal = 1,
+    High = 2
+}
+
+public enum DeliveryGuarantee
+{
+    AtMostOnce,
+    AtLeastOnce
+}
+
+public enum OrderingGuarantee
+{
+    None,
+    Fifo,
+    PerPartition
+}
+
+public enum DestinationRole
+{
+    Queue,
+    Topic,
+    Subscription,
+    Binding
+}
+
+public sealed record TransportMessage
+{
+    public required ReadOnlyMemory<byte> Body { get; init; }
+    public MessageHeaders Headers { get; init; } = MessageHeaders.Empty;
+    public string? MessageId { get; init; }
+}
+
+public sealed record TransportSendOptions
+{
+    public MessagePriority Priority { get; init; } = MessagePriority.Normal;
+    public DateTimeOffset? DeliverAt { get; init; }
+    public string? DeduplicationId { get; init; }
+    public string? PartitionKey { get; init; }
+}
+
+public sealed record TransportEntry
+{
+    public required string Id { get; init; }
+    public required string Destination { get; init; }
+    public required ReadOnlyMemory<byte> Body { get; init; }
+    public MessageHeaders Headers { get; init; } = MessageHeaders.Empty;
+    public int DeliveryCount { get; init; } = 1;
+    public DateTimeOffset? EnqueuedUtc { get; init; }
+    public required Receipt Receipt { get; init; }
+}
+
+public readonly struct Receipt
+{
+    public object? TransportState { get; init; }
+}
+
+public sealed record ReceiveRequest
+{
+    public int MaxMessages { get; init; } = 1;
+    public TimeSpan? MaxWaitTime { get; init; }
+}
+
+public sealed record SendItemResult
+{
+    public string? MessageId { get; init; }
+    public required bool Success { get; init; }
+    public string? ErrorCode { get; init; }
+    public bool IsRetryable { get; init; }
+}
+
+public sealed record SendResult
+{
+    public required IReadOnlyList<SendItemResult> Items { get; init; }
+    public bool AllSucceeded => Items.All(i => i.Success);
+}
+
+public sealed class ReceiptExpiredException : Exception
+{
+    public ReceiptExpiredException() : base("The transport receipt has expired or has already been settled.") { }
+
+    public ReceiptExpiredException(string message) : base(message) { }
+
+    public ReceiptExpiredException(string message, Exception innerException) : base(message, innerException) { }
+}
+
+public sealed record DestinationDeclaration
+{
+    public required string Name { get; init; }
+    public DestinationRole Role { get; init; } = DestinationRole.Queue;
+    public string? Source { get; init; }
+}
+
+public sealed record PushOptions
+{
+    public int MaxConcurrentMessages { get; init; } = 1;
+    public TimeSpan PollInterval { get; init; } = TimeSpan.FromSeconds(1);
+}
+
+public interface ITransportInfo
+{
+    DeliveryGuarantee DeliveryGuarantee { get; }
+    OrderingGuarantee Ordering { get; }
+    IReadOnlySet<DestinationRole> SupportedRoles { get; }
+    int? MaxBatchSize { get; }
+    long? MaxMessageBytes { get; }
+}
+
+public interface IMessageTransport : IAsyncDisposable
+{
+    Task<SendResult> SendAsync(string destination, IReadOnlyList<TransportMessage> messages, TransportSendOptions options, CancellationToken ct = default);
+    Task CompleteAsync(TransportEntry entry, CancellationToken ct = default);
+    Task AbandonAsync(TransportEntry entry, CancellationToken ct = default);
+}
+
+public interface ISupportsPull : IMessageTransport
+{
+    Task<IReadOnlyList<TransportEntry>> ReceiveAsync(string source, ReceiveRequest request, CancellationToken ct);
+}
+
+public interface ISupportsPush : IMessageTransport
+{
+    Task<IPushSubscription> SubscribeAsync(string source, Func<TransportEntry, CancellationToken, Task> onMessage, PushOptions options, CancellationToken ct);
+}
+
+public interface ISupportsRedeliveryDelay : IMessageTransport
+{
+    Task AbandonAsync(TransportEntry entry, TimeSpan redeliveryDelay, CancellationToken ct);
+}
+
+public interface ISupportsDeadLetter : IMessageTransport
+{
+    Task DeadLetterAsync(TransportEntry entry, string? reason, CancellationToken ct);
+}
+
+public interface ISupportsLockRenewal : IMessageTransport
+{
+    Task RenewLockAsync(TransportEntry entry, TimeSpan? duration, CancellationToken ct);
+}
+
+public interface ISupportsVisibilityTimeout : IMessageTransport
+{
+    Task<IReadOnlyList<TransportEntry>> ReceiveAsync(string source, ReceiveRequest request, TimeSpan visibility, CancellationToken ct);
+}
+
+public interface ISupportsStats : IMessageTransport
+{
+    Task<QueueStats> GetStatsAsync(string destination, CancellationToken ct);
+}
+
+public interface ISupportsPriority : IMessageTransport { }
+
+public interface ISupportsDelayedDelivery : IMessageTransport { }
+
+public interface ISupportsExpiration : IMessageTransport { }
+
+public interface ISupportsProvisioning : IMessageTransport
+{
+    Task EnsureAsync(IReadOnlyList<DestinationDeclaration> declarations, CancellationToken ct);
+    Task DeleteAsync(string name, CancellationToken ct);
+    Task<bool> ExistsAsync(string name, CancellationToken ct);
+}
+
+public interface IPushSubscription : IAsyncDisposable
+{
+    string Source { get; }
+}

--- a/src/Foundatio/Messaging/PubSub.cs
+++ b/src/Foundatio/Messaging/PubSub.cs
@@ -1,0 +1,301 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Foundatio.Queues;
+using Foundatio.Serializer;
+using Foundatio.Utility;
+
+namespace Foundatio.Messaging;
+
+public sealed record PublishOptions
+{
+    public MessagePriority Priority { get; init; } = MessagePriority.Normal;
+    public TimeSpan? Delay { get; init; }
+    public DateTimeOffset? DeliverAt { get; init; }
+    public TimeSpan? TimeToLive { get; init; }
+    public string? CorrelationId { get; init; }
+    public string? DeduplicationId { get; init; }
+    public string? Topic { get; init; }
+    public MessageHeaders? Headers { get; init; }
+}
+
+public sealed record SubscriptionOptions
+{
+    public string? Topic { get; init; }
+    public string? Subscription { get; init; }
+    public AckMode AckMode { get; init; } = AckMode.Auto;
+    public int MaxConcurrency { get; init; } = 1;
+    public int MaxAttempts { get; init; } = 5;
+}
+
+public sealed record PubSubOptions
+{
+    public ISerializer Serializer { get; init; } = DefaultSerializer.Instance;
+    public string ContentType { get; init; } = "application/json";
+    public Func<Type, string>? TopicResolver { get; init; }
+    public Func<Type, string>? MessageTypeResolver { get; init; }
+    public Func<Type, string, string>? SubscriptionResolver { get; init; }
+}
+
+public interface IPubSub : IAsyncDisposable
+{
+    Task PublishAsync<T>(T message, PublishOptions? options = null, CancellationToken cancellationToken = default) where T : class;
+    Task PublishBatchAsync<T>(IEnumerable<T> messages, PublishOptions? options = null, CancellationToken cancellationToken = default) where T : class;
+    Task SubscribeAsync<T>(Func<IReceivedMessage<T>, CancellationToken, Task> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default) where T : class;
+}
+
+public sealed class PubSub : IPubSub
+{
+    private readonly IMessageTransport _transport;
+    private readonly PubSubOptions _options;
+    private int _isDisposed;
+
+    public PubSub(IMessageTransport transport, PubSubOptions? options = null)
+    {
+        _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+        _options = options ?? new PubSubOptions();
+    }
+
+    public async Task PublishAsync<T>(T message, PublishOptions? options = null, CancellationToken cancellationToken = default) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        ThrowIfDisposed();
+
+        options ??= new PublishOptions();
+        string topic = GetTopic(typeof(T), options.Topic);
+        await EnsureTopicAsync(topic, cancellationToken).AnyContext();
+
+        var result = await _transport.SendAsync(topic, [CreateTransportMessage(message, options)], CreateSendOptions(options), cancellationToken).AnyContext();
+        var item = result.Items.Count > 0 ? result.Items[0] : null;
+        if (item is null || !item.Success)
+            throw new MessageBusException($"Unable to publish message to \"{topic}\": {item?.ErrorCode ?? "unknown error"}");
+    }
+
+    public async Task PublishBatchAsync<T>(IEnumerable<T> messages, PublishOptions? options = null, CancellationToken cancellationToken = default) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+        ThrowIfDisposed();
+
+        options ??= new PublishOptions();
+        string topic = GetTopic(typeof(T), options.Topic);
+        await EnsureTopicAsync(topic, cancellationToken).AnyContext();
+
+        var transportMessages = messages.Select(message =>
+        {
+            ArgumentNullException.ThrowIfNull(message);
+            return CreateTransportMessage(message, options);
+        }).ToArray();
+
+        if (transportMessages.Length == 0)
+            return;
+
+        var result = await _transport.SendAsync(topic, transportMessages, CreateSendOptions(options), cancellationToken).AnyContext();
+        if (!result.AllSucceeded)
+            throw new MessageBusException($"Unable to publish {result.Items.Count(i => !i.Success)} of {result.Items.Count} messages to \"{topic}\".");
+    }
+
+    public async Task SubscribeAsync<T>(Func<IReceivedMessage<T>, CancellationToken, Task> handler, SubscriptionOptions? options = null, CancellationToken cancellationToken = default) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        ThrowIfDisposed();
+
+        options ??= new SubscriptionOptions();
+        string topic = GetTopic(typeof(T), options.Topic);
+        string subscription = GetSubscription(typeof(T), topic, options.Subscription);
+        await EnsureSubscriptionAsync(topic, subscription, cancellationToken).AnyContext();
+
+        if (_transport is ISupportsPush push)
+        {
+            await using var pushSubscription = await push.SubscribeAsync(subscription, async (entry, token) =>
+            {
+                var received = await CreateReceivedMessageAsync<T>(entry, token).AnyContext();
+                await HandleMessageAsync(received, handler, options, token).AnyContext();
+            }, new PushOptions { MaxConcurrentMessages = Math.Max(1, options.MaxConcurrency) }, cancellationToken).AnyContext();
+
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).AnyContext();
+            return;
+        }
+
+        if (_transport is not ISupportsPull pull)
+            throw new MessageBusException($"Transport \"{_transport.GetType().Name}\" does not support subscriptions.");
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var entries = await pull.ReceiveAsync(subscription, new ReceiveRequest
+            {
+                MaxMessages = Math.Max(1, options.MaxConcurrency),
+                MaxWaitTime = TimeSpan.FromSeconds(1)
+            }, cancellationToken).AnyContext();
+
+            foreach (var entry in entries)
+            {
+                var received = await CreateReceivedMessageAsync<T>(entry, cancellationToken).AnyContext();
+                await HandleMessageAsync(received, handler, options, cancellationToken).AnyContext();
+            }
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _isDisposed, 1) == 1)
+            return ValueTask.CompletedTask;
+
+        return _transport.DisposeAsync();
+    }
+
+    private async Task EnsureTopicAsync(string topic, CancellationToken cancellationToken)
+    {
+        if (_transport is ISupportsProvisioning provisioning)
+            await provisioning.EnsureAsync([new DestinationDeclaration { Name = topic, Role = DestinationRole.Topic }], cancellationToken).AnyContext();
+    }
+
+    private async Task EnsureSubscriptionAsync(string topic, string subscription, CancellationToken cancellationToken)
+    {
+        if (_transport is ISupportsProvisioning provisioning)
+        {
+            await provisioning.EnsureAsync([
+                new DestinationDeclaration { Name = topic, Role = DestinationRole.Topic },
+                new DestinationDeclaration { Name = subscription, Role = DestinationRole.Subscription, Source = topic }
+            ], cancellationToken).AnyContext();
+        }
+    }
+
+    private async Task<IReceivedMessage<T>> CreateReceivedMessageAsync<T>(TransportEntry entry, CancellationToken cancellationToken) where T : class
+    {
+        try
+        {
+            var message = _options.Serializer.Deserialize<T>(entry.Body);
+            if (message is null)
+                throw new MessageBusException($"Message \"{entry.Id}\" deserialized to null.");
+
+            return new ReceivedMessage<T>(_transport, entry, message, cancellationToken);
+        }
+        catch (Exception ex) when (ex is not MessageBusException)
+        {
+            await DeadLetterPoisonMessageAsync(entry, "deserialize-failure", cancellationToken).AnyContext();
+            throw new MessageBusException($"Unable to deserialize message \"{entry.Id}\".", ex);
+        }
+        catch (MessageBusException)
+        {
+            await DeadLetterPoisonMessageAsync(entry, "deserialize-failure", cancellationToken).AnyContext();
+            throw;
+        }
+    }
+
+    private async Task HandleMessageAsync<T>(IReceivedMessage<T> message, Func<IReceivedMessage<T>, CancellationToken, Task> handler, SubscriptionOptions options, CancellationToken cancellationToken) where T : class
+    {
+        try
+        {
+            await handler(message, cancellationToken).AnyContext();
+
+            if (options.AckMode == AckMode.Auto && !message.IsHandled)
+                await message.CompleteAsync(cancellationToken).AnyContext();
+        }
+        catch
+        {
+            if (!message.IsHandled)
+                await message.RejectAsync(message.Attempts < options.MaxAttempts, "handler-error", cancellationToken).AnyContext();
+        }
+    }
+
+    private TransportMessage CreateTransportMessage<T>(T message, PublishOptions options) where T : class
+    {
+        var headers = (options.Headers ?? MessageHeaders.Empty).ToBuilder()
+            .Set(KnownHeaders.MessageType, GetMessageType(typeof(T)))
+            .Set(KnownHeaders.ContentType, _options.ContentType)
+            .Set(KnownHeaders.Priority, options.Priority.ToString());
+
+        if (!String.IsNullOrEmpty(options.CorrelationId))
+            headers.Set(KnownHeaders.CorrelationId, options.CorrelationId);
+
+        if (Activity.Current is { } activity)
+        {
+            if (!String.IsNullOrEmpty(activity.Id))
+                headers.SetIfMissing(KnownHeaders.TraceParent, activity.Id);
+
+            if (!String.IsNullOrEmpty(activity.TraceStateString))
+                headers.SetIfMissing(KnownHeaders.TraceState, activity.TraceStateString);
+        }
+
+        if (options.TimeToLive is { } ttl)
+            headers.Set(KnownHeaders.Expiration, DateTimeOffset.UtcNow.Add(ttl).ToString("O", CultureInfo.InvariantCulture));
+
+        return new TransportMessage
+        {
+            Body = _options.Serializer.SerializeToBytes(message),
+            Headers = headers.Build()
+        };
+    }
+
+    private static TransportSendOptions CreateSendOptions(PublishOptions options)
+    {
+        return new TransportSendOptions
+        {
+            Priority = options.Priority,
+            DeliverAt = options.DeliverAt ?? (options.Delay is { } delay ? DateTimeOffset.UtcNow.Add(delay) : null),
+            DeduplicationId = options.DeduplicationId
+        };
+    }
+
+    private string GetTopic(Type messageType, string? topic)
+    {
+        return !String.IsNullOrEmpty(topic)
+            ? topic
+            : (_options.TopicResolver?.Invoke(messageType) ?? ToKebabCase(messageType.Name));
+    }
+
+    private string GetSubscription(Type messageType, string topic, string? subscription)
+    {
+        return !String.IsNullOrEmpty(subscription)
+            ? subscription
+            : (_options.SubscriptionResolver?.Invoke(messageType, topic) ?? $"{topic}.{ToKebabCase(messageType.Name)}");
+    }
+
+    private string GetMessageType(Type messageType)
+    {
+        return _options.MessageTypeResolver?.Invoke(messageType) ?? messageType.FullName ?? messageType.Name;
+    }
+
+    private async Task DeadLetterPoisonMessageAsync(TransportEntry entry, string reason, CancellationToken cancellationToken)
+    {
+        if (_transport is ISupportsDeadLetter deadLetter)
+            await deadLetter.DeadLetterAsync(entry, reason, cancellationToken).AnyContext();
+        else
+            await _transport.AbandonAsync(entry, cancellationToken).AnyContext();
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _isDisposed) == 1, this);
+    }
+
+    private static string ToKebabCase(string value)
+    {
+        if (String.IsNullOrEmpty(value))
+            return value;
+
+        Span<char> buffer = stackalloc char[value.Length * 2];
+        int position = 0;
+        for (int index = 0; index < value.Length; index++)
+        {
+            char current = value[index];
+            if (Char.IsUpper(current))
+            {
+                if (index > 0)
+                    buffer[position++] = '-';
+
+                buffer[position++] = Char.ToLowerInvariant(current);
+            }
+            else
+            {
+                buffer[position++] = current;
+            }
+        }
+
+        return new String(buffer[..position]);
+    }
+}

--- a/src/Foundatio/Queues/MessageQueue.cs
+++ b/src/Foundatio/Queues/MessageQueue.cs
@@ -1,0 +1,399 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Foundatio.Messaging;
+using Foundatio.Serializer;
+using Foundatio.Utility;
+
+namespace Foundatio.Queues;
+
+public enum AckMode
+{
+    Auto,
+    Manual
+}
+
+public sealed record EnqueueOptions
+{
+    public MessagePriority Priority { get; init; } = MessagePriority.Normal;
+    public TimeSpan? Delay { get; init; }
+    public DateTimeOffset? DeliverAt { get; init; }
+    public TimeSpan? TimeToLive { get; init; }
+    public string? CorrelationId { get; init; }
+    public string? DeduplicationId { get; init; }
+    public string? Destination { get; init; }
+    public MessageHeaders? Headers { get; init; }
+}
+
+public sealed record ReceiveOptions
+{
+    public string? Source { get; init; }
+    public TimeSpan? MaxWaitTime { get; init; } = TimeSpan.FromSeconds(30);
+}
+
+public sealed record WorkerOptions
+{
+    public AckMode AckMode { get; init; } = AckMode.Auto;
+    public string? Source { get; init; }
+    public int MaxConcurrency { get; init; } = 1;
+    public int MaxAttempts { get; init; } = 5;
+    public Func<int, TimeSpan>? RedeliveryBackoff { get; init; }
+}
+
+public sealed record MessageQueueOptions
+{
+    public ISerializer Serializer { get; init; } = DefaultSerializer.Instance;
+    public string ContentType { get; init; } = "application/json";
+    public Func<Type, string>? DestinationResolver { get; init; }
+    public Func<Type, string>? MessageTypeResolver { get; init; }
+}
+
+public interface IMessageQueue : IAsyncDisposable
+{
+    Task<string> EnqueueAsync<T>(T message, EnqueueOptions? options = null, CancellationToken cancellationToken = default) where T : class;
+    Task EnqueueBatchAsync<T>(IEnumerable<T> messages, EnqueueOptions? options = null, CancellationToken cancellationToken = default) where T : class;
+    Task<IReceivedMessage<T>?> ReceiveAsync<T>(ReceiveOptions? options = null, CancellationToken cancellationToken = default) where T : class;
+    Task StartWorkingAsync<T>(Func<IReceivedMessage<T>, CancellationToken, Task> handler, WorkerOptions? options = null, CancellationToken cancellationToken = default) where T : class;
+}
+
+public interface IReceivedMessage<out T> where T : class
+{
+    T Message { get; }
+    string Id { get; }
+    MessageHeaders Headers { get; }
+    string? CorrelationId { get; }
+    string? MessageType { get; }
+    MessagePriority Priority { get; }
+    int Attempts { get; }
+    bool IsHandled { get; }
+    CancellationToken CancellationToken { get; }
+    Task CompleteAsync(CancellationToken cancellationToken = default);
+    Task RejectAsync(bool retry = true, string? reason = null, CancellationToken cancellationToken = default);
+    Task DeadLetterAsync(string? reason = null, CancellationToken cancellationToken = default);
+    Task RenewLockAsync(TimeSpan? duration = null, CancellationToken cancellationToken = default);
+    Task ReportProgressAsync(int? percent = null, string? message = null, CancellationToken cancellationToken = default);
+}
+
+public sealed class MessageQueue : IMessageQueue
+{
+    private readonly IMessageTransport _transport;
+    private readonly MessageQueueOptions _options;
+    private int _isDisposed;
+
+    public MessageQueue(IMessageTransport transport, MessageQueueOptions? options = null)
+    {
+        _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+        _options = options ?? new MessageQueueOptions();
+    }
+
+    public async Task<string> EnqueueAsync<T>(T message, EnqueueOptions? options = null, CancellationToken cancellationToken = default) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        ThrowIfDisposed();
+
+        options ??= new EnqueueOptions();
+        string destination = GetDestination(typeof(T), options.Destination);
+        var result = await _transport.SendAsync(destination, [CreateTransportMessage(message, options)], CreateSendOptions(options), cancellationToken).AnyContext();
+        var item = result.Items.Count > 0 ? result.Items[0] : null;
+
+        if (item is null || !item.Success)
+            throw new QueueException($"Unable to enqueue message to \"{destination}\": {item?.ErrorCode ?? "unknown error"}");
+
+        return item.MessageId ?? throw new QueueException($"Transport did not return a message id for \"{destination}\".");
+    }
+
+    public async Task EnqueueBatchAsync<T>(IEnumerable<T> messages, EnqueueOptions? options = null, CancellationToken cancellationToken = default) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+        ThrowIfDisposed();
+
+        options ??= new EnqueueOptions();
+        string destination = GetDestination(typeof(T), options.Destination);
+        var transportMessages = messages.Select(message =>
+        {
+            ArgumentNullException.ThrowIfNull(message);
+            return CreateTransportMessage(message, options);
+        }).ToArray();
+
+        if (transportMessages.Length == 0)
+            return;
+
+        var result = await _transport.SendAsync(destination, transportMessages, CreateSendOptions(options), cancellationToken).AnyContext();
+        if (!result.AllSucceeded)
+            throw new QueueException($"Unable to enqueue {result.Items.Count(i => !i.Success)} of {result.Items.Count} messages to \"{destination}\".");
+    }
+
+    public async Task<IReceivedMessage<T>?> ReceiveAsync<T>(ReceiveOptions? options = null, CancellationToken cancellationToken = default) where T : class
+    {
+        ThrowIfDisposed();
+
+        if (_transport is not ISupportsPull pull)
+            throw new QueueException($"Transport \"{_transport.GetType().Name}\" does not support pull receive.");
+
+        options ??= new ReceiveOptions();
+        string source = GetDestination(typeof(T), options.Source);
+        var entries = await pull.ReceiveAsync(source, new ReceiveRequest
+        {
+            MaxMessages = 1,
+            MaxWaitTime = options.MaxWaitTime
+        }, cancellationToken).AnyContext();
+
+        if (entries.Count == 0)
+            return null;
+
+        return await CreateReceivedMessageAsync<T>(entries[0], cancellationToken).AnyContext();
+    }
+
+    public async Task StartWorkingAsync<T>(Func<IReceivedMessage<T>, CancellationToken, Task> handler, WorkerOptions? options = null, CancellationToken cancellationToken = default) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        ThrowIfDisposed();
+
+        options ??= new WorkerOptions();
+        string source = GetDestination(typeof(T), options.Source);
+
+        if (_transport is ISupportsPush push)
+        {
+            await using var subscription = await push.SubscribeAsync(source, async (entry, token) =>
+            {
+                var received = await CreateReceivedMessageAsync<T>(entry, token).AnyContext();
+                await HandleMessageAsync(received, handler, options, token).AnyContext();
+            }, new PushOptions { MaxConcurrentMessages = Math.Max(1, options.MaxConcurrency) }, cancellationToken).AnyContext();
+
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).AnyContext();
+            return;
+        }
+
+        if (_transport is not ISupportsPull pull)
+            throw new QueueException($"Transport \"{_transport.GetType().Name}\" does not support receiving messages.");
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var entries = await pull.ReceiveAsync(source, new ReceiveRequest
+            {
+                MaxMessages = Math.Max(1, options.MaxConcurrency),
+                MaxWaitTime = TimeSpan.FromSeconds(1)
+            }, cancellationToken).AnyContext();
+
+            foreach (var entry in entries)
+            {
+                var received = await CreateReceivedMessageAsync<T>(entry, cancellationToken).AnyContext();
+                await HandleMessageAsync(received, handler, options, cancellationToken).AnyContext();
+            }
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _isDisposed, 1) == 1)
+            return ValueTask.CompletedTask;
+
+        return _transport.DisposeAsync();
+    }
+
+    private async Task<IReceivedMessage<T>> CreateReceivedMessageAsync<T>(TransportEntry entry, CancellationToken ct) where T : class
+    {
+        try
+        {
+            var message = _options.Serializer.Deserialize<T>(entry.Body);
+            if (message is null)
+                throw new QueueException($"Message \"{entry.Id}\" deserialized to null.");
+
+            return new ReceivedMessage<T>(_transport, entry, message, ct);
+        }
+        catch (Exception ex) when (ex is not QueueException)
+        {
+            await DeadLetterPoisonMessageAsync(entry, "deserialize-failure", ct).AnyContext();
+            throw new QueueException($"Unable to deserialize message \"{entry.Id}\".", ex);
+        }
+        catch (QueueException)
+        {
+            await DeadLetterPoisonMessageAsync(entry, "deserialize-failure", ct).AnyContext();
+            throw;
+        }
+    }
+
+    private async Task HandleMessageAsync<T>(IReceivedMessage<T> message, Func<IReceivedMessage<T>, CancellationToken, Task> handler, WorkerOptions options, CancellationToken ct) where T : class
+    {
+        try
+        {
+            await handler(message, ct).AnyContext();
+
+            if (options.AckMode == AckMode.Auto && !message.IsHandled)
+                await message.CompleteAsync(ct).AnyContext();
+        }
+        catch
+        {
+            if (!message.IsHandled)
+                await message.RejectAsync(message.Attempts < options.MaxAttempts, "handler-error", ct).AnyContext();
+        }
+    }
+
+    private TransportMessage CreateTransportMessage<T>(T message, EnqueueOptions options) where T : class
+    {
+        var headers = (options.Headers ?? MessageHeaders.Empty).ToBuilder()
+            .Set(KnownHeaders.MessageType, GetMessageType(typeof(T)))
+            .Set(KnownHeaders.ContentType, _options.ContentType)
+            .Set(KnownHeaders.Priority, options.Priority.ToString());
+
+        if (!String.IsNullOrEmpty(options.CorrelationId))
+            headers.Set(KnownHeaders.CorrelationId, options.CorrelationId);
+
+        if (Activity.Current is { } activity)
+        {
+            if (!String.IsNullOrEmpty(activity.Id))
+                headers.SetIfMissing(KnownHeaders.TraceParent, activity.Id);
+
+            if (!String.IsNullOrEmpty(activity.TraceStateString))
+                headers.SetIfMissing(KnownHeaders.TraceState, activity.TraceStateString);
+        }
+
+        if (options.TimeToLive is { } ttl)
+            headers.Set(KnownHeaders.Expiration, DateTimeOffset.UtcNow.Add(ttl).ToString("O", CultureInfo.InvariantCulture));
+
+        return new TransportMessage
+        {
+            Body = _options.Serializer.SerializeToBytes(message),
+            Headers = headers.Build()
+        };
+    }
+
+    private static TransportSendOptions CreateSendOptions(EnqueueOptions options)
+    {
+        return new TransportSendOptions
+        {
+            Priority = options.Priority,
+            DeliverAt = options.DeliverAt ?? (options.Delay is { } delay ? DateTimeOffset.UtcNow.Add(delay) : null),
+            DeduplicationId = options.DeduplicationId
+        };
+    }
+
+    private string GetDestination(Type messageType, string? destination)
+    {
+        return !String.IsNullOrEmpty(destination)
+            ? destination
+            : (_options.DestinationResolver?.Invoke(messageType) ?? ToKebabCase(messageType.Name));
+    }
+
+    private string GetMessageType(Type messageType)
+    {
+        return _options.MessageTypeResolver?.Invoke(messageType) ?? messageType.FullName ?? messageType.Name;
+    }
+
+    private async Task DeadLetterPoisonMessageAsync(TransportEntry entry, string reason, CancellationToken ct)
+    {
+        if (_transport is ISupportsDeadLetter deadLetter)
+            await deadLetter.DeadLetterAsync(entry, reason, ct).AnyContext();
+        else
+            await _transport.AbandonAsync(entry, ct).AnyContext();
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _isDisposed) == 1, this);
+    }
+
+    private static string ToKebabCase(string value)
+    {
+        if (String.IsNullOrEmpty(value))
+            return value;
+
+        Span<char> buffer = stackalloc char[value.Length * 2];
+        int position = 0;
+        for (int index = 0; index < value.Length; index++)
+        {
+            char current = value[index];
+            if (Char.IsUpper(current))
+            {
+                if (index > 0)
+                    buffer[position++] = '-';
+
+                buffer[position++] = Char.ToLowerInvariant(current);
+            }
+            else
+            {
+                buffer[position++] = current;
+            }
+        }
+
+        return new String(buffer[..position]);
+    }
+}
+
+internal sealed class ReceivedMessage<T> : IReceivedMessage<T> where T : class
+{
+    private readonly IMessageTransport _transport;
+    private readonly TransportEntry _entry;
+    private int _isHandled;
+
+    public ReceivedMessage(IMessageTransport transport, TransportEntry entry, T message, CancellationToken cancellationToken)
+    {
+        _transport = transport;
+        _entry = entry;
+        Message = message;
+        CancellationToken = cancellationToken;
+    }
+
+    public T Message { get; }
+    public string Id => _entry.Id;
+    public MessageHeaders Headers => _entry.Headers;
+    public string? CorrelationId => Headers.GetValueOrDefault(KnownHeaders.CorrelationId);
+    public string? MessageType => Headers.GetValueOrDefault(KnownHeaders.MessageType);
+    public MessagePriority Priority => Enum.TryParse(Headers.GetValueOrDefault(KnownHeaders.Priority), ignoreCase: true, out MessagePriority priority) ? priority : MessagePriority.Normal;
+    public int Attempts => _entry.DeliveryCount;
+    public bool IsHandled => Volatile.Read(ref _isHandled) == 1;
+    public CancellationToken CancellationToken { get; }
+
+    public Task CompleteAsync(CancellationToken cancellationToken = default)
+    {
+        if (!TryMarkHandled())
+            return Task.CompletedTask;
+
+        return _transport.CompleteAsync(_entry, cancellationToken);
+    }
+
+    public Task RejectAsync(bool retry = true, string? reason = null, CancellationToken cancellationToken = default)
+    {
+        return retry ? AbandonAsync(cancellationToken) : DeadLetterAsync(reason, cancellationToken);
+    }
+
+    public async Task DeadLetterAsync(string? reason = null, CancellationToken cancellationToken = default)
+    {
+        if (!TryMarkHandled())
+            return;
+
+        if (_transport is ISupportsDeadLetter deadLetter)
+            await deadLetter.DeadLetterAsync(_entry, reason, cancellationToken).AnyContext();
+        else
+            await _transport.AbandonAsync(_entry, cancellationToken).AnyContext();
+    }
+
+    public Task RenewLockAsync(TimeSpan? duration = null, CancellationToken cancellationToken = default)
+    {
+        return _transport is ISupportsLockRenewal lockRenewal
+            ? lockRenewal.RenewLockAsync(_entry, duration, cancellationToken)
+            : Task.CompletedTask;
+    }
+
+    public Task ReportProgressAsync(int? percent = null, string? message = null, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
+    private Task AbandonAsync(CancellationToken ct)
+    {
+        if (!TryMarkHandled())
+            return Task.CompletedTask;
+
+        return _transport.AbandonAsync(_entry, ct);
+    }
+
+    private bool TryMarkHandled()
+    {
+        return Interlocked.CompareExchange(ref _isHandled, 1, 0) == 0;
+    }
+}

--- a/tests/Foundatio.Tests/Jobs/JobRuntimeTests.cs
+++ b/tests/Foundatio.Tests/Jobs/JobRuntimeTests.cs
@@ -1,0 +1,224 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Foundatio.Jobs;
+using Foundatio.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Foundatio.Tests.Jobs;
+
+public class JobRuntimeTests
+{
+    [Fact]
+    public async Task CreateIfAbsentAsync_WithExistingJob_DoesNotOverwriteStateAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var store = new InMemoryJobRuntimeStore();
+
+        await store.CreateIfAbsentAsync(new JobState
+        {
+            JobId = "job-1",
+            Name = "first",
+            Status = JobStatus.Queued
+        }, cancellationToken);
+
+        await store.CreateIfAbsentAsync(new JobState
+        {
+            JobId = "job-1",
+            Name = "second",
+            Status = JobStatus.Failed,
+            Error = "should not overwrite"
+        }, cancellationToken);
+
+        var state = await store.GetAsync("job-1", cancellationToken);
+
+        Assert.NotNull(state);
+        Assert.Equal("first", state.Name);
+        Assert.Equal(JobStatus.Queued, state.Status);
+        Assert.Null(state.Error);
+    }
+
+    [Fact]
+    public async Task TryClaimAsync_WhenLeaseIsHeldByAnotherNode_ReturnsFalseUntilLeaseExpiresAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var store = new InMemoryJobRuntimeStore();
+
+        await store.CreateIfAbsentAsync(new JobState
+        {
+            JobId = "job-1",
+            Name = "test",
+            Status = JobStatus.Queued
+        }, cancellationToken);
+
+        Assert.True(await store.TryClaimAsync("job-1", "node-a", TimeSpan.FromMinutes(1), cancellationToken));
+        Assert.False(await store.TryClaimAsync("job-1", "node-b", TimeSpan.FromMinutes(1), cancellationToken));
+        Assert.True(await store.ReleaseClaimAsync("job-1", "node-a", cancellationToken));
+        Assert.True(await store.TryClaimAsync("job-1", "node-b", TimeSpan.FromMinutes(1), cancellationToken));
+
+        var state = await store.GetAsync("job-1", cancellationToken);
+        Assert.NotNull(state);
+        Assert.Equal("node-b", state.NodeId);
+        Assert.NotNull(state.LeaseExpiresUtc);
+    }
+
+    [Fact]
+    public async Task ClaimDueDispatchesAsync_ClaimsReleasesAndCompletesDueDispatchesAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var store = new InMemoryJobRuntimeStore();
+        var now = DateTimeOffset.UtcNow;
+
+        await store.ScheduleDispatchAsync(new ScheduledDispatchState
+        {
+            DispatchId = "dispatch-1",
+            Kind = ScheduledDispatchKind.QueueMessage,
+            Destination = "work",
+            Body = "hello"u8.ToArray(),
+            DueUtc = now.AddSeconds(-1)
+        }, cancellationToken);
+
+        await store.ScheduleDispatchAsync(new ScheduledDispatchState
+        {
+            DispatchId = "dispatch-2",
+            Kind = ScheduledDispatchKind.QueueMessage,
+            Destination = "work",
+            Body = "later"u8.ToArray(),
+            DueUtc = now.AddHours(1)
+        }, cancellationToken);
+
+        var claimed = await store.ClaimDueDispatchesAsync(now, 10, "node-a", TimeSpan.FromMinutes(1), cancellationToken);
+
+        var dispatch = Assert.Single(claimed);
+        Assert.Equal("dispatch-1", dispatch.DispatchId);
+        Assert.Equal("node-a", dispatch.ClaimOwner);
+        Assert.Equal(1, dispatch.Attempts);
+
+        var claimedAgain = await store.ClaimDueDispatchesAsync(now, 10, "node-b", TimeSpan.FromMinutes(1), cancellationToken);
+        Assert.Empty(claimedAgain);
+
+        await store.ReleaseDispatchAsync("dispatch-1", "node-a", now.AddSeconds(-1), cancellationToken);
+
+        var reclaimed = await store.ClaimDueDispatchesAsync(now, 10, "node-b", TimeSpan.FromMinutes(1), cancellationToken);
+        dispatch = Assert.Single(reclaimed);
+        Assert.Equal("node-b", dispatch.ClaimOwner);
+        Assert.Equal(2, dispatch.Attempts);
+
+        await store.CompleteDispatchAsync("dispatch-1", "node-b", cancellationToken);
+
+        var afterComplete = await store.ClaimDueDispatchesAsync(now, 10, "node-c", TimeSpan.FromMinutes(1), cancellationToken);
+        Assert.Empty(afterComplete);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenJobSucceeds_TracksCompletedStateAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var store = new InMemoryJobRuntimeStore();
+        var probe = new JobRuntimeProbe();
+        await using var serviceProvider = new ServiceCollection()
+            .AddSingleton(probe)
+            .BuildServiceProvider();
+        var client = new JobClient(store, serviceProvider, nodeId: "node-a");
+
+        string jobId = await client.RunAsync<SuccessfulTrackedJob>(new RunJobOptions { JobId = "job-1" }, cancellationToken);
+
+        var state = await client.GetAsync(jobId, cancellationToken);
+        Assert.NotNull(state);
+        Assert.Equal(1, probe.RunCount);
+        Assert.Equal(JobStatus.Completed, state.Status);
+        Assert.Equal(1, state.Attempt);
+        Assert.Equal(100, state.Progress);
+        Assert.NotNull(state.StartedUtc);
+        Assert.NotNull(state.CompletedUtc);
+        Assert.Null(state.NodeId);
+        Assert.Null(state.LeaseExpiresUtc);
+    }
+
+    [Fact]
+    public async Task RequestCancellationAsync_WhenJobIsRunning_CancelsAndTracksStateAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var store = new InMemoryJobRuntimeStore();
+        var probe = new JobRuntimeProbe();
+        await using var serviceProvider = new ServiceCollection()
+            .AddSingleton(probe)
+            .BuildServiceProvider();
+        var client = new JobClient(store, serviceProvider, nodeId: "node-a");
+
+        var runTask = client.RunAsync<CancellableTrackedJob>(new RunJobOptions { JobId = "job-1" }, cancellationToken);
+        await probe.Started.Task.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+
+        Assert.True(await client.RequestCancellationAsync("job-1", cancellationToken));
+
+        await probe.Cancelled.Task.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+        string jobId = await runTask.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+        var state = await client.GetAsync(jobId, cancellationToken);
+
+        Assert.NotNull(state);
+        Assert.Equal(JobStatus.Cancelled, state.Status);
+        Assert.True(state.CancellationRequested);
+        Assert.NotNull(state.CompletedUtc);
+        Assert.Null(state.NodeId);
+        Assert.Null(state.LeaseExpiresUtc);
+    }
+
+    private sealed class JobRuntimeProbe
+    {
+        private int _runCount;
+
+        public TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Cancelled { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int RunCount => Volatile.Read(ref _runCount);
+
+        public void RecordRun()
+        {
+            Interlocked.Increment(ref _runCount);
+        }
+    }
+
+    private sealed class SuccessfulTrackedJob : IJob
+    {
+        private readonly JobRuntimeProbe _probe;
+
+        public SuccessfulTrackedJob(JobRuntimeProbe probe)
+        {
+            _probe = probe;
+        }
+
+        public Task<JobResult> RunAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            _probe.RecordRun();
+            return Task.FromResult(JobResult.Success);
+        }
+    }
+
+    private sealed class CancellableTrackedJob : IJob
+    {
+        private readonly JobRuntimeProbe _probe;
+
+        public CancellableTrackedJob(JobRuntimeProbe probe)
+        {
+            _probe = probe;
+        }
+
+        public async Task<JobResult> RunAsync(CancellationToken cancellationToken = default)
+        {
+            _probe.Started.TrySetResult();
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
+                return JobResult.Success;
+            }
+            catch (OperationCanceledException)
+            {
+                _probe.Cancelled.TrySetResult();
+                throw;
+            }
+        }
+    }
+}

--- a/tests/Foundatio.Tests/Jobs/JobSchedulerTests.cs
+++ b/tests/Foundatio.Tests/Jobs/JobSchedulerTests.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Foundatio.Jobs;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Foundatio.Tests.Jobs;
+
+public class JobSchedulerTests
+{
+    [Fact]
+    public async Task EnqueueDueOccurrencesAsync_WhenOccurrenceIsDue_CreatesSingleGlobalOccurrenceAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var scheduler = new InMemoryJobScheduler();
+        var store = new InMemoryJobRuntimeStore();
+        var processor = CreateProcessor(scheduler, store, "node-a");
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 30, TimeSpan.Zero);
+
+        await scheduler.ScheduleAsync(new ScheduledJobDefinition
+        {
+            Name = "nightly",
+            Cron = "* * * * *",
+            JobType = typeof(ScheduledProbeJob)
+        }, cancellationToken);
+
+        var first = await processor.EnqueueDueOccurrencesAsync(now, cancellationToken);
+        var second = await processor.EnqueueDueOccurrencesAsync(now, cancellationToken);
+
+        var dispatch = Assert.Single(first);
+        Assert.Empty(second);
+        Assert.Equal("nightly:20260101000000:global", dispatch.DispatchId);
+        Assert.Equal(ScheduledDispatchKind.JobOccurrence, dispatch.Kind);
+        Assert.Equal("nightly", dispatch.Headers["job.name"]);
+
+        var state = await store.GetAsync(dispatch.JobId!, cancellationToken);
+        Assert.NotNull(state);
+        Assert.Equal(JobStatus.Scheduled, state.Status);
+        Assert.Equal(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero), state.ScheduledForUtc);
+    }
+
+    [Fact]
+    public async Task RunDueOccurrencesAsync_WhenOccurrenceIsDue_RunsConfiguredJobAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var scheduler = new InMemoryJobScheduler();
+        var store = new InMemoryJobRuntimeStore();
+        var probe = new JobSchedulerProbe();
+        await using var serviceProvider = new ServiceCollection()
+            .AddSingleton(probe)
+            .BuildServiceProvider();
+        var client = new JobClient(store, serviceProvider, nodeId: "node-a");
+        var processor = new JobScheduleProcessor(scheduler, store, client, nodeId: "node-a");
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 30, TimeSpan.Zero);
+
+        await scheduler.ScheduleAsync(new ScheduledJobDefinition
+        {
+            Name = "nightly",
+            Cron = "* * * * *",
+            JobType = typeof(ScheduledProbeJob)
+        }, cancellationToken);
+        var scheduled = await processor.EnqueueDueOccurrencesAsync(now, cancellationToken);
+
+        int completed = await processor.RunDueOccurrencesAsync(now, cancellationToken: cancellationToken);
+
+        var dispatch = Assert.Single(scheduled);
+        var state = await store.GetAsync(dispatch.JobId!, cancellationToken);
+        Assert.Equal(1, completed);
+        Assert.Equal(1, probe.RunCount);
+        Assert.NotNull(state);
+        Assert.Equal(JobStatus.Completed, state.Status);
+        Assert.Equal(1, state.Attempt);
+        Assert.Equal(100, state.Progress);
+    }
+
+    [Fact]
+    public async Task EnqueueDueOccurrencesAsync_WithPerNodeScope_CreatesOccurrencePerNodeAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var scheduler = new InMemoryJobScheduler();
+        var store = new InMemoryJobRuntimeStore();
+        var nodeA = CreateProcessor(scheduler, store, "node-a");
+        var nodeB = CreateProcessor(scheduler, store, "node-b");
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 30, TimeSpan.Zero);
+
+        await scheduler.ScheduleAsync(new ScheduledJobDefinition
+        {
+            Name = "per-node",
+            Cron = "* * * * *",
+            JobType = typeof(ScheduledProbeJob),
+            Scope = ScheduledJobScope.PerNode
+        }, cancellationToken);
+
+        var first = await nodeA.EnqueueDueOccurrencesAsync(now, cancellationToken);
+        var second = await nodeB.EnqueueDueOccurrencesAsync(now, cancellationToken);
+
+        Assert.Equal("per-node:20260101000000:node-a", Assert.Single(first).DispatchId);
+        Assert.Equal("per-node:20260101000000:node-b", Assert.Single(second).DispatchId);
+
+        var states = await store.QueryAsync(new JobQuery { Name = "per-node" }, cancellationToken);
+        Assert.Equal(2, states.Count);
+    }
+
+    [Fact]
+    public async Task EnqueueDueOccurrencesAsync_WithMisfireWindow_CatchesRecentMissedOccurrenceAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var scheduler = new InMemoryJobScheduler();
+        var store = new InMemoryJobRuntimeStore();
+        var processor = CreateProcessor(scheduler, store, "node-a");
+        var now = new DateTimeOffset(2026, 1, 1, 0, 5, 0, TimeSpan.Zero);
+
+        await scheduler.ScheduleAsync(new ScheduledJobDefinition
+        {
+            Name = "daily",
+            Cron = "0 0 * * *",
+            JobType = typeof(ScheduledProbeJob),
+            MisfireWindow = TimeSpan.FromMinutes(10)
+        }, cancellationToken);
+
+        var scheduled = await processor.EnqueueDueOccurrencesAsync(now, cancellationToken);
+
+        var dispatch = Assert.Single(scheduled);
+        var state = await store.GetAsync(dispatch.JobId!, cancellationToken);
+        Assert.NotNull(state);
+        Assert.Equal(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero), state.ScheduledForUtc);
+    }
+
+    [Fact]
+    public async Task RunDueOccurrencesAsync_WhenDispatchIsNotJobOccurrence_ReleasesItAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var scheduler = new InMemoryJobScheduler();
+        var store = new InMemoryJobRuntimeStore();
+        var processor = CreateProcessor(scheduler, store, "node-a");
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        await store.ScheduleDispatchAsync(new ScheduledDispatchState
+        {
+            DispatchId = "delayed-message",
+            Kind = ScheduledDispatchKind.QueueMessage,
+            Destination = "work",
+            Body = "hello"u8.ToArray(),
+            DueUtc = now
+        }, cancellationToken);
+
+        int completed = await processor.RunDueOccurrencesAsync(now, cancellationToken: cancellationToken);
+
+        Assert.Equal(0, completed);
+        var claimed = await store.ClaimDueDispatchesAsync(now, 10, "node-b", TimeSpan.FromMinutes(1), cancellationToken);
+        var dispatch = Assert.Single(claimed);
+        Assert.Equal("delayed-message", dispatch.DispatchId);
+        Assert.Equal("node-b", dispatch.ClaimOwner);
+    }
+    private static JobScheduleProcessor CreateProcessor(IJobScheduler scheduler, IJobRuntimeStore store, string nodeId)
+    {
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton(new JobSchedulerProbe())
+            .BuildServiceProvider();
+        var client = new JobClient(store, serviceProvider, nodeId: nodeId);
+        return new JobScheduleProcessor(scheduler, store, client, nodeId: nodeId);
+    }
+
+    private sealed class JobSchedulerProbe
+    {
+        private int _runCount;
+
+        public int RunCount => Volatile.Read(ref _runCount);
+
+        public void RecordRun()
+        {
+            Interlocked.Increment(ref _runCount);
+        }
+    }
+
+    private sealed class ScheduledProbeJob : IJob
+    {
+        private readonly JobSchedulerProbe _probe;
+
+        public ScheduledProbeJob(JobSchedulerProbe probe)
+        {
+            _probe = probe;
+        }
+
+        public Task<JobResult> RunAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            _probe.RecordRun();
+            return Task.FromResult(JobResult.Success);
+        }
+    }
+}

--- a/tests/Foundatio.Tests/Messaging/InMemoryMessageTransportTests.cs
+++ b/tests/Foundatio.Tests/Messaging/InMemoryMessageTransportTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Foundatio.Messaging;
+using Xunit;
+
+namespace Foundatio.Tests.Messaging;
+
+public class InMemoryMessageTransportTests : MessageTransportConformanceTests
+{
+    public InMemoryMessageTransportTests(ITestOutputHelper output) : base(output) { }
+
+    protected override IMessageTransport CreateTransport()
+    {
+        return new InMemoryMessageTransport();
+    }
+
+    [Fact]
+    public void MessageHeaders_AreImmutableAndCaseInsensitive()
+    {
+        var source = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["message.type"] = "order.created"
+        };
+
+        var headers = MessageHeaders.Create(source);
+        source["message.type"] = "changed";
+
+        Assert.Equal("order.created", headers["MESSAGE.TYPE"]);
+        Assert.Equal("order.created", headers.GetValueOrDefault("Message.Type"));
+        Assert.True(headers.ContainsKey("MESSAGE.TYPE"));
+
+        var updated = headers.ToBuilder()
+            .Set("TraceParent", "00-123")
+            .SetIfMissing("traceparent", "ignored")
+            .Build();
+
+        Assert.Equal("00-123", updated["traceparent"]);
+        Assert.False(headers.ContainsKey("traceparent"));
+    }
+
+    [Fact]
+    public override Task CanSendAndReceiveBatchAsync()
+    {
+        return base.CanSendAndReceiveBatchAsync();
+    }
+
+    [Fact]
+    public override Task AbandonAsync_RedeliversWithIncrementedDeliveryCountAsync()
+    {
+        return base.AbandonAsync_RedeliversWithIncrementedDeliveryCountAsync();
+    }
+
+    [Fact]
+    public override Task CompleteAsync_WithExpiredReceipt_ThrowsReceiptExpiredExceptionAsync()
+    {
+        return base.CompleteAsync_WithExpiredReceipt_ThrowsReceiptExpiredExceptionAsync();
+    }
+
+    [Fact]
+    public override Task SubscribeAsync_DeliversPushMessagesAsync()
+    {
+        return base.SubscribeAsync_DeliversPushMessagesAsync();
+    }
+
+    [Fact]
+    public override Task SendAsync_ToTopic_FansOutToSubscriptionsAsync()
+    {
+        return base.SendAsync_ToTopic_FansOutToSubscriptionsAsync();
+    }
+
+    [Fact]
+    public override Task ReceiveAsync_RespectsPriorityAsync()
+    {
+        return base.ReceiveAsync_RespectsPriorityAsync();
+    }
+
+    [Fact]
+    public override Task SendAsync_WithDeliverAt_DelaysVisibilityAsync()
+    {
+        return base.SendAsync_WithDeliverAt_DelaysVisibilityAsync();
+    }
+
+    [Fact]
+    public override Task DeadLetterAsync_MovesEntryToDeadletterStatsAsync()
+    {
+        return base.DeadLetterAsync_MovesEntryToDeadletterStatsAsync();
+    }
+
+    [Fact]
+    public override Task ReceiveAsync_WithExpiredMessage_DeadlettersAndSkipsAsync()
+    {
+        return base.ReceiveAsync_WithExpiredMessage_DeadlettersAndSkipsAsync();
+    }
+}

--- a/tests/Foundatio.Tests/Messaging/PubSubTests.cs
+++ b/tests/Foundatio.Tests/Messaging/PubSubTests.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Foundatio.AsyncEx;
+using Foundatio.Messaging;
+using Foundatio.Queues;
+using Foundatio.Tests.Extensions;
+using Xunit;
+
+namespace Foundatio.Tests.Messaging;
+
+public class PubSubTests
+{
+    [Fact]
+    public async Task PublishAsync_FansOutToMultipleSubscriptionsAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var transport = new InMemoryMessageTransport();
+        await using var pubSub = new PubSub(transport);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(10));
+
+        var firstReceived = new AsyncCountdownEvent(1);
+        var secondReceived = new AsyncCountdownEvent(1);
+
+        var first = pubSub.SubscribeAsync<PreviewEvent>((message, _) =>
+        {
+            Assert.Equal("published", message.Message.Data);
+            firstReceived.Signal();
+            return Task.CompletedTask;
+        }, new SubscriptionOptions { Subscription = "subscriber-a" }, cts.Token);
+
+        var second = pubSub.SubscribeAsync<PreviewEvent>((message, _) =>
+        {
+            Assert.Equal("published", message.Message.Data);
+            secondReceived.Signal();
+            return Task.CompletedTask;
+        }, new SubscriptionOptions { Subscription = "subscriber-b" }, cts.Token);
+
+        await pubSub.PublishAsync(new PreviewEvent { Data = "published" }, cancellationToken: cancellationToken);
+
+        await firstReceived.WaitAsync(TimeSpan.FromSeconds(2));
+        await secondReceived.WaitAsync(TimeSpan.FromSeconds(2));
+        await cts.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await first);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await second);
+
+        var firstStats = await transport.GetStatsAsync("subscriber-a", cancellationToken);
+        var secondStats = await transport.GetStatsAsync("subscriber-b", cancellationToken);
+        Assert.Equal(1, firstStats.Completed);
+        Assert.Equal(1, secondStats.Completed);
+    }
+
+    [Fact]
+    public async Task PublishBatchAsync_DeliversAllMessagesAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var transport = new InMemoryMessageTransport();
+        await using var pubSub = new PubSub(transport);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(10));
+        var received = new AsyncCountdownEvent(2);
+
+        var subscription = pubSub.SubscribeAsync<PreviewEvent>((message, _) =>
+        {
+            Assert.StartsWith("batch-", message.Message.Data);
+            received.Signal();
+            return Task.CompletedTask;
+        }, new SubscriptionOptions { Subscription = "batch-subscription" }, cts.Token);
+
+        await pubSub.PublishBatchAsync([
+            new PreviewEvent { Data = "batch-one" },
+            new PreviewEvent { Data = "batch-two" }
+        ], cancellationToken: cancellationToken);
+
+        await received.WaitAsync(TimeSpan.FromSeconds(2));
+        await cts.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await subscription);
+
+        var stats = await transport.GetStatsAsync("batch-subscription", cancellationToken);
+        Assert.Equal(2, stats.Completed);
+    }
+
+    [Fact]
+    public async Task PublishAsync_WithOptions_PropagatesHeadersAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var pubSub = new PubSub(new InMemoryMessageTransport());
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(10));
+        var received = new TaskCompletionSource<IReceivedMessage<PreviewEvent>>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var subscription = pubSub.SubscribeAsync<PreviewEvent>((message, _) =>
+        {
+            received.TrySetResult(message);
+            return Task.CompletedTask;
+        }, new SubscriptionOptions { Subscription = "metadata-subscription" }, cts.Token);
+
+        await pubSub.PublishAsync(new PreviewEvent { Data = "metadata" }, new PublishOptions
+        {
+            CorrelationId = "corr-456",
+            Priority = MessagePriority.High,
+            Headers = MessageHeaders.Create([
+                new KeyValuePair<string, string>("tenant", "acme")
+            ])
+        }, cancellationToken);
+
+        var completed = await Task.WhenAny(received.Task, Task.Delay(TimeSpan.FromSeconds(2), cancellationToken));
+        Assert.Equal(received.Task, completed);
+
+        var message = await received.Task;
+        Assert.Equal("metadata", message.Message.Data);
+        Assert.Equal("corr-456", message.CorrelationId);
+        Assert.Equal(MessagePriority.High, message.Priority);
+        Assert.Equal("acme", message.Headers["tenant"]);
+        Assert.Equal(typeof(PreviewEvent).FullName, message.MessageType);
+
+        await cts.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await subscription);
+    }
+
+    [Fact]
+    public async Task PublishAsync_WithDelay_DelaysDeliveryAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var pubSub = new PubSub(new InMemoryMessageTransport());
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(10));
+        var received = new AsyncCountdownEvent(1);
+
+        var subscription = pubSub.SubscribeAsync<PreviewEvent>((_, _) =>
+        {
+            received.Signal();
+            return Task.CompletedTask;
+        }, new SubscriptionOptions { Subscription = "delayed-subscription" }, cts.Token);
+
+        await pubSub.PublishAsync(new PreviewEvent { Data = "later" }, new PublishOptions { Delay = TimeSpan.FromMilliseconds(250) }, cancellationToken);
+
+        await Assert.ThrowsAsync<TimeoutException>(async () => await received.WaitAsync(TimeSpan.FromMilliseconds(50)));
+        await received.WaitAsync(TimeSpan.FromSeconds(2));
+
+        await cts.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await subscription);
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_WhenHandlerFails_RedeliversAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var transport = new InMemoryMessageTransport();
+        await using var pubSub = new PubSub(transport);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(10));
+        var received = new AsyncCountdownEvent(2);
+        int attempts = 0;
+
+        var subscription = pubSub.SubscribeAsync<PreviewEvent>((message, _) =>
+        {
+            attempts++;
+            Assert.Equal(attempts, message.Attempts);
+            received.Signal();
+
+            if (attempts == 1)
+                throw new InvalidOperationException("try again");
+
+            return Task.CompletedTask;
+        }, new SubscriptionOptions { Subscription = "retry-subscription", MaxAttempts = 2 }, cts.Token);
+
+        await pubSub.PublishAsync(new PreviewEvent { Data = "retry" }, cancellationToken: cancellationToken);
+
+        await received.WaitAsync(TimeSpan.FromSeconds(2));
+        await cts.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await subscription);
+
+        var stats = await transport.GetStatsAsync("retry-subscription", cancellationToken);
+        Assert.Equal(1, stats.Completed);
+        Assert.Equal(1, stats.Abandoned);
+    }
+
+    private sealed class PreviewEvent
+    {
+        public string? Data { get; set; }
+    }
+}

--- a/tests/Foundatio.Tests/Queue/MessageQueueTests.cs
+++ b/tests/Foundatio.Tests/Queue/MessageQueueTests.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Foundatio.AsyncEx;
+using Foundatio.Messaging;
+using Foundatio.Queues;
+using Foundatio.Tests.Extensions;
+using Xunit;
+
+namespace Foundatio.Tests.Queue;
+
+public class MessageQueueTests
+{
+    [Fact]
+    public async Task EnqueueAsync_WithOptions_CanReceiveAndCompleteAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var transport = new InMemoryMessageTransport();
+        await using var queue = new MessageQueue(transport);
+
+        string id = await queue.EnqueueAsync(new PreviewWorkItem { Data = "hello" }, new EnqueueOptions
+        {
+            CorrelationId = "corr-123",
+            Priority = MessagePriority.High,
+            Headers = MessageHeaders.Create([
+                new KeyValuePair<string, string>("tenant", "acme")
+            ])
+        }, cancellationToken);
+
+        var received = await queue.ReceiveAsync<PreviewWorkItem>(new ReceiveOptions { MaxWaitTime = TimeSpan.FromSeconds(1) }, cancellationToken);
+
+        Assert.NotNull(received);
+        Assert.Equal(id, received.Id);
+        Assert.Equal("hello", received.Message.Data);
+        Assert.Equal("corr-123", received.CorrelationId);
+        Assert.Equal(MessagePriority.High, received.Priority);
+        Assert.Equal(1, received.Attempts);
+        Assert.Equal("acme", received.Headers["tenant"]);
+        Assert.Equal(typeof(PreviewWorkItem).FullName, received.MessageType);
+
+        await received.CompleteAsync(cancellationToken);
+
+        var stats = await transport.GetStatsAsync("preview-work-item", cancellationToken);
+        Assert.Equal(1, stats.Completed);
+        Assert.Equal(0, stats.Working);
+    }
+
+    [Fact]
+    public async Task EnqueueBatchAsync_UsesDestinationOverrideAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var transport = new InMemoryMessageTransport();
+        await using var queue = new MessageQueue(transport);
+
+        await queue.EnqueueBatchAsync([
+            new PreviewWorkItem { Data = "one" },
+            new PreviewWorkItem { Data = "two" }
+        ], new EnqueueOptions { Destination = "custom-work" }, cancellationToken);
+
+        var first = await queue.ReceiveAsync<PreviewWorkItem>(new ReceiveOptions { Source = "custom-work", MaxWaitTime = TimeSpan.FromSeconds(1) }, cancellationToken);
+        var second = await queue.ReceiveAsync<PreviewWorkItem>(new ReceiveOptions { Source = "custom-work", MaxWaitTime = TimeSpan.FromSeconds(1) }, cancellationToken);
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.Equal("one", first.Message.Data);
+        Assert.Equal("two", second.Message.Data);
+
+        await first.CompleteAsync(cancellationToken);
+        await second.CompleteAsync(cancellationToken);
+    }
+
+    [Fact]
+    public async Task RejectAsync_WithRetry_RedeliversAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var queue = new MessageQueue(new InMemoryMessageTransport());
+        await queue.EnqueueAsync(new PreviewWorkItem { Data = "retry" }, cancellationToken: cancellationToken);
+
+        var first = await queue.ReceiveAsync<PreviewWorkItem>(new ReceiveOptions { MaxWaitTime = TimeSpan.FromSeconds(1) }, cancellationToken);
+        Assert.NotNull(first);
+
+        await first.RejectAsync(cancellationToken: cancellationToken);
+
+        var second = await queue.ReceiveAsync<PreviewWorkItem>(new ReceiveOptions { MaxWaitTime = TimeSpan.FromSeconds(1) }, cancellationToken);
+        Assert.NotNull(second);
+        Assert.Equal(first.Id, second.Id);
+        Assert.Equal(2, second.Attempts);
+        Assert.Equal("retry", second.Message.Data);
+
+        await second.CompleteAsync(cancellationToken);
+    }
+
+    [Fact]
+    public async Task RejectAsync_WithoutRetry_DeadLettersAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var transport = new InMemoryMessageTransport();
+        await using var queue = new MessageQueue(transport);
+
+        await queue.EnqueueAsync(new PreviewWorkItem { Data = "bad" }, cancellationToken: cancellationToken);
+        var message = await queue.ReceiveAsync<PreviewWorkItem>(new ReceiveOptions { MaxWaitTime = TimeSpan.FromSeconds(1) }, cancellationToken);
+        Assert.NotNull(message);
+
+        await message.RejectAsync(retry: false, reason: "validation", cancellationToken: cancellationToken);
+
+        var stats = await transport.GetStatsAsync("preview-work-item", cancellationToken);
+        Assert.Equal(1, stats.Deadletter);
+        Assert.Equal(0, stats.Working);
+    }
+
+    [Fact]
+    public async Task StartWorkingAsync_WithAutoAck_CompletesMessageAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var transport = new InMemoryMessageTransport();
+        await using var queue = new MessageQueue(transport);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(10));
+        var handled = new AsyncCountdownEvent(1);
+
+        var worker = queue.StartWorkingAsync<PreviewWorkItem>((message, _) =>
+        {
+            Assert.Equal("work", message.Message.Data);
+            handled.Signal();
+            return Task.CompletedTask;
+        }, cancellationToken: cts.Token);
+
+        await queue.EnqueueAsync(new PreviewWorkItem { Data = "work" }, cancellationToken: cts.Token);
+        await handled.WaitAsync(TimeSpan.FromSeconds(2));
+        await cts.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await worker);
+
+        var stats = await transport.GetStatsAsync("preview-work-item", cancellationToken);
+        Assert.Equal(1, stats.Completed);
+    }
+
+    [Fact]
+    public async Task EnqueueAsync_WithDelay_DelaysVisibilityAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var queue = new MessageQueue(new InMemoryMessageTransport());
+
+        await queue.EnqueueAsync(new PreviewWorkItem { Data = "later" }, new EnqueueOptions { Delay = TimeSpan.FromMilliseconds(250) }, cancellationToken);
+
+        var immediate = await queue.ReceiveAsync<PreviewWorkItem>(new ReceiveOptions { MaxWaitTime = TimeSpan.FromMilliseconds(50) }, cancellationToken);
+        Assert.Null(immediate);
+
+        var delayed = await queue.ReceiveAsync<PreviewWorkItem>(new ReceiveOptions { MaxWaitTime = TimeSpan.FromSeconds(2) }, cancellationToken);
+        Assert.NotNull(delayed);
+        Assert.Equal("later", delayed.Message.Data);
+        await delayed.CompleteAsync(cancellationToken);
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_WithExpiredMessage_DeadLettersAndReturnsNullAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var transport = new InMemoryMessageTransport();
+        await using var queue = new MessageQueue(transport);
+
+        await queue.EnqueueAsync(new PreviewWorkItem { Data = "expired" }, new EnqueueOptions { TimeToLive = TimeSpan.FromMilliseconds(-1) }, cancellationToken);
+
+        var received = await queue.ReceiveAsync<PreviewWorkItem>(new ReceiveOptions { MaxWaitTime = TimeSpan.FromMilliseconds(50) }, cancellationToken);
+        Assert.Null(received);
+
+        var stats = await transport.GetStatsAsync("preview-work-item", cancellationToken);
+        Assert.Equal(1, stats.Deadletter);
+    }
+
+    [Fact]
+    public async Task ReceiveAsync_WithPoisonPayload_DeadLettersAndThrowsQueueExceptionAsync()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var transport = new InMemoryMessageTransport();
+        await using var queue = new MessageQueue(transport);
+
+        await transport.SendAsync("preview-work-item", [
+            new TransportMessage
+            {
+                Body = "not-json"u8.ToArray(),
+                Headers = MessageHeaders.Create([
+                    new KeyValuePair<string, string>(KnownHeaders.MessageType, typeof(PreviewWorkItem).FullName!)
+                ])
+            }
+        ], new TransportSendOptions(), cancellationToken);
+
+        await Assert.ThrowsAsync<QueueException>(async () =>
+            await queue.ReceiveAsync<PreviewWorkItem>(new ReceiveOptions { MaxWaitTime = TimeSpan.FromSeconds(1) }, cancellationToken));
+
+        var stats = await transport.GetStatsAsync("preview-work-item", cancellationToken);
+        Assert.Equal(1, stats.Deadletter);
+        Assert.Equal(0, stats.Working);
+    }
+
+    private sealed class PreviewWorkItem
+    {
+        public string? Data { get; set; }
+    }
+}


### PR DESCRIPTION
# Foundatio Messaging & Jobs — Breaking Redesign

A clean, breaking (major-version) rewrite of Foundatio's queue, pub/sub (`IMessageBus`), work-item, and CRON-job abstractions into one coherent messaging + durable-jobs core. The current abstractions are single-type, poll-based, allocation-heavy, hard to implement transports for, and lack durable job state and durable scheduling. The new design moves all the hard parts into core, keeps transports tiny (bytes + headers), and unifies queues, pub/sub, and jobs on one substrate. This is still a **major-version replacement** for the prime `Foundatio.Queues` / `Foundatio.Messaging` / `Foundatio.Jobs` abstractions, but it should be delivered as a **gated phased rollout**, not a single big rewrite. The public replacement should be cut only after the transport substrate, conformance harness, and at least one real external provider mapping have proven the design.

## Approach — expose messaging *patterns*, not a generic bus

Foundatio deliberately does **not** try to be a generic, do-everything message bus or broker abstraction. It exposes the **messaging patterns the vast majority of apps actually use** — **work queues** (competing consumers; at-least-once; ack/retry/dead-letter) and **pub/sub** (fan-out) — plus **durable jobs and scheduling** built on the same substrate, as the first-class abstractions.

This is a deliberate departure from existing messaging libraries. Those tend to be extremely generic and highly configurable — powerful, but the team finds it genuinely hard and confusing to figure out how to implement the super-common patterns most apps need; the flexibility comes at the expense of approachability for the common case. Foundatio inverts that trade-off: **the common patterns *are* the API and are obvious to use**, transports stay swappable underneath, and advanced needs are met by clearly-scoped, opt-in capabilities rather than up-front configuration. Everything in this design serves that goal — which is also why the hard parts (serialization, routing, multi-type dispatch, priority, retry/dead-letter, back-pressure, durable scheduling) live in core and transports stay tiny.

---

# Part 1 — Shortcomings of the current library

(Verified against `src/Foundatio` and `src/Foundatio.Extensions.Hosting`.)

## 1. One message type per queue/topic
`IQueue<T>` is generic over a single CLR type; `IMessageBus` routes by `Type` with one `Topic` per bus instance — one queue/topic ⇒ one .NET type. No polymorphic handling: you can't put N message types on one destination and dispatch each to its own handler without N queues/topics or hand-rolled wrappers. No priority support within a destination.

## 2. Heavyweight transports
Providers inherit fat base classes — `QueueBase<T,TOptions>` has ~10 abstract overrides and bakes in serializer ownership, CLR-type↔string mapping, the worker loop, metrics, events, behaviors, poison handling, and resilience; `MessageBusBase<TOptions>` is similar. Transports serialize themselves. Consumption is **poll-based** (worker loops call `DequeueImplAsync`; in-memory polls on a 10s timeout) — no push. **No back-pressure** (unbounded enqueue). Capabilities are implicit — providers silently no-op or throw for unsupported features (e.g. delayed delivery falls back to an in-memory timer that's lost on restart) with no discovery.

## 3. No batching
No batch enqueue/dequeue or batch publish/subscribe APIs — one round-trip per message caps throughput.

## 4. Pub/sub conflated as a generic "message bus"
`IMessageBus` is named like a generic bus but is pub/sub — Foundatio implements messaging *patterns* (work queues, pub/sub), not a generic bus. Subscribers effectively receive ALL messages and filter by assignable CLR type in-process (task-per-subscriber); topic is a per-instance option, so listening to a subset of topics needs multiple bus instances. No per-message ack/reject; fire-and-forget with no documented delivery guarantee; subscriber errors are swallowed (can't distinguish "no subscribers" from "handler threw").

## 5. No generic, opt-in job-state tracking
No generic durable/queryable job state. Work-item progress is fire-and-forget `WorkItemStatus` published over `IMessageBus` (not stored); CRON history is in-memory, capped ~10, per-node, lost on restart. No cancel-by-id (only host-shutdown token / lock release). Tracking isn't opt-in per job. `WorkItemJob` is a separate ad-hoc persisted-job system on `IQueue<WorkItemData>`, not unified with CRON/`IJob`.

## 6. Non-durable distributed CRON
Distributed CRON runs the job body **in-process under a distributed lock** (two locks: a per-scheduled-minute lock held 1h + a per-job-running lock held 15m) and **enqueues no durable occurrence** — a node crash mid-run loses the run with no retry/dead-letter/monitor. **Retries are unimplemented** (`// TODO set next run time to retry, but need max retry count` at `ScheduledJobInstance.cs:277` & `:296`). Coarse per-minute cadence with misfire rules (skip if >1h late, fast-track if <10min out). No node identity for coordination/debugging; manual run has no idempotency/return/completion signal; distributed state sync over `IMessageBus` is lossy (no durability/replay/resync).

## 7. Allocation-heavy / no binary path
Values are deep-cloned (`QueueEntry.Value = value.DeepClone()`); serialization always allocates a fresh `byte[]`; no `ReadOnlyMemory<byte>` path. Metrics gauges do sync-over-async (`GetAwaiter().GetResult()`), risking thread-pool starvation.

## 8. Other cross-cutting issues
- **Assembly-qualified type discriminator** (`"FullName, Assembly"` + a version-stripping fallback in `MessageBusBase`) — brittle across services/versions.
- **Dead-letter access returns typed `IEnumerable<T>`** — can't inspect poison/unknown payloads without the original type.
- **Poison messages produce a phantom `IQueueEntry<T>` with null `Value`** — breaks the type contract.
- **Retry policy is global per queue**, not per-message; no custom backoff per message.
- **No ordering guarantees** modeled or documented (FIFO / partitions / sessions).
- **Trace/correlation propagation is manual and ad-hoc** (CorrelationId doubles as traceparent; a magic `"TraceState"` property).
- **Sync + async disposal** on the public interfaces (legacy baggage).
- **Metrics/events live in the base class** every provider inherits, rather than centralized in core.
- **Continuous job loop** has no exponential backoff / circuit-break on repeated failures (hot-spins at ~100ms).
- **Manual lock renewal** required during processing; no auto-renew → orphan / split-brain risk.
- **DX/registration friction**: triple-generic option builders; no message factory for testing handlers.

---

# Part 2 — v2 Design

Two end-user APIs — **`IQueue`** (durable competing-consumer work) and **`IPubSub`** (fan-out) — share one **consume core**, one **wire model**, one **capability model**, and the **jobs** layer. Transports are tiny (bytes + headers); core owns serialization, routing, multi-type dispatch, priority lanes, retry/backoff/dead-letter, back-pressure, the due-time substrate, job-state, scheduling, tracing, and metrics.

## Namespaces
- `Foundatio.Messaging` — the single **`IMessageTransport`** + wire model (headers, transport messages, capabilities), serializer + content-type registry, type-routing registry, `IPubSub`.
- `Foundatio.Queues` — `IQueue`, the unified `IReceivedMessage<T>`, worker/consume options.
- `Foundatio.Jobs` — `IJob`, `JobContext`, `IJobClient` / `IJobMonitor` for app code, `IJobRuntimeStore` for provider/runtime coordination, scheduler, monitor, durable CRON.
- `Foundatio.TestHarness` — reusable transport **conformance suite** + core-behavior/jobs test bases (referenced by every provider repo); ships the in-memory reference transport that passes it.

## Layering
```
App      ──▶ IQueue / IPubSub / IJob
Core     ──▶ serialize (+content-type registry) · type→destination routing · multi-type/polymorphic dispatch ·
             priority lanes + bounded priority buffer (back-pressure) · Auto/Manual ack · retry/backoff/dead-letter ·
             due-time substrate (delay/backoff/CRON) · expiry · job-state · scheduler + monitor · tracing · metrics
Transport──▶ IMessageTransport  (one contract; bytes + headers; send/consume/complete/abandon + ISupportsX; queue vs topic = destination role)
```

## Wire model & headers (`Foundatio.Messaging`)
```csharp
public enum MessagePriority { Low = 0, Normal = 1, High = 2 }
public enum DeliveryGuarantee { AtMostOnce, AtLeastOnce }
public enum OrderingGuarantee { None, Fifo, PerPartition }

public sealed class MessageHeaders : IReadOnlyDictionary<string,string> {        // case-insensitive (Ordinal), immutable, FrozenDictionary
    public static MessageHeaders Empty { get; }
    public static MessageHeaders Create(IEnumerable<KeyValuePair<string,string>> headers);
    public string? GetValueOrDefault(string key);
    public Builder ToBuilder();
    public sealed class Builder { public Builder Add/Set/SetIfMissing(string k, string v); public bool Remove(string k); public MessageHeaders Build(); }
}
public static class KnownHeaders {   // reserved message.* namespace for system keys
    public const string MessageType="message.type", ContentType="message.content_type", CorrelationId="message.correlation_id",
        TraceParent="traceparent", TraceState="tracestate", Priority="message.priority",
        Expiration="message.expiration", Attempts="message.attempts", DeadLetterReason="message.dead_letter.reason";
}

// Transport-facing: PURE body bytes + SEPARATE headers. The transport owns how headers are physically carried.
public sealed record TransportMessage { public required ReadOnlyMemory<byte> Body { get; init; } public MessageHeaders Headers { get; init; } = MessageHeaders.Empty; public string? MessageId { get; init; } }
public sealed record TransportSendOptions { public MessagePriority Priority { get; init; } = MessagePriority.Normal; public DateTimeOffset? DeliverAt { get; init; } public string? DeduplicationId { get; init; } public string? PartitionKey { get; init; } } // Priority honored iff transport is ISupportsPriority; DeliverAt iff ISupportsDelayedDelivery
public sealed record TransportEntry { public required string Id { get; init; } public required string Destination { get; init; } public required ReadOnlyMemory<byte> Body { get; init; } public MessageHeaders Headers { get; init; } = MessageHeaders.Empty; public int DeliveryCount { get; init; } = 1; public DateTimeOffset? EnqueuedUtc { get; init; } public required Receipt Receipt { get; init; } }
public readonly struct Receipt { public object? TransportState { get; init; } }   // opaque, instance/connection-scoped, non-serializable
public sealed record ReceiveRequest { public int MaxMessages { get; init; } = 1; public TimeSpan? MaxWaitTime { get; init; } }
public sealed record SendItemResult { public string? MessageId { get; init; } public required bool Success { get; init; } public string? ErrorCode { get; init; } public bool IsRetryable { get; init; } }
public sealed record SendResult { public required IReadOnlyList<SendItemResult> Items { get; init; } public bool AllSucceeded { get; } }
public sealed class ReceiptExpiredException : Exception { }

// Capabilities are discovered by which interfaces a transport implements — pattern-match `is ISupportsX` — NOT a property on the base contract.
// The few descriptive facts that aren't method-presence are reported via an OPTIONAL interface (absence ⇒ safe defaults: at-most-once, unordered, no advertised limits):
public interface ITransportInfo {
    DeliveryGuarantee DeliveryGuarantee { get; }
    OrderingGuarantee Ordering { get; }
    IReadOnlySet<DestinationRole> SupportedRoles { get; }   // which roles this backend can provision (Queue/Topic/Subscription/…) — validated against the topology at startup
    int? MaxBatchSize { get; }
    long? MaxMessageBytes { get; }
}
```

## Transport contract (provider-facing) — one transport for both patterns
There is a **single transport**. Queue vs pub/sub is **not** a different interface — it's the **`DestinationRole`** of the destination, set at provisioning: send to a **queue** = competing-consumer; send to a **topic** = fan-out to its subscriptions; you **consume** a queue or a subscription identically. `SendAsync` covers "publish" (a topic destination fans out). Both end-user APIs (`IQueue`, `IPubSub`) run over this one transport.

**Required base (produce + ack):**
```csharp
public interface IMessageTransport : IAsyncDisposable {
    Task<SendResult> SendAsync(string destination, IReadOnlyList<TransportMessage> messages, TransportSendOptions options, CancellationToken ct = default); // destination = queue OR topic
    Task CompleteAsync(TransportEntry entry, CancellationToken ct = default);                                          // ack; throws ReceiptExpiredException if invalid; no-op on at-most-once
    Task AbandonAsync(TransportEntry entry, CancellationToken ct = default);                                           // immediate requeue
}
```
**Consume:** a transport implements **`ISupportsPull` and/or `ISupportsPush` (at least one)**; core adapts both to the unified handler model and prefers push when present. The consume **source** is a queue or a subscription.
**Optional `ISupportsX` (implement only if native; otherwise core emulates or flags):**
```csharp
ISupportsPull               : IMessageTransport { Task<IReadOnlyList<TransportEntry>> ReceiveAsync(string source, ReceiveRequest request, CancellationToken ct); }                       // batch pull; empty list on timeout (never null/throw)
ISupportsPush               : IMessageTransport { Task<IPushSubscription> SubscribeAsync(string source, Func<TransportEntry,CancellationToken,Task> onMessage, PushOptions options, CancellationToken ct); }   // push delivery — one of pull/push required
ISupportsRedeliveryDelay    : IMessageTransport { Task AbandonAsync(TransportEntry e, TimeSpan redeliveryDelay, CancellationToken ct); }   // else core due-time hold
ISupportsDeadLetter         : IMessageTransport { Task DeadLetterAsync(TransportEntry e, string? reason, CancellationToken ct); }          // else core managed {dest}-deadletter
ISupportsLockRenewal        : IMessageTransport { Task RenewLockAsync(TransportEntry e, TimeSpan? duration, CancellationToken ct); }       // else no-op + log (un-emulable)
ISupportsVisibilityTimeout  : IMessageTransport { Task<IReadOnlyList<TransportEntry>> ReceiveAsync(string source, ReceiveRequest request, TimeSpan visibility, CancellationToken ct); } // un-emulable
ISupportsStats              : IMessageTransport { Task<QueueStats> GetStatsAsync(string destination, CancellationToken ct); }              // un-emulable; absent ⇒ depth unknown
ISupportsPriority           : IMessageTransport { }   // marker: honors TransportSendOptions.Priority + delivers higher-priority first (else core priority lanes)
ISupportsDelayedDelivery    : IMessageTransport { }   // marker: honors TransportSendOptions.DeliverAt (else core due-time substrate)
ISupportsExpiration         : IMessageTransport { }   // marker: honors the message.expiration header / TTL natively (else core enforces on receive)
ISupportsProvisioning       : IMessageTransport { Task EnsureAsync(IReadOnlyList<DestinationDeclaration> declarations, CancellationToken ct); Task DeleteAsync(string name, CancellationToken ct); Task<bool> ExistsAsync(string name, CancellationToken ct); }   // batch ensure (one-item list for dynamic); provisions queues/topics/subscriptions/bindings + related resources per DestinationRole coherently
public interface IPushSubscription : IAsyncDisposable { string Source { get; } }   // named handle so a push subscription can grow (Pause/Resume, Name, IsActive, stats…) without breaking callers
```
Capability discovery is `transport is ISupportsX` (pattern-match) — no capabilities property; marker interfaces signal "honor this option/header natively" without adding a method. A transport advertises **which `DestinationRole`s it can provision** via `ITransportInfo.SupportedRoles`, so "this backend can't do topics" is validated at startup rather than expressed as a missing interface. **Per-pattern different brokers** (e.g. SQS queues + Redis pub/sub) = named/keyed transport registration + a per-destination selector.

## Unified received message + ack (`Foundatio.Queues`)
```csharp
public enum AckMode { Auto, Manual }
public interface IReceivedMessage<out T> where T : class {
    T Message { get; }
    string Id { get; } MessageHeaders Headers { get; } string? CorrelationId { get; } string? MessageType { get; }
    MessagePriority Priority { get; } int Attempts { get; } bool IsHandled { get; }
    CancellationToken CancellationToken { get; }                          // host shutdown ∪ lock loss ∪ persisted cancel (when tracked)
    Task CompleteAsync(CancellationToken ct = default);
    Task RejectAsync(bool retry = true, string? reason = null, CancellationToken ct = default);  // retry→backoff→DLQ; !retry→DLQ
    Task DeadLetterAsync(string? reason = null, CancellationToken ct = default);
    Task RenewLockAsync(TimeSpan? duration = null, CancellationToken ct = default);              // no-op+log where unsupported
    Task ReportProgressAsync(int? percent = null, string? message = null, CancellationToken ct = default); // logs-only when not tracking
}
```
Queues (competing-consumer, at-least-once) and pub/sub (fan-out; guarantee per transport) **share this exact consume model**; `Reject`/`DeadLetter` are no-ops + flagged on at-most-once transports.

## End-user produce APIs
```csharp
public sealed record EnqueueOptions { public MessagePriority Priority { get; init; } = MessagePriority.Normal; public TimeSpan? Delay { get; init; } public DateTimeOffset? DeliverAt { get; init; } public TimeSpan? TimeToLive { get; init; } public string? CorrelationId { get; init; } public string? DeduplicationId { get; init; } public string? Destination { get; init; } public MessageHeaders? Headers { get; init; } }
public interface IQueue : IAsyncDisposable {
    Task<string> EnqueueAsync<T>(T message, EnqueueOptions? o = null, CancellationToken ct = default) where T : class;
    Task EnqueueBatchAsync<T>(IEnumerable<T> messages, EnqueueOptions? o = null, CancellationToken ct = default) where T : class;
}
public interface IPubSub : IAsyncDisposable {
    Task PublishAsync<T>(T message, PublishOptions? o = null, CancellationToken ct = default) where T : class;
    Task PublishBatchAsync<T>(IEnumerable<T> messages, PublishOptions? o = null, CancellationToken ct = default) where T : class;
}
```

## Routing, dispatch & workers (core)
- **Type → destination:** convention (`OrderPlaced`→`order-placed`) > `[Queue]`/`[Topic]` > fluent `Map<T>(...)` > custom fn. **`message.type`** = logical alias (`[MessageType("...")]`/registry; N inbound aliases → 1 type).
- **Per-type handler registration; core derives the consumer topology** — handlers routing to the same destination share ONE worker that dispatches by `message.type` → **most-specific handler (base/interface fallback)**. Single registered type + missing discriminator ⇒ **infer** (raw-producer interop). Unknown/unresolvable or deserialize-failure ⇒ **poison** (default dead-letter, reason in header) + optional `HandleUnknown`.
- **Worker** = handler-based (never poll). **Auto ack default** (return=Complete, throw=Reject(retry)); **Manual** opt-in. **Single-message handler is the default** (core auto-batches the fetch); optional **batch handler** (`HandleBatch<T>`) with per-message ack (unacked follow batch outcome). Core owns retry/backoff/attempt-cap/dead-letter.
```csharp
public sealed record WorkerOptions { public AckMode AckMode { get; init; } = AckMode.Auto; public int Prefetch { get; init; } = 1; public int MaxConcurrency { get; init; } = 1; public int BatchSize { get; init; } = 1; public int MaxAttempts { get; init; } = 5; public Func<int,TimeSpan>? RedeliveryBackoff { get; init; } public bool TrackState { get; init; } = false; public PoisonDisposition OnUnknownType { get; init; } = PoisonDisposition.DeadLetter; public PoisonDisposition OnDeserializeFailure { get; init; } = PoisonDisposition.DeadLetter; }
public enum PoisonDisposition { DeadLetter, AbandonWithCap, RouteToFallback, CompleteAndDrop }
```

## Priority lanes & back-pressure (core)
- Core maps `(destination, priority)` → physical lane (`orders`, `orders$high`, …) — the lanes are part of the derived topology (provisioned per the provisioning mode); routes on send by `EnqueueOptions.Priority`. **Native-priority transports** (those implementing `ISupportsPriority`) use one destination + `TransportSendOptions.Priority` (no lanes).
- Consume fills a **bounded priority buffer** (size = `Prefetch`) from the lanes (or native), **drains high→low** to the handler with `MaxConcurrency`, with a **configurable anti-starvation** weight (every Nth pull services a lower lane). The buffer IS the back-pressure: full ⇒ stop pulling / pause push.

## Provisioning & topology (core)
Provisioning is a **separate optional capability**, not on the data-plane contract — `ISupportsProvisioning` with a **batch `EnsureAsync(IReadOnlyList<DestinationDeclaration>)`** (a one-item list for dynamic ensure-on-first-use; the full set on startup), plus `DeleteAsync`/`ExistsAsync` — creating **queues, topics, subscriptions, and bindings per `DestinationRole`**, related resources coherently in one pass. Auto-creating backends (Redis, in-memory) don't implement it (create-on-send); brokers needing explicit creation do.
```csharp
public sealed record DestinationOptions {
    public bool PriorityEnabled { get; init; }            // provision priority lanes / native max-priority
    public TimeSpan? DefaultMessageTtl { get; init; }
    public DeadLetterPolicy? DeadLetter { get; init; }    // DLQ target + native redrive/max-receive backstop (the attempt-cap policy stays core-owned)
    public TimeSpan? LockDuration { get; init; }          // default visibility/lock window
    public int? Partitions { get; init; }
    public IReadOnlyDictionary<string,string>? NativeOptions { get; init; }  // escape hatch for provider-specific settings
}
public sealed record DeadLetterPolicy { public string? Destination { get; init; } public int? MaxDeliveries { get; init; } }

public enum DestinationRole { Queue, Topic, Subscription, PriorityLane, DeadLetter }
public sealed record DestinationDeclaration { public required string Name { get; init; } public DestinationRole Role { get; init; } public DestinationOptions Options { get; init; } = new(); public string? TopicBinding { get; init; } } // a subscription/lane/DLQ names what it binds to
```
The transport maps what it can to **native creation params** (SQS redrive policy; Azure SB queue properties / lock duration / TTL; RabbitMQ declare args — `x-max-priority`/`message-ttl`/DLX); core honors the rest itself.

**Core derives the topology** (not hand-maintained): from `Map<T>`, handler registrations, cron jobs, priority lanes (knowable from the fixed `Low`/`Normal`/`High` enum), DLQ targets, and the job/due-time/state destinations → a set of declarations `(name, role, DestinationOptions)`.

A **hosted provisioner** applies a **`ProvisioningMode`**:
- **Dynamic** (default) — ensure-on-first-use: `EnsureAsync([declaration])` (one-item list), lazy + cached.
- **OnStartup** — provision the entire derived topology in one `EnsureAsync(allDeclarations)` call, fail-fast (everything exists before traffic); the transport creates related resources/bindings (topic + subscriptions + DLQ + redrive) coherently.
- **Validate** — don't create; check `ExistsAsync` for every declaration on startup, fail-fast if missing (locked-down / externally-provisioned environments where the app lacks create permissions).
- **None** — do nothing; assume pre-provisioned.

If the chosen mode needs provisioning but the transport lacks `ISupportsProvisioning` (and doesn't auto-create), that's surfaced as a **startup configuration error**.

## Serialization (core)
`ISerializer` + a **content-type registry**: a default serializer for send (stamps `message.content_type`); receive picks the serializer by content-type (mixed formats per destination + external interop). Body = pure bytes; **transport owns header encoding** (native attributes; pack-into-one under limits like SQS's 10; or fold into payload where it can't carry headers). Buffers owned/non-pooled in v1; the entry/receipt contract is shaped to enable pooling/zero-copy later. Trace context rides in headers — core injects `traceparent`/`tracestate` on send and starts a consumer `Activity` on receive.

## Due-time substrate + expiry (core)
- **One durable "make visible at T" mechanism** backs delayed/scheduled send (`Delay`/`DeliverAt`), **redelivery-backoff** (Reject → reappear later), and **CRON occurrences**. Native per-message delay used where the transport implements `ISupportsDelayedDelivery`; else core persists the pending dispatch in the **same durable runtime store used for jobs** (`IJobRuntimeStore`), claims due records with a short lease, and materializes them into the destination/lane when due (survives restarts). This intentionally avoids a separate `IDueTimeStore`; the requirement is one runtime store contract with due-time methods, not two parallel persistence abstractions. A delayed message **enters its priority lane when due**.
- **TTL** → absolute `message.expiration` (enqueue + TTL); enforced on receive (native broker TTL where present); expired ⇒ **dead-letter `expired`** (default) or drop.

## Job client + runtime store (`Foundatio.Jobs`)
```csharp
public enum JobStatus { Queued, Scheduled, Processing, Completed, Failed, Cancelled, DeadLettered }
public enum ScheduledDispatchKind { QueueMessage, PubSubMessage, JobOccurrence }
public sealed record JobState { /* JobId, Name, Status, Progress, ProgressMessage, Attempt, NodeId, timestamps, Error, CancellationRequested, ScheduledForUtc */ }
public sealed record ScheduledDispatchState { /* DispatchId, Kind, Destination, Body, Headers, Options, DueUtc, ClaimOwner, ClaimExpiresUtc, Attempts, JobId? */ }
public sealed record JobStatePatch { /* Status?, Progress?, ProgressMessage?, Error?, AttemptDelta?, NodeId?, LeaseExpiresUtc?, LastUpdatedUtc? */ }

// App-facing read model for dashboards and diagnostics.
public interface IJobMonitor {
    Task<JobState?> GetAsync(string jobId, CancellationToken ct = default);
    Task<IReadOnlyList<JobState>> QueryAsync(JobQuery query, CancellationToken ct = default);
}

// App-facing command surface. Normal users inject this, not the runtime store.
public interface IJobClient : IJobMonitor {
    Task<string> RunAsync<TJob>(RunJobOptions? options = null, CancellationToken ct = default) where TJob : IJob;
    Task<bool> RequestCancellationAsync(string jobId, CancellationToken ct = default);
}

// Runtime/provider-facing SPI. The same concrete implementation can back IJobClient/IJobMonitor,
// but app code should not need these methods.
public interface IJobRuntimeStore : IJobMonitor {                // ALL updates are field-level/partial — never whole-record replace
    Task CreateIfAbsentAsync(JobState initial, CancellationToken ct = default);                 // occurrence anchor + dedup (atomic)
    Task<bool> TryTransitionAsync(string jobId, JobStatus expectedStatus, JobStatus newStatus, JobStatePatch? patch = null, CancellationToken ct = default);
    Task<bool> TryClaimAsync(string jobId, string nodeId, TimeSpan lease, CancellationToken ct = default);
    Task<bool> RenewClaimAsync(string jobId, string nodeId, TimeSpan lease, CancellationToken ct = default);
    Task<bool> ReleaseClaimAsync(string jobId, string nodeId, CancellationToken ct = default);
    Task SetProgressAsync(string jobId, int? percent = null, string? message = null, CancellationToken ct = default);
    Task IncrementAttemptAsync(string jobId, CancellationToken ct = default);
    Task<bool> IsCancellationRequestedAsync(string jobId, CancellationToken ct = default);
    Task ScheduleDispatchAsync(ScheduledDispatchState dispatch, CancellationToken ct = default); // create/dedup pending due-time dispatch
    Task<IReadOnlyList<ScheduledDispatchState>> ClaimDueDispatchesAsync(DateTimeOffset now, int limit, string nodeId, TimeSpan lease, CancellationToken ct = default);
    Task CompleteDispatchAsync(string dispatchId, string nodeId, CancellationToken ct = default);
    Task ReleaseDispatchAsync(string dispatchId, string nodeId, DateTimeOffset nextDueUtc, CancellationToken ct = default);
}
```
**Opt-in per registration** (`WorkerOptions.TrackState`; CRON occurrences are always tracked). When on, core auto-manages the lifecycle (`Queued→Processing→Completed/Failed/Cancelled`) through conditional transitions, claim ownership, and renewable leases; the handler only adds progress via the context. `ReportProgressAsync` when untracked ⇒ logs only (never throws). Cancellation is requested through `IJobClient` and observed cooperatively by the runtime (context token + progress checkpoint). Delayed-send fallback, retry backoff, and CRON occurrence materialization use the scheduled-dispatch methods on `IJobRuntimeStore` so there is one durable coordination dependency to configure and test, without exposing those methods to normal app code.

## Durable CRON (`Foundatio.Jobs`)
```csharp
public interface IJob { Task<JobResult> RunAsync(JobContext ctx); }
public sealed class JobContext { /* JobId, Name, TriggerKind, Attempt, ScheduledForUtc, Services, CancellationToken */ public T? GetMessage<T>() where T:class; public Task ReportProgressAsync(int? percent=null, string? message=null, CancellationToken ct=default); public Task RenewLockAsync(TimeSpan? d=null, CancellationToken ct=default); }
public sealed record ScheduledJobDefinition { public required string Name { get; init; } public required string Cron { get; init; } public TimeZoneInfo? TimeZone { get; init; } public ScheduledJobScope Scope { get; init; } = ScheduledJobScope.Global; public OverlapPolicy Overlap { get; init; } = OverlapPolicy.SkipIfRunning; public TimeSpan? MisfireWindow { get; init; } public int MaxRetries { get; init; } = 3; public bool Enabled { get; init; } = true; }
public enum ScheduledJobScope { Global, PerNode }
public interface IJobScheduler { Task ScheduleAsync(ScheduledJobDefinition def, CancellationToken ct = default); Task UnscheduleAsync(string name, CancellationToken ct = default); Task<IReadOnlyList<ScheduledJobDefinition>> GetSchedulesAsync(CancellationToken ct = default); }
```
**Flow:** scheduler tick (configurable, ~1s) → due occurrence id `{job}:{tick}:{scope}` (Global=`global`, PerNode=`{nodeId}`) → `CreateIfAbsentAsync` (atomic anchor + dedup; store implementations use native CAS/conditional writes or their own lock internally) → `ScheduleDispatchAsync`/claim due occurrence → materialize onto `IQueue` (always tracked) → worker resolves `IJob` from DI and runs it using `TryClaimAsync` + renewable ownership. A hosted **monitor** reconciles `IJobRuntimeStore.QueryAsync` vs worker liveness (heartbeat via lock-renewal/`LastUpdated` + node id): created-but-never-picked-up or started-then-stale occurrences are **re-enqueued up to `MaxRetries`, then aborted/dead-lettered** (+ optional alert hook). **Misfire** = skip past the per-schedule window (catch-up within window). **NodeId** = config > `FOUNDATIO_NODE_ID` > machine name.

## DI / registration
```csharp
services.AddFoundatio(b => b.UseQueueTransport<InMemoryQueueTransport>().UsePubSubTransport<InMemoryPubSubTransport>().UseSerializer<SystemTextJsonSerializer>().Map<OrderShipped>(queue: "orders"));
services.AddQueueHandler<OrderPlaced>(async (msg, ct) => { … }, o => o with { TrackState = true });   // delegate or class handler
services.AddPubSubHandler<CacheInvalidated>(async (msg, ct) => { … });
services.AddJob<ReportJob>();                                   // one-off / manual via IJobClient
services.AddCronJob<NightlyRollupJob>("0 0 * * *", o => o with { Scope = ScheduledJobScope.Global });
```

## Observability & stats (core)
Stats are split by **authoritative vs derived** — conflating them is what made this hard before:
- **Throughput / rates** (sent, received, completed, abandoned, dead-lettered, errors, process-duration, queue-latency) are emitted as **OpenTelemetry metrics** from the core pipeline — counters/histograms tagged `destination` / `message.type` / `priority` / `transport`. These are flow metrics; a metrics backend (or an in-proc reader) aggregates them across nodes.
- **Current depth** (queued / in-flight / dead-lettered) is **queried from the transport** via optional **`ISupportsStats`** — the broker is the source of truth, so out-of-band changes (purges, TTL expiry, other producers/consumers, redelivery) are reflected accurately. Broker depth is **inherently cluster-wide** (one query returns the whole destination's depth), approximate on some backends, and **cached + rate-limited** by core. **No derived/aggregated depth counter is maintained** — it would drift from reality.
- **Tracked-work status** (in-progress + progress %, completed/failed/cancelled, history) comes from **`IJobMonitor.QueryAsync`** — backed by the shared runtime store, so it's authoritative and cluster-wide for *tracked* jobs/occurrences.
- **Observable gauges never block:** they read only in-memory counters or the cached transport-depth snapshot — never a synchronous transport call (fixes the old sync-over-async gauge that risked thread-pool starvation).
- **Full OpenTelemetry, built in:** a `Meter` per area (`Foundatio.Queues` / `Foundatio.Messaging` / `Foundatio.Jobs`), the shared `ActivitySource` (producer + consumer spans, context propagated through headers), and structured `ILogger`. Wire up OTel → metrics + traces + logs with zero extra code.
- **High-performance logging patterns:** all logging uses **source-generated `[LoggerMessage]`** (compile-time, allocation-free, no boxing) with stable event ids and named structured fields — never string interpolation/concatenation in log calls; expensive/diagnostic messages are guarded with `ILogger.IsEnabled(level)`; correlation/message ids flow via `ILogger` scopes. Logging is cheap enough to leave in the hot path.
- **Dashboard:** core exposes the **data** — a per-destination stats snapshot API (core throughput counters + on-demand transport depth) and the `IJobMonitor` query — plus OTel. **No first-party dashboard UI**; build your own over the data or point a metrics backend at the OTel output.

## Capability model (summary)
**Discovery:** a transport's capabilities = the interfaces it implements (`is ISupportsX`) — there is **no capabilities property** on the contract. **Required base:** `Send`, `Complete`, `Abandon`, `Dispose`, **plus ≥1 consume capability — `ISupportsPull` and/or `ISupportsPush`** (core adapts; prefers push when present). **Optional `ISupportsX`, core-emulated when absent:** redelivery-delay (→due-time via `IJobRuntimeStore`), dead-letter (→managed DLQ), priority (→lanes), delayed delivery (→durable due-time via `IJobRuntimeStore`), expiration (→on-receive). **Optional, not emulable (no-op/unavailable):** lock-renewal, queue-depth stats (throughput metrics are always-on via core/OTel — only current depth needs the transport), visibility-timeout, **provisioning** (`ISupportsProvisioning` — batch `EnsureAsync(declarations)`; auto-creating backends need none — governed by `ProvisioningMode`). **Descriptive facts** (delivery guarantee, ordering, supported roles, batch/size limits) come from the **optional `ITransportInfo` interface**; absence ⇒ safe defaults. There is **one `IMessageTransport`** for both patterns — queue vs pub/sub is the destination's `DestinationRole`, not a separate interface.

## Provider mapping (separate repos)
- **In-memory** — reference, full surface, exact stats.
- **Azure Service Bus** — native complete/abandon/DLQ/lock-renewal/scheduled-messages; no per-receive visibility; no native priority → core lanes.
- **AWS SQS/SNS** — visibility = lock; redelivery-delay via `ChangeMessageVisibility`; batch/attrs ≤10 (transport packs headers); delay ≤900s else `IJobRuntimeStore` due-time fallback; no priority → lanes.
- **Redis** — lists + sorted-sets (ZSET → native priority by score); first-class `IJobRuntimeStore` (SET NX / ZSET); pub/sub at-most-once, streams durable.
- **RabbitMQ** — ack/nack/DLX; `x-max-priority` → native priority; no lock-renewal; delay via plugin/TTL else core.
- **Kafka** — topic + consumer-group (subscription) roles; at-least-once via offset commit; no per-message complete/abandon, delay, priority, or DLQ (offset-based → core-emulated or unavailable); `SupportedRoles` excludes queue-role semantics that need per-message ack.

## Testing — core tests + a reusable transport conformance harness
A **first-class deliverable**: shipping a new transport means referencing `Foundatio.TestHarness`, supplying a factory, and getting a full pass/fail conformance suite — the same model the current library uses (a provider subclasses a base test and overrides a `Create…` factory).

- **`Foundatio.TestHarness` (NuGet)** — a reusable, xUnit-based **transport conformance suite**. A transport author writes one small subclass and inherits the entire suite:
```csharp
public class RedisMessageTransportTests : MessageTransportConformanceTests {
    protected override IMessageTransport CreateTransport() => new RedisMessageTransport(/* test connection */);
}
```
- **Capability-aware:** the harness inspects which `ISupportsX` the transport implements (+ `ITransportInfo`) and runs only the applicable tests — capabilities a transport doesn't claim are **skipped, not failed**. A minimal transport (send + consume + complete/abandon) passes a small suite; a full-featured one runs everything.
- **Conformance coverage:** produce + batch send; consume via pull and/or push; complete/abandon; receipt validity + `ReceiptExpiredException`; redelivery (native + core-emulated); dead-letter (native + core fallback); priority ordering + anti-starvation (lanes or native); expiration; delayed / due-time delivery; provisioning (`Ensure`/`Exists`/`Delete` + roles/topology); back-pressure (bounded in-flight under a slow handler); fan-out vs competing-consumer (topic vs queue role); delivery-guarantee assertions; header + trace round-trip; cancellation + disposal.
- **In-memory reference transport** ships in core and **passes the full conformance suite** — it proves the harness, is the default for app dev/testing, and is the baseline the core-behavior + benchmark suites run against.
- **Core-behavior suite (transport-agnostic, on in-memory):** type→destination routing; multi-type + polymorphic dispatch (most-specific + base/interface fallback); discriminator inference; poison handling; Auto/Manual ack; retry → backoff → dead-letter; batch handler + partial-failure; serializer/content-type registry; priority; trace propagation; observability counters.
- **Jobs suite:** opt-in tracking + partial state updates; occurrence dedup (create-if-absent) under concurrent schedulers; monitor retry/abort of lost/stuck occurrences; misfire policy; cooperative cancellation; PerNode node-id stability.
- **Compat suite:** the old-API shims behave correctly over the new core.
- The **same transport factory** powers the benchmark suite below, so a transport is conformance-tested and benchmarked with one identical plug-in.

## Performance & benchmarks
- Binary `ReadOnlyMemory<byte>` bodies, pooling-ready contract, bounded channels, `TimeProvider`, minimal hot-path allocation.
- **Transport-swappable benchmark suite** (BenchmarkDotNet `[MemoryDiagnoser]` + a sustained throughput/latency rig), parameterized by the same factory as the conformance harness — enqueue/dequeue, priority-drain, dispatch, serialize, fan-out, back-pressure — so transports compare apples-to-apples and regressions are caught in CI.

## Migration / compat
Breaking major version. Separate `Foundatio.Compat.*` packages re-expose the old `IQueue<T>` / `IMessageBus` / `WorkItemJob` / CRON APIs over the new core (namespace/registration swap; not drop-in).

## Phased build sequence
The work should be sequenced as vertical slices with explicit exit gates. Keep new public APIs internal/preview until the transport abstraction has passed both the in-memory reference implementation and one real provider. If the real provider exposes a mismatch, revise the abstraction before expanding into jobs, scheduler, or broad provider ports.

0. **Compatibility and break map** — document old API behaviors that must survive in shims, source/binary breaking changes, provider capability gaps, migration constraints, and success criteria for the major release.
1. **Transport foundation** — wire model + headers + serializer/content-type registry + capability discovery + minimal `IMessageTransport` + in-memory reference transport + conformance harness + benchmark baseline.
2. **Real-provider vertical slice** — port one production transport early, preferably SQS or Azure Service Bus, and validate send/receive, settlement, batching, headers, tracing, delay limits, DLQ, provisioning, and capability reporting against the same conformance harness.
3. **Queue core** — build `IQueue` over the proven substrate: routing, dispatch, manual receive API, handler workers, Auto/Manual ack, retry/backoff/DLQ, back-pressure, priority lanes, due-time, expiry, tracing, and core behavior tests.
4. **Pub/sub core** — build `IPubSub` over the same substrate with topic/subscription roles, fan-out behavior, at-most-once/at-least-once semantics surfaced by capabilities, and pub/sub-specific conformance coverage.
5. **Job client + runtime coordination** — add `IJobClient` / `IJobMonitor` for app-facing job status, progress, manual run, and cancellation, backed by `IJobRuntimeStore` for opt-in tracking, ownership/heartbeat, conditional state transitions, and fallback due-time scheduling; do not introduce a separate `IDueTimeStore`.
6. **Durable CRON** — add scheduler + monitor on top of `IQueue` and `IJobRuntimeStore`, including occurrence deduplication, scheduled-dispatch claim/materialize flow, misfire handling, stale-run recovery, retries, and dead-lettering.
7. **Provider ports** — port Redis, Azure, AWS, RabbitMQ, Kafka, and other providers one at a time; each provider must pass its advertised conformance matrix and benchmark smoke suite before release.
8. **Compat and migration** — ship old-API shims, migration guide, upgrade samples, and tests proving `IQueue<T>`, `IMessageBus`, `WorkItemJob`, and CRON compatibility over the new core.

## Non-goals
Sagas, routing DSL, exactly-once *delivery* (impossible in the general case), schema registry, workflow engine, broker-independent topology beyond simple destination/topic provisioning (`ISupportsProvisioning` + `DestinationOptions`), `IMemoryOwner` zero-copy (v1).

**Note on exactly-once:** at-least-once + idempotent handlers gives **effectively-once** processing, and the design already ships the dedup primitives to support it — scheduler **occurrence CAS** (`CreateIfAbsentAsync`), producer **`DeduplicationId`**, and consumer **dedup-by-key** via the lock/CAS store. True once-per-side-effect still requires the dedup record to commit in the same transaction as the side effect (transactional outbox/inbox); a distributed lock alone can't close the crash window between performing a side effect and acking the message.
