### PR TITLE
docs: clarify Redis connection lifetime and graceful shutdown

### DIFF
--- a/.agents/skills/foundatio/SKILL.md
+++ b/.agents/skills/foundatio/SKILL.md
@@ -67,24 +67,26 @@ builder.Services.AddSingleton<ILockProvider>(sp =>
 Swap to production by changing only DI registration:
 
 ```csharp
-var redis = await ConnectionMultiplexer.ConnectAsync("localhost:6379");
+// DI owns and disposes the shared multiplexer during host shutdown.
+builder.Services.AddSingleton<IConnectionMultiplexer>(sp =>
+    ConnectionMultiplexer.Connect("localhost:6379"));
 
 builder.Services.AddSingleton<ICacheClient>(sp =>
     new RedisCacheClient(o =>
     {
-        o.ConnectionMultiplexer = redis;
+        o.ConnectionMultiplexer = sp.GetRequiredService<IConnectionMultiplexer>();
         o.LoggerFactory = sp.GetRequiredService<ILoggerFactory>();
     }));
 builder.Services.AddSingleton<IMessageBus>(sp =>
     new RedisMessageBus(o =>
     {
-        o.Subscriber = redis.GetSubscriber();
+        o.Subscriber = sp.GetRequiredService<IConnectionMultiplexer>().GetSubscriber();
         o.LoggerFactory = sp.GetRequiredService<ILoggerFactory>();
     }));
 builder.Services.AddSingleton<IQueue<OrderWorkItem>>(sp =>
     new RedisQueue<OrderWorkItem>(o =>
     {
-        o.ConnectionMultiplexer = redis;
+        o.ConnectionMultiplexer = sp.GetRequiredService<IConnectionMultiplexer>();
         o.LoggerFactory = sp.GetRequiredService<ILoggerFactory>();
     }));
 ```

--- a/docs/guide/dependency-injection.md
+++ b/docs/guide/dependency-injection.md
@@ -87,18 +87,19 @@ if (builder.Environment.IsDevelopment())
 }
 else
 {
-    // Redis for production
-    var redis = ConnectionMultiplexer.Connect(
-        builder.Configuration.GetConnectionString("Redis")
-    );
-
-    builder.Services.AddSingleton<IConnectionMultiplexer>(redis);
+    // Container-owned Redis connection for production
+    builder.Services.AddSingleton<IConnectionMultiplexer>(sp =>
+        ConnectionMultiplexer.Connect(
+            builder.Configuration.GetConnectionString("Redis")
+        ));
 
     builder.Services.AddSingleton<ICacheClient>(sp =>
-        new RedisCacheClient(o => o.ConnectionMultiplexer = redis));
+        new RedisCacheClient(o => o.ConnectionMultiplexer =
+            sp.GetRequiredService<IConnectionMultiplexer>()));
 
     builder.Services.AddSingleton<IMessageBus>(sp =>
-        new RedisMessageBus(o => o.Subscriber = redis.GetSubscriber()));
+        new RedisMessageBus(o => o.Subscriber =
+            sp.GetRequiredService<IConnectionMultiplexer>().GetSubscriber()));
 
     builder.Services.AddSingleton<IFileStorage>(sp =>
         new AzureFileStorage(o => {

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -137,21 +137,24 @@ using StackExchange.Redis;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Configure Redis connection
-var redis = await ConnectionMultiplexer.ConnectAsync("localhost:6379");
-builder.Services.AddSingleton<IConnectionMultiplexer>(redis);
+// Configure a container-owned Redis connection
+builder.Services.AddSingleton<IConnectionMultiplexer>(sp =>
+    ConnectionMultiplexer.Connect("localhost:6379"));
 
 // Use Redis implementations
 builder.Services.AddSingleton<ICacheClient>(sp =>
-    new RedisCacheClient(o => o.ConnectionMultiplexer = redis)
+    new RedisCacheClient(o => o.ConnectionMultiplexer =
+        sp.GetRequiredService<IConnectionMultiplexer>())
 );
 
 builder.Services.AddSingleton<IMessageBus>(sp =>
-    new RedisMessageBus(o => o.Subscriber = redis.GetSubscriber())
+    new RedisMessageBus(o => o.Subscriber =
+        sp.GetRequiredService<IConnectionMultiplexer>().GetSubscriber())
 );
 
 builder.Services.AddSingleton<IQueue<WorkItem>>(sp =>
-    new RedisQueue<WorkItem>(o => o.ConnectionMultiplexer = redis)
+    new RedisQueue<WorkItem>(o => o.ConnectionMultiplexer =
+        sp.GetRequiredService<IConnectionMultiplexer>())
 );
 ```
 

--- a/docs/guide/implementations/redis.md
+++ b/docs/guide/implementations/redis.md
@@ -538,11 +538,11 @@ var redis = await ConnectionMultiplexer.ConnectAsync(options);
 
 Foundatio's Redis providers (`RedisCacheClient`, `RedisQueue<T>`, `RedisMessageBus`, `RedisFileStorage`, `CacheLockProvider`) all **borrow** an `IConnectionMultiplexer` you supply -- they never own or close it. This is intentional: the same multiplexer is typically shared across cache, queue, message bus, and locks, so a single provider closing it on `Dispose()` would break the others. Closing the connection is your application's responsibility.
 
-This matters most in **cluster mode**, where a single multiplexer opens a connection to *every* shard. If your process is killed (scale-in, deploy, crash) without cleanly closing that connection, each shard is left holding a socket with output buffers still queued for a client that will never read them again. Because Redis/Valkey's event loop is single-threaded, a pile-up of these stale sockets can pin a node's CPU at 100% until the connection is cleared.
+This matters most when a host or network failure prevents Redis from receiving a normal close. In **cluster mode**, a single multiplexer opens a connection to *every* shard, so a lost host can leave each shard with a half-open socket and output buffers queued for a client that will never read them again. Because Redis/Valkey's event loop is single-threaded, a pile-up of these stale sockets can pin a node's CPU at 100% until the connections are cleared. If a process exits on a live host -- even via `SIGKILL` -- the operating system normally closes its TCP descriptors and Redis observes a `FIN` or reset; graceful shutdown is still useful because it lets hosted work drain and closes the multiplexer deliberately.
 
 Two complementary mitigations:
 
-**1. Let the DI container dispose the multiplexer on graceful shutdown.** Register it with a factory (not a pre-built instance) so `IServiceProvider` disposal -- triggered by `IHostApplicationLifetime.ApplicationStopping` during `SIGTERM`/`SIGINT` -- closes it and sends a clean `FIN`:
+**1. Let the DI container dispose the multiplexer on graceful shutdown.** Register it with a factory (not a pre-built instance) so the host-owned service provider disposes it during shutdown and sends a clean `FIN`:
 
 ```csharp
 // ✅ Factory registration: container creates it, so container disposes it
@@ -554,10 +554,10 @@ If you must keep a pre-built instance around, dispose it explicitly:
 
 ```csharp
 var lifetime = app.Services.GetRequiredService<IHostApplicationLifetime>();
-lifetime.ApplicationStopping.Register(() => redis.Dispose());
+lifetime.ApplicationStopped.Register(() => redis.Dispose());
 ```
 
-**2. Configure a server-side backstop for hard kills** (`SIGKILL`, scale-in via orchestration, ungraceful crashes) where no client-side shutdown code runs at all. Set these on your Redis/Valkey server or parameter group:
+**2. Configure server-side backstops for host or network failures** (for example, a lost node or network partition) where no client-side shutdown code can run. Set these on your Redis/Valkey server or parameter group:
 
 - `timeout` -- e.g. `300` (seconds). Forces the server to drop a connection that has been completely idle for this long.
 - `tcp-keepalive` -- e.g. `300` or lower. Has the OS send low-level TCP probes to detect and reap dead sockets.

--- a/docs/guide/implementations/redis.md
+++ b/docs/guide/implementations/redis.md
@@ -534,18 +534,56 @@ var options = new ConfigurationOptions
 var redis = await ConnectionMultiplexer.ConnectAsync(options);
 ```
 
+### Connection Lifetime & Graceful Shutdown
+
+Foundatio's Redis providers (`RedisCacheClient`, `RedisQueue<T>`, `RedisMessageBus`, `RedisFileStorage`, `CacheLockProvider`) all **borrow** an `IConnectionMultiplexer` you supply -- they never own or close it. This is intentional: the same multiplexer is typically shared across cache, queue, message bus, and locks, so a single provider closing it on `Dispose()` would break the others. Closing the connection is your application's responsibility.
+
+This matters most in **cluster mode**, where a single multiplexer opens a connection to *every* shard. If your process is killed (scale-in, deploy, crash) without cleanly closing that connection, each shard is left holding a socket with output buffers still queued for a client that will never read them again. Because Redis/Valkey's event loop is single-threaded, a pile-up of these stale sockets can pin a node's CPU at 100% until the connection is cleared.
+
+Two complementary mitigations:
+
+**1. Let the DI container dispose the multiplexer on graceful shutdown.** Register it with a factory (not a pre-built instance) so `IServiceProvider` disposal -- triggered by `IHostApplicationLifetime.ApplicationStopping` during `SIGTERM`/`SIGINT` -- closes it and sends a clean `FIN`:
+
+```csharp
+// ✅ Factory registration: container creates it, so container disposes it
+services.AddSingleton<IConnectionMultiplexer>(sp =>
+    ConnectionMultiplexer.Connect(connectionString));
+```
+
+If you must keep a pre-built instance around, dispose it explicitly:
+
+```csharp
+var lifetime = app.Services.GetRequiredService<IHostApplicationLifetime>();
+lifetime.ApplicationStopping.Register(() => redis.Dispose());
+```
+
+**2. Configure a server-side backstop for hard kills** (`SIGKILL`, scale-in via orchestration, ungraceful crashes) where no client-side shutdown code runs at all. Set these on your Redis/Valkey server or parameter group:
+
+- `timeout` -- e.g. `300` (seconds). Forces the server to drop a connection that has been completely idle for this long.
+- `tcp-keepalive` -- e.g. `300` or lower. Has the OS send low-level TCP probes to detect and reap dead sockets.
+
+StackExchange.Redis's own `KeepAlive` option defaults to `60` seconds, which is lower than the settings above, so healthy connections won't be culled by the server-side timeout.
+
 ## Best Practices
 
 ### 1. Connection Management
 
 ```csharp
-// ✅ Singleton connection
+// ✅ Singleton connection, registered as a factory so the DI container
+// owns and disposes it (sends a clean FIN on shutdown)
+services.AddSingleton<IConnectionMultiplexer>(sp =>
+    ConnectionMultiplexer.Connect("redis:6379"));
+
+// ❌ Registering a pre-built instance -- the container only disposes
+// objects it creates, so this connection is never closed on shutdown
 services.AddSingleton<IConnectionMultiplexer>(
     ConnectionMultiplexer.Connect("redis:6379"));
 
-// ❌ Creating new connections
+// ❌ Creating new connections per use
 var redis = ConnectionMultiplexer.Connect("redis:6379");
 ```
+
+See [Connection Lifetime & Graceful Shutdown](#connection-lifetime-graceful-shutdown) for why the registration style matters.
 
 ### 2. Key Naming
 

--- a/docs/guide/implementations/redis.md
+++ b/docs/guide/implementations/redis.md
@@ -562,6 +562,8 @@ lifetime.ApplicationStopping.Register(() => redis.Dispose());
 - `timeout` -- e.g. `300` (seconds). Forces the server to drop a connection that has been completely idle for this long.
 - `tcp-keepalive` -- e.g. `300` or lower. Has the OS send low-level TCP probes to detect and reap dead sockets.
 
+The `timeout` setting applies to normal clients, not clients in Pub/Sub mode. If you use `RedisMessageBus` (or another provider with a subscribed connection), also configure `tcp-keepalive` and an appropriate `client-output-buffer-limit pubsub` so Redis can disconnect dead or stalled subscribers. Graceful shutdown should still dispose the shared multiplexer explicitly, since server-side backstops cannot replace client cleanup.
+
 StackExchange.Redis's own `KeepAlive` option defaults to `60` seconds, which is lower than the settings above, so healthy connections won't be culled by the server-side timeout.
 
 ## Best Practices

--- a/docs/guide/locks.md
+++ b/docs/guide/locks.md
@@ -449,8 +449,8 @@ services.AddSingleton<ILockProvider>(sp =>
 ### With Redis
 
 ```csharp
-services.AddSingleton<IConnectionMultiplexer>(
-    await ConnectionMultiplexer.ConnectAsync("localhost:6379")
+services.AddSingleton<IConnectionMultiplexer>(sp =>
+    ConnectionMultiplexer.Connect("localhost:6379")
 );
 
 services.AddSingleton<ICacheClient>(sp =>

--- a/src/Foundatio.DataProtection/Foundatio.DataProtection.csproj
+++ b/src/Foundatio.DataProtection/Foundatio.DataProtection.csproj
@@ -4,8 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.28" />
-    <!-- Override transitive System.Security.Cryptography.Xml 8.0.3 pulled in by Microsoft.AspNetCore.DataProtection to remediate GHSA-23rf-6693-g89p and related advisories -->
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Foundatio\Foundatio.csproj" />

--- a/src/Foundatio.DataProtection/Foundatio.DataProtection.csproj
+++ b/src/Foundatio.DataProtection/Foundatio.DataProtection.csproj
@@ -4,6 +4,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.28" />
+    <!-- Override transitive System.Security.Cryptography.Xml 8.0.3 pulled in by Microsoft.AspNetCore.DataProtection to remediate GHSA-23rf-6693-g89p and related advisories -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Foundatio\Foundatio.csproj" />


### PR DESCRIPTION
## Summary

Fixes a misleading example in the Redis docs and adds guidance on connection lifetime during shutdown, prompted by a production incident where zombie Redis/Valkey client connections (left behind by processes killed during scale-in) pinned cluster nodes at 100% CPU.

## Changes to `docs/guide/implementations/redis.md`

1. **Fixed `Best Practices → 1. Connection Management`**: the previous ✅ example registered a pre-built `IConnectionMultiplexer` instance via `AddSingleton<IConnectionMultiplexer>(ConnectionMultiplexer.Connect(...))`. Since the DI container only disposes objects **it creates**, this instance is never disposed/closed on shutdown. Replaced the recommended pattern with factory registration (`AddSingleton<IConnectionMultiplexer>(sp => ConnectionMultiplexer.Connect(...))`), which the container does own and dispose, and relabeled the instance-registration form as a ❌ anti-pattern with an explanation.

2. **Added `Production Considerations → Connection Lifetime & Graceful Shutdown`**: explains that Foundatio's Redis providers (cache, queue, message bus, file storage, lock provider) borrow the multiplexer and never close it themselves — closing it is the application's responsibility, since it's typically shared across multiple providers. Covers:
   - Why this is especially costly in **cluster mode** (a single multiplexer holds a connection to every shard, multiplying the number of stale sockets left behind per process crash/scale-in)
   - App-side fix: factory-registered DI (container-owned) or explicit disposal via `IHostApplicationLifetime.ApplicationStopping`, so graceful `SIGTERM`/`SIGINT` sends a clean TCP FIN
   - Server-side backstop for hard kills (`SIGKILL`, ungraceful crashes) where no client shutdown code runs: `timeout` / `tcp-keepalive` settings on the Redis/Valkey server or parameter group
   - Note that StackExchange.Redis's own `KeepAlive` (default 60s) is lower than the recommended server timeouts, so healthy connections aren't affected

No code changes — documentation only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
