### PR TITLE
chore: update xUnit dependencies to v4

### DIFF
--- a/src/Foundatio.Xunit.v3/Foundatio.Xunit.v3.csproj
+++ b/src/Foundatio.Xunit.v3/Foundatio.Xunit.v3.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0" />
-    <PackageReference Include="xunit.v3.assert" Version="3.2.2" />
-    <PackageReference Include="xunit.v3.extensibility.core" Version="3.2.2" />
+    <PackageReference Include="xunit.v3.assert" Version="4.0.0-pre.154" />
+    <PackageReference Include="xunit.v3.extensibility.core" Version="4.0.0-pre.154" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.Xunit.v3/Foundatio.Xunit.v3.csproj
+++ b/src/Foundatio.Xunit.v3/Foundatio.Xunit.v3.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0" />
-    <PackageReference Include="xunit.v3.assert" Version="4.0.0-pre.154" />
-    <PackageReference Include="xunit.v3.extensibility.core" Version="4.0.0-pre.154" />
+    <PackageReference Include="xunit.v3.assert" Version="4.0.0" />
+    <PackageReference Include="xunit.v3.extensibility.core" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.Xunit.v3/Retry/RetryTestCase.cs
+++ b/src/Foundatio.Xunit.v3/Retry/RetryTestCase.cs
@@ -59,7 +59,10 @@ public class RetryTestCase : XunitTestCase, ISelfExecutingXunitTestCase
         IMessageBus messageBus,
         object?[] constructorArguments,
         ExceptionAggregator aggregator,
-        CancellationTokenSource cancellationTokenSource)
+        CancellationTokenSource cancellationTokenSource,
+        ParallelMode parallelMode,
+        ExecutionScheduler scheduler,
+        FixtureMappingManager methodFixtureMappings)
     {
         var runCount = 0;
 
@@ -76,10 +79,13 @@ public class RetryTestCase : XunitTestCase, ISelfExecutingXunitTestCase
                 delayedMessageBus,
                 testAggregator,
                 cancellationTokenSource,
+                parallelMode,
+                scheduler,
                 TestMethod.TestClass.Class.Name,
                 TestMethod.TestClass.Class.Name,
                 explicitOption,
-                constructorArguments);
+                constructorArguments,
+                methodFixtureMappings);
 
             if (testAggregator.HasExceptions || summary.Failed == 0 || ++runCount >= _maxRetries)
             {

--- a/src/Foundatio.Xunit.v3/Retry/RetryTestCase.cs
+++ b/src/Foundatio.Xunit.v3/Retry/RetryTestCase.cs
@@ -72,20 +72,16 @@ public class RetryTestCase : XunitTestCase, ISelfExecutingXunitTestCase
             using var delayedMessageBus = new DelayedMessageBus(messageBus);
             var testAggregator = new ExceptionAggregator();
 
-            var tests = await CreateTests();
-            var summary = await XunitTestCaseRunner.Instance.Run(
-                this,
-                tests,
-                delayedMessageBus,
-                testAggregator,
-                cancellationTokenSource,
-                parallelMode,
-                scheduler,
-                TestMethod.TestClass.Class.Name,
-                TestMethod.TestClass.Class.Name,
-                explicitOption,
-                constructorArguments,
-                methodFixtureMappings);
+            var summary = await XunitRunnerHelper.RunXunitTestCase(
+                testCase: this,
+                messageBus: delayedMessageBus,
+                cancellationTokenSource: cancellationTokenSource,
+                parallelMode: parallelMode,
+                scheduler: scheduler,
+                aggregator: testAggregator,
+                explicitOption: explicitOption,
+                constructorArguments: constructorArguments,
+                methodFixtureMappings: methodFixtureMappings);
 
             if (testAggregator.HasExceptions || summary.Failed == 0 || ++runCount >= _maxRetries)
             {

--- a/src/Foundatio.Xunit.v3/Retry/RetryTheoryTestCase.cs
+++ b/src/Foundatio.Xunit.v3/Retry/RetryTheoryTestCase.cs
@@ -59,7 +59,10 @@ public class RetryTheoryTestCase : XunitDelayEnumeratedTheoryTestCase, ISelfExec
         IMessageBus messageBus,
         object?[] constructorArguments,
         ExceptionAggregator aggregator,
-        CancellationTokenSource cancellationTokenSource)
+        CancellationTokenSource cancellationTokenSource,
+        ParallelMode parallelMode,
+        ExecutionScheduler scheduler,
+        FixtureMappingManager methodFixtureMappings)
     {
         var runCount = 0;
 
@@ -76,10 +79,13 @@ public class RetryTheoryTestCase : XunitDelayEnumeratedTheoryTestCase, ISelfExec
                 delayedMessageBus,
                 testAggregator,
                 cancellationTokenSource,
+                parallelMode,
+                scheduler,
                 TestMethod.TestClass.Class.Name,
                 TestMethod.TestClass.Class.Name,
                 explicitOption,
-                constructorArguments);
+                constructorArguments,
+                methodFixtureMappings);
 
             if (testAggregator.HasExceptions || summary.Failed == 0 || ++runCount >= _maxRetries)
             {

--- a/src/Foundatio.Xunit.v3/Retry/RetryTheoryTestCase.cs
+++ b/src/Foundatio.Xunit.v3/Retry/RetryTheoryTestCase.cs
@@ -72,20 +72,16 @@ public class RetryTheoryTestCase : XunitDelayEnumeratedTheoryTestCase, ISelfExec
             using var delayedMessageBus = new DelayedMessageBus(messageBus);
             var testAggregator = new ExceptionAggregator();
 
-            var tests = await CreateTests();
-            var summary = await XunitTestCaseRunner.Instance.Run(
-                this,
-                tests,
-                delayedMessageBus,
-                testAggregator,
-                cancellationTokenSource,
-                parallelMode,
-                scheduler,
-                TestMethod.TestClass.Class.Name,
-                TestMethod.TestClass.Class.Name,
-                explicitOption,
-                constructorArguments,
-                methodFixtureMappings);
+            var summary = await XunitRunnerHelper.RunXunitTestCase(
+                testCase: this,
+                messageBus: delayedMessageBus,
+                cancellationTokenSource: cancellationTokenSource,
+                parallelMode: parallelMode,
+                scheduler: scheduler,
+                aggregator: testAggregator,
+                explicitOption: explicitOption,
+                constructorArguments: constructorArguments,
+                methodFixtureMappings: methodFixtureMappings);
 
             if (testAggregator.HasExceptions || summary.Failed == 0 || ++runCount >= _maxRetries)
             {

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -8,8 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="xunit.v3.mtp-v2" Version="4.0.0-pre.154" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.5" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageReference Include="xunit.v3.mtp-v2" Version="4.0.0-pre.154" />
+    <PackageReference Include="xunit.v3.mtp-v2" Version="4.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.5" PrivateAssets="All" />
   </ItemGroup>

--- a/tests/Foundatio.Tests/Properties/AssemblyInfo.cs
+++ b/tests/Foundatio.Tests/Properties/AssemblyInfo.cs
@@ -1,1 +1,1 @@
-﻿[assembly: Xunit.CollectionBehaviorAttribute(DisableTestParallelization = true, MaxParallelThreads = 1)]
+﻿[assembly: Xunit.v3.Parallelization(Mode = Xunit.Sdk.ParallelMode.None)]


### PR DESCRIPTION
## What changed

- Update the active xUnit v3 test stack and Visual Studio adapter to stable `4.0.0`.
- Adapt Foundatio's custom retry test cases to xUnit v4's required `ISelfExecutingXunitTestCase.Run` signature.
- Route retry execution through xUnit's canonical `XunitRunnerHelper.RunXunitTestCase` helper with named arguments, preserving the framework-defined parameter order while eliminating fragile positional mapping.
- Replace the obsolete v3 parallelization settings with the xUnit v4 assembly-level parallelization declaration.
- Keep `Foundatio.Xunit` on xUnit v2 because it intentionally supports the legacy v2 extensibility API.

## Validation

- `dotnet restore Foundatio.slnx`
- `dotnet build Foundatio.slnx --no-restore` — 0 warnings, 0 errors
- Focused retry suite — 14 passed, 0 failed
- `dotnet test Foundatio.slnx --no-build --no-restore` — 1,913 passed, 13 skipped, 0 failed
- Formatter verification passed for both changed retry files. Repository-wide formatting still reports pre-existing whitespace in the vendored Cronos source.
- Resolved package graph confirms all eligible xUnit framework and runner packages are `4.0.0`.
- Thermo-nuclear code-quality review completed with no blocking findings.

The full workspace solution still has separate provider repositories pinning xUnit 3.2.2; those repositories are outside this PR and were not modified.